### PR TITLE
Update README to reflect simplified frontmatter format

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,23 +272,25 @@ func TestParameters(t *testing.T) {
 
 Requirements are written in Markdown with YAML frontmatter:
 
-**requirements/REQ-VEL-001.md**:
+**requirements/REQ-VEL-001.sysreq.md**:
 
 ```markdown
 ---
 id: REQ-VEL-001
-title: Maximum Vehicle Velocity
-type: safety
 status: approved
-priority: critical
 sil: ASIL-D
 security_related: false
-tags: [velocity, safety, ASIL-D]
+version: 2
+changelog:
+  - version: 2
+    description: Added parent requirement version tracking support
+  - version: 1
+    description: Initial maximum velocity requirement definition
 references:
   parameters:
     - examples/vehicle_params.bzl#maximum_vehicle_velocity
   requirements:
-    - path: examples/requirements/REQ-BRK-001.md
+    - path: examples/requirements/REQ-BRK-001.sysreq.md
       version: 1
   standards:
     - ISO 26262:2018, Part 3, Section 7
@@ -308,7 +310,7 @@ under any operating conditions.
 
 This requirement is derived from [ISO 26262:2018, Part 3, Section 7](https://www.iso.org/standard/68383.html)
 safety analysis for ASIL-D classification. The requirement relates to braking
-performance (see [REQ-BRK-001](examples/requirements/REQ-BRK-001.md)).
+performance (see [REQ-BRK-001](examples/requirements/REQ-BRK-001.sysreq.md)).
 
 ## Verification
 


### PR DESCRIPTION
## Summary

Updated the "Define Requirements" section in README.md to reflect the current simplified frontmatter format after PR #20 removed redundant fields.

## Changes

### Updated frontmatter example to show:

**Removed fields** (no longer in examples):
- `title` - duplicates the # heading
- `type` - not actionable
- `priority` - subjective
- `tags` - redundant

**Added fields shown**:
- `version` - version tracking
- `changelog` - version history

### Other updates:
- File extension: `.md` → `.sysreq.md`
- Cross-reference paths updated to use `.sysreq.md` extension

## Verification

- [x] All 119 tests passing
- [x] Pre-commit hooks passing
- [x] Documentation matches actual example files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>