### PR TITLE
Improve compliance reporting with configurable critical types

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Fire is a Bazel module for managing safety-critical system requirements, paramet
 - **Test References**: `[test_name](BUILD.bazel#test_name)` syntax
 - **Bi-directional Validation**: Body markdown references must match frontmatter declarations
 - **Traceability Matrix**: Generate matrices showing requirement relationships
-- **Coverage Reports**: Track which requirements have parameter/test coverage
+- **Coverage Reports**: Track which requirements have parameter references, linked tests, and standard references
 - **Unit Tests**: Comprehensive tests for reference validation and markdown parsing
 
 ### Phase 4: Multi-Language Code Generation
@@ -588,17 +588,27 @@ impact_report = traceability.generate_change_impact_markdown(requirements_data)
 
 ### Compliance Reports
 
-Generate compliance reports for safety standards (ISO 26262, DO-178C, etc.):
+Generate compliance reports for safety standards (ISO 26262, IEC 61508, etc.):
 
 ```python
+# Standard-agnostic compliance report
 compliance_report = traceability.generate_compliance_markdown(requirements_data, "ISO 26262")
+
+# With critical requirement type highlighting
+compliance_report = traceability.generate_compliance_markdown(
+    requirements_data,
+    "ISO 26262",
+    critical_type="safety"  # or "security", "regulatory", etc.
+)
 # Includes:
-# - Summary statistics (safety reqs, functional reqs, coverage percentages)
+# - Summary statistics (breakdown by requirement type, standard references, linked tests)
 # - Requirements by status (draft, approved, verified, etc.)
-# - Safety requirements with test/standard coverage
-# - Compliance gaps (safety reqs without tests or standard references)
+# - Critical type requirements detail (if specified)
+# - Compliance gaps (critical reqs without linked tests or standard references)
 # - Unverified requirements
 ```
+
+**Note**: Reports show "Linked Tests" not "Test Coverage" - this refers to requirements with test references in their frontmatter, not verified test execution.
 
 ### Coverage Dashboard
 
@@ -658,7 +668,8 @@ generate_report(
     name = "compliance_report",
     srcs = glob(["requirements/*.md"]),
     report_type = "compliance",
-    standard = "ISO 26262",
+    standard = "ISO 26262",  # or "IEC 61508", etc.
+    critical_type = "safety",  # Optional: highlight critical requirements
     out = "COMPLIANCE_ISO26262.md",
 )
 ```
@@ -679,9 +690,14 @@ bazel build //path/to:traceability_matrix //path/to:coverage_report //path/to:ch
 **Available Report Types**:
 
 - `traceability`: Full traceability matrix with Requirements → Parameters, Requirements → Requirements (with versions), Requirements → Tests, Requirements → Standards
-- `coverage`: Coverage metrics showing percentage of requirements with parameter/test/standard coverage
+- `coverage`: Metrics showing percentage of requirements with parameter references, linked tests, and standard references
 - `change_impact`: Identifies requirements with stale parent version references
-- `compliance`: Compliance report for a specific standard (specify with `standard` attribute)
+- `compliance`: Compliance report for a specific standard
+  - Attributes: `standard` (required, e.g., "ISO 26262", "IEC 61508"), `critical_type` (optional, e.g., "safety", "security")
+  - Shows breakdown by requirement type, status distribution, and compliance gaps
+  - Highlights critical requirement type if specified
+
+**Note**: "Linked Tests" refers to requirements with test references in frontmatter, not verified test execution.
 
 ### Example
 

--- a/examples/BUILD.bazel
+++ b/examples/BUILD.bazel
@@ -89,6 +89,7 @@ generate_report(
     name = "compliance_report",
     srcs = glob(["requirements/*.md"]),
     out = "COMPLIANCE_ISO26262.md",
+    critical_type = "safety",  # Highlight safety requirements
     report_type = "compliance",
     standard = "ISO 26262",
 )

--- a/fire/starlark/reports.bzl
+++ b/fire/starlark/reports.bzl
@@ -19,6 +19,10 @@ def _generate_report_impl(ctx):
     if ctx.attr.standard:
         args.add("--standard=" + ctx.attr.standard)
 
+    # Add critical_type if specified
+    if ctx.attr.critical_type:
+        args.add("--critical-type=" + ctx.attr.critical_type)
+
     # Run the Python script
     ctx.actions.run(
         inputs = ctx.files.srcs + [script],
@@ -34,6 +38,9 @@ def _generate_report_impl(ctx):
 generate_report = rule(
     implementation = _generate_report_impl,
     attrs = {
+        "critical_type": attr.string(
+            doc = "Requirement type to highlight in compliance reports (e.g., 'safety', 'security')",
+        ),
         "out": attr.output(
             mandatory = True,
             doc = "Output markdown file",
@@ -49,7 +56,7 @@ generate_report = rule(
             doc = "List of requirement markdown files to include in the report",
         ),
         "standard": attr.string(
-            doc = "Standard name for compliance reports (e.g., 'ISO 26262', 'DO-178C')",
+            doc = "Standard name for compliance reports (e.g., 'ISO 26262', 'IEC 61508')",
         ),
         "_script": attr.label(
             default = Label("//fire/starlark:generate_report.py"),


### PR DESCRIPTION
## Summary
- Made compliance reports standard-agnostic to support any safety/quality standard (ISO 26262, IEC 61508, DO-178C, etc.)
- Added `critical_type` parameter to allow highlighting specific requirement types (safety, security, regulatory, etc.)
- Renamed "Test Coverage" to "Linked Tests" throughout to accurately reflect that these are frontmatter references, not verified test execution

## Changes

### fire/starlark/reports.bzl
- Added `critical_type` attribute to `generate_report` rule
- Updated documentation to show IEC 61508 as example alongside ISO 26262

### fire/starlark/generate_report.py
- **Coverage Report**: 
  - Added explanatory note distinguishing "Linked Tests" from verified test execution
  - Renamed all "Test Coverage" terminology to "Linked Tests" or "Test References"
- **Compliance Report**:
  - Made report show breakdown by ALL requirement types dynamically (not just hard-coded "safety")
  - Added `critical_type` parameter for optional highlighting with ⚠️ marker
  - Added detailed sections for critical type requirements when specified
  - Added compliance gap analysis for critical requirements without tests/standards
  - Added "Requirements Not Yet Verified" table showing all non-verified requirements

### examples/BUILD.bazel
- Added `critical_type = "safety"` to compliance report example demonstrating the new feature

### README.md
- Updated all references from "Test Coverage" to "Linked Tests"
- Added documentation for `critical_type` parameter usage
- Added IEC 61508 as example standard alongside ISO 26262
- Added explanatory notes about the distinction between linked tests and verified test execution
- Updated compliance report documentation to reflect new type-agnostic approach

## Test Plan
- [x] All 93 existing tests passing
- [x] Successfully built all example report targets
- [x] Verified compliance report shows correct type breakdown
- [x] Verified critical type highlighting works correctly with `critical_type = "safety"`

## Motivation

The initial compliance report implementation was overfitted to automotive use cases (ISO 26262, hard-coded "safety" requirements). This makes the tool:
- More flexible for different industries (medical devices, aerospace, finance, etc.)
- Clearer about what "test coverage" actually means (frontmatter links, not execution verification)
- Configurable to highlight whatever requirement type is critical for the specific domain

🤖 Generated with [Claude Code](https://claude.com/claude-code)