### PR TITLE
Migrate software requirements to YAML block format

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -175,9 +175,28 @@ bazel build //examples:compliance_report
 
 ### Software Requirements (`.swreq.md`)
 
-- YAML frontmatter (component, version, sil, security_related, system_function)
-- List-based requirements format with sections for each requirement
-- Each requirement has: ID, Parent, SIL, Sec, Description
+- Optional YAML frontmatter (system_function)
+- Section-based format with ## headers for each requirement ID
+- Each requirement contains:
+  - YAML code block with: parent, parent_version, sil, sec
+  - Markdown description starting with "Derived from [PARENT](link?version=X#PARENT)" link
+
+Example format:
+
+````markdown
+## REQ_BC_CALCULATE_FORCE
+
+```yaml
+parent: /examples/requirements/REQ-BRK-001.sysreq.md#REQ-BRK-001
+parent_version: 1
+sil: ASIL-D
+sec: false
+```
+
+Derived from [REQ-BRK-001](/examples/requirements/REQ-BRK-001.sysreq.md?version=1#REQ-BRK-001).
+The brake controller component shall calculate the required brake force...
+
+````
 
 ### Technical Specifications (`.techspec.md`)
 

--- a/examples/brake_actuator/doc/brake_actuator.swreq.md
+++ b/examples/brake_actuator/doc/brake_actuator.swreq.md
@@ -8,50 +8,70 @@ This document contains the software requirements for the Brake Actuator componen
 
 ## REQ_BA_RECEIVE_COMMANDS
 
-- **ID**: REQ_BA_RECEIVE_COMMANDS
-- **Parent**: /examples/requirements/REQ-BRK-001.sysreq.md#REQ-BRK-001
-- **SIL**: ASIL-D
-- **Sec**: false
-- **Description**: The brake actuator component shall subscribe to brake force commands at a rate of 50 Hz and process each received command within 2 milliseconds. Each command contains brake force as a percentage [0, 100], a timestamp, and a status field. If no command is received within 30 milliseconds (timeout), the component shall initiate a controlled pressure release by ramping the hydraulic pressure to zero over 100 milliseconds.
+```yaml
+parent: /examples/requirements/REQ-BRK-001.sysreq.md#REQ-BRK-001
+parent_version: 1
+sil: ASIL-D
+sec: false
+```
+
+Derived from [REQ-BRK-001](/examples/requirements/REQ-BRK-001.sysreq.md?version=1#REQ-BRK-001).
+The brake actuator component shall subscribe to brake force commands at a rate of 50 Hz and process each received command within 2 milliseconds. Each command contains brake force as a percentage [0, 100], a timestamp, and a status field. If no command is received within 30 milliseconds (timeout), the component shall initiate a controlled pressure release by ramping the hydraulic pressure to zero over 100 milliseconds.
 
 ---
 
 ## REQ_BA_CONVERT_FORCE
 
-- **ID**: REQ_BA_CONVERT_FORCE
-- **Parent**: /examples/requirements/REQ-BRK-001.sysreq.md#REQ-BRK-001
-- **SIL**: ASIL-D
-- **Sec**: false
-- **Description**: The brake actuator component shall convert brake force percentage commands to hydraulic pressure setpoints using the linear relationship: target_pressure = (brake_force_percent × max_pressure) / 100, where max_pressure is calibrated to 120 bar for the vehicle brake system. The conversion shall be performed for each received brake command before updating the pressure controller setpoint. Zero brake force (0 percent) shall result in zero pressure (0 bar), and maximum brake force (100 percent) shall result in 120 bar target pressure.
+```yaml
+parent: /examples/requirements/REQ-BRK-001.sysreq.md#REQ-BRK-001
+parent_version: 1
+sil: ASIL-D
+sec: false
+```
+
+Derived from [REQ-BRK-001](/examples/requirements/REQ-BRK-001.sysreq.md?version=1#REQ-BRK-001).
+The brake actuator component shall convert brake force percentage commands to hydraulic pressure setpoints using the linear relationship: target_pressure = (brake_force_percent × max_pressure) / 100, where max_pressure is calibrated to 120 bar for the vehicle brake system. The conversion shall be performed for each received brake command before updating the pressure controller setpoint. Zero brake force (0 percent) shall result in zero pressure (0 bar), and maximum brake force (100 percent) shall result in 120 bar target pressure.
 
 ---
 
 ## REQ_BA_CONTROL_HYDRAULICS
 
-- **ID**: REQ_BA_CONTROL_HYDRAULICS
-- **Parent**: /examples/requirements/REQ-BRK-001.sysreq.md#REQ-BRK-001
-- **SIL**: ASIL-D
-- **Sec**: false
-- **Description**: The brake actuator component shall control the electro-hydraulic valve using a PI (Proportional-Integral) controller running at 1000 Hz to maintain actual hydraulic pressure within 1 bar of the target pressure. The controller shall use proportional gain Kp = 5.0 (percent per bar) and integral gain Ki = 2.0 (percent per bar-second). The controller output shall be a PWM duty cycle in range [0, 100] percent commanding the hydraulic valve. The component shall monitor actual pressure per REQ_BA_MONITOR_PRESSURE to calculate pressure error for the controller.
+```yaml
+parent: /examples/requirements/REQ-BRK-001.sysreq.md#REQ-BRK-001
+parent_version: 1
+sil: ASIL-D
+sec: false
+```
+
+Derived from [REQ-BRK-001](/examples/requirements/REQ-BRK-001.sysreq.md?version=1#REQ-BRK-001).
+The brake actuator component shall control the electro-hydraulic valve using a PI (Proportional-Integral) controller running at 1000 Hz to maintain actual hydraulic pressure within 1 bar of the target pressure. The controller shall use proportional gain Kp = 5.0 (percent per bar) and integral gain Ki = 2.0 (percent per bar-second). The controller output shall be a PWM duty cycle in range [0, 100] percent commanding the hydraulic valve. The component shall monitor actual pressure per REQ_BA_MONITOR_PRESSURE to calculate pressure error for the controller.
 
 ---
 
 ## REQ_BA_MONITOR_PRESSURE
 
-- **ID**: REQ_BA_MONITOR_PRESSURE
-- **Parent**: /examples/requirements/REQ-BRK-001.sysreq.md#REQ-BRK-001
-- **SIL**: ASIL-D
-- **Sec**: false
-- **Description**: The brake actuator component shall read the hydraulic pressure sensor at 1000 Hz via an analog-to-digital converter. The sensor provides pressure values in the range [0, 150] bar with 0.1 bar precision. The component shall validate each pressure reading to ensure it is within the valid range. If the pressure sensor reading is out of range or the sensor fails, the component shall enter FAULT state per REQ_BA_SAFETY_LIMITS. The actual pressure shall be used as feedback for the pressure controller REQ_BA_CONTROL_HYDRAULICS and published in the actuator status message at 50 Hz.
+```yaml
+parent: /examples/requirements/REQ-BRK-001.sysreq.md#REQ-BRK-001
+parent_version: 1
+sil: ASIL-D
+sec: false
+```
+
+Derived from [REQ-BRK-001](/examples/requirements/REQ-BRK-001.sysreq.md?version=1#REQ-BRK-001).
+The brake actuator component shall read the hydraulic pressure sensor at 1000 Hz via an analog-to-digital converter. The sensor provides pressure values in the range [0, 150] bar with 0.1 bar precision. The component shall validate each pressure reading to ensure it is within the valid range. If the pressure sensor reading is out of range or the sensor fails, the component shall enter FAULT state per REQ_BA_SAFETY_LIMITS. The actual pressure shall be used as feedback for the pressure controller REQ_BA_CONTROL_HYDRAULICS and published in the actuator status message at 50 Hz.
 
 ---
 
 ## REQ_BA_SAFETY_LIMITS
 
-- **ID**: REQ_BA_SAFETY_LIMITS
-- **Parent**: /examples/requirements/REQ-BRK-001.sysreq.md#REQ-BRK-001
-- **SIL**: ASIL-D
-- **Sec**: false
-- **Description**: The brake actuator component shall enforce safety limits on hydraulic pressure to prevent damage and ensure safe operation. The component shall limit target pressure to a maximum of 120 bar under normal conditions and 150 bar absolute maximum (hardware limit). The component shall limit pressure increase rate to 50 bar per second to prevent hydraulic shock. If any safety fault is detected (pressure sensor out of range, valve malfunction, excessive pressure error greater than 10 bar for more than 500 milliseconds), the component shall enter FAULT state, set valve PWM to 0 percent, release hydraulic pressure, and publish FAULT status.
+```yaml
+parent: /examples/requirements/REQ-BRK-001.sysreq.md#REQ-BRK-001
+parent_version: 1
+sil: ASIL-D
+sec: false
+```
+
+Derived from [REQ-BRK-001](/examples/requirements/REQ-BRK-001.sysreq.md?version=1#REQ-BRK-001).
+The brake actuator component shall enforce safety limits on hydraulic pressure to prevent damage and ensure safe operation. The component shall limit target pressure to a maximum of 120 bar under normal conditions and 150 bar absolute maximum (hardware limit). The component shall limit pressure increase rate to 50 bar per second to prevent hydraulic shock. If any safety fault is detected (pressure sensor out of range, valve malfunction, excessive pressure error greater than 10 bar for more than 500 milliseconds), the component shall enter FAULT state, set valve PWM to 0 percent, release hydraulic pressure, and publish FAULT status.
 
 ---

--- a/examples/brake_control/doc/brake_controller.swreq.md
+++ b/examples/brake_control/doc/brake_controller.swreq.md
@@ -8,80 +8,112 @@ This document contains the software requirements for the Brake Controller compon
 
 ## REQ_BC_CALCULATE_FORCE
 
-- **ID**: REQ_BC_CALCULATE_FORCE
-- **Parent**: /examples/requirements/REQ-BRK-001.sysreq.md#REQ-BRK-001
-- **SIL**: ASIL-D
-- **Sec**: false
-- **Description**: The brake controller component shall calculate the required brake force based on current vehicle speed, target deceleration, and estimated friction coefficient. The calculation shall use a PID controller with feed-forward compensation derived from the braking distance table REQ_BC_USE_BRAKING_TABLE. The brake force shall be expressed as a percentage value in the range [0, 100].
+```yaml
+parent: /examples/requirements/REQ-BRK-001.sysreq.md#REQ-BRK-001
+parent_version: 1
+sil: ASIL-D
+sec: false
+```
+
+Derived from [REQ-BRK-001](/examples/requirements/REQ-BRK-001.sysreq.md?version=1#REQ-BRK-001).
+The brake controller component shall calculate the required brake force based on current vehicle speed, target deceleration, and estimated friction coefficient. The calculation shall use a PID controller with feed-forward compensation derived from the braking distance table REQ_BC_USE_BRAKING_TABLE. The brake force shall be expressed as a percentage value in the range [0, 100].
 
 ---
 
 ## REQ_BC_MONITOR_DECELERATION
 
-- **ID**: REQ_BC_MONITOR_DECELERATION
-- **Parent**: /examples/requirements/REQ-BRK-001.sysreq.md#REQ-BRK-001
-- **SIL**: ASIL-D
-- **Sec**: false
-- **Description**: The brake controller component shall continuously monitor the actual vehicle deceleration by reading the vehicle status at a minimum rate of 50 Hz. The monitored deceleration shall be compared against the target deceleration, and the error shall be used as input to the brake force calculation algorithm REQ_BC_CALCULATE_FORCE.
+```yaml
+parent: /examples/requirements/REQ-BRK-001.sysreq.md#REQ-BRK-001
+parent_version: 1
+sil: ASIL-D
+sec: false
+```
+
+Derived from [REQ-BRK-001](/examples/requirements/REQ-BRK-001.sysreq.md?version=1#REQ-BRK-001).
+The brake controller component shall continuously monitor the actual vehicle deceleration by reading the vehicle status at a minimum rate of 50 Hz. The monitored deceleration shall be compared against the target deceleration, and the error shall be used as input to the brake force calculation algorithm REQ_BC_CALCULATE_FORCE.
 
 ---
 
 ## REQ_BC_USE_BRAKING_TABLE
 
-- **ID**: REQ_BC_USE_BRAKING_TABLE
-- **Parent**: /examples/requirements/REQ-BRK-001.sysreq.md#REQ-BRK-001
-- **SIL**: ASIL-D
-- **Sec**: false
-- **Description**: The brake controller component shall use the braking distance table parameter to determine the relationship between vehicle speed, friction coefficient, and required braking distance. The table shall be loaded from vehicle parameters at initialization and validated to contain at least 6 data points. For intermediate values not present in the table, the component shall perform linear interpolation.
+```yaml
+parent: /examples/requirements/REQ-BRK-001.sysreq.md#REQ-BRK-001
+parent_version: 1
+sil: ASIL-D
+sec: false
+```
+
+Derived from [REQ-BRK-001](/examples/requirements/REQ-BRK-001.sysreq.md?version=1#REQ-BRK-001).
+The brake controller component shall use the braking distance table parameter to determine the relationship between vehicle speed, friction coefficient, and required braking distance. The table shall be loaded from vehicle parameters at initialization and validated to contain at least 6 data points. For intermediate values not present in the table, the component shall perform linear interpolation.
 
 ---
 
 ## REQ_BC_EMERGENCY_BRAKE
 
-- **ID**: REQ_BC_EMERGENCY_BRAKE
-- **Parent**: /examples/requirements/REQ-BRK-001.sysreq.md#REQ-BRK-001
-- **SIL**: ASIL-D
-- **Sec**: false
-- **Description**: The brake controller component shall enter emergency braking mode and command maximum brake force (100 percent) if any of the following error conditions are detected: vehicle status input timeout (age greater than 40 milliseconds), vehicle speed exceeds maximum safe speed (30 meters per second), or friction estimate is invalid or out of range [0.3, 0.9]. The component shall continue in emergency braking mode until all error conditions are cleared for at least 500 milliseconds.
+```yaml
+parent: /examples/requirements/REQ-BRK-001.sysreq.md#REQ-BRK-001
+parent_version: 1
+sil: ASIL-D
+sec: false
+```
+
+Derived from [REQ-BRK-001](/examples/requirements/REQ-BRK-001.sysreq.md?version=1#REQ-BRK-001).
+The brake controller component shall enter emergency braking mode and command maximum brake force (100 percent) if any of the following error conditions are detected: vehicle status input timeout (age greater than 40 milliseconds), vehicle speed exceeds maximum safe speed (30 meters per second), or friction estimate is invalid or out of range [0.3, 0.9]. The component shall continue in emergency braking mode until all error conditions are cleared for at least 500 milliseconds.
 
 ---
 
 ## REQ_BC_OUTPUT_RATE
 
-- **ID**: REQ_BC_OUTPUT_RATE
-- **Parent**: /examples/requirements/REQ-BRK-001.sysreq.md#REQ-BRK-001
-- **SIL**: ASIL-D
-- **Sec**: false
-- **Description**: The brake controller component shall publish brake force commands at a rate of 50 Hz (20 millisecond period) with a maximum jitter of 2 milliseconds. Each command shall include a timestamp, the commanded brake force percentage, and a status field indicating whether the component is operating in nominal mode or emergency mode as defined in REQ_BC_EMERGENCY_BRAKE.
+```yaml
+parent: /examples/requirements/REQ-BRK-001.sysreq.md#REQ-BRK-001
+parent_version: 1
+sil: ASIL-D
+sec: false
+```
+
+Derived from [REQ-BRK-001](/examples/requirements/REQ-BRK-001.sysreq.md?version=1#REQ-BRK-001).
+The brake controller component shall publish brake force commands at a rate of 50 Hz (20 millisecond period) with a maximum jitter of 2 milliseconds. Each command shall include a timestamp, the commanded brake force percentage, and a status field indicating whether the component is operating in nominal mode or emergency mode as defined in REQ_BC_EMERGENCY_BRAKE.
 
 ---
 
 ## REQ_BC_INPUT_VALIDATION
 
-- **ID**: REQ_BC_INPUT_VALIDATION
-- **Parent**: /examples/requirements/REQ-BRK-001.sysreq.md#REQ-BRK-001
-- **SIL**: ASIL-D
-- **Sec**: false
-- **Description**: The brake controller component shall validate all input values at each processing cycle. Vehicle speed shall be validated to be in range [0, 30] meters per second. Vehicle acceleration shall be validated to be in range [-15, 5] meters per second squared. Friction coefficient shall be validated to be in range [0.3, 0.9]. If any input value is out of range or stale (exceeds maximum age), the component shall trigger the emergency braking mode per REQ_BC_EMERGENCY_BRAKE.
+```yaml
+parent: /examples/requirements/REQ-BRK-001.sysreq.md#REQ-BRK-001
+parent_version: 1
+sil: ASIL-D
+sec: false
+```
+
+Derived from [REQ-BRK-001](/examples/requirements/REQ-BRK-001.sysreq.md?version=1#REQ-BRK-001).
+The brake controller component shall validate all input values at each processing cycle. Vehicle speed shall be validated to be in range [0, 30] meters per second. Vehicle acceleration shall be validated to be in range [-15, 5] meters per second squared. Friction coefficient shall be validated to be in range [0.3, 0.9]. If any input value is out of range or stale (exceeds maximum age), the component shall trigger the emergency braking mode per REQ_BC_EMERGENCY_BRAKE.
 
 ---
 
 ## REQ_BC_FORCE_LIMITS
 
-- **ID**: REQ_BC_FORCE_LIMITS
-- **Parent**: /examples/requirements/REQ-BRK-001.sysreq.md#REQ-BRK-001
-- **SIL**: ASIL-D
-- **Sec**: false
-- **Description**: The brake controller component shall limit all calculated brake force values to the range [0, 100] percent before publishing brake commands. Values below 0 shall be clamped to 0, and values above 100 shall be clamped to 100. The component shall ensure that brake force can never be commanded outside this safe range under any circumstances, including during transient conditions or error recovery.
+```yaml
+parent: /examples/requirements/REQ-BRK-001.sysreq.md#REQ-BRK-001
+parent_version: 1
+sil: ASIL-D
+sec: false
+```
+
+Derived from [REQ-BRK-001](/examples/requirements/REQ-BRK-001.sysreq.md?version=1#REQ-BRK-001).
+The brake controller component shall limit all calculated brake force values to the range [0, 100] percent before publishing brake commands. Values below 0 shall be clamped to 0, and values above 100 shall be clamped to 100. The component shall ensure that brake force can never be commanded outside this safe range under any circumstances, including during transient conditions or error recovery.
 
 ---
 
 ## REQ_BC_INITIALIZATION
 
-- **ID**: REQ_BC_INITIALIZATION
-- **Parent**: /examples/requirements/REQ-BRK-001.sysreq.md#REQ-BRK-001
-- **SIL**: ASIL-D
-- **Sec**: false
-- **Description**: The brake controller component shall perform initialization at startup including: loading and validating the braking distance table from vehicle parameters, verifying table structure and data ranges, initializing all controller state variables to zero, establishing subscriptions to required input topics, and beginning to publish brake commands. If initialization fails due to invalid parameters or inability to establish communication, the component shall report an error and not enter operational mode.
+```yaml
+parent: /examples/requirements/REQ-BRK-001.sysreq.md#REQ-BRK-001
+parent_version: 1
+sil: ASIL-D
+sec: false
+```
+
+Derived from [REQ-BRK-001](/examples/requirements/REQ-BRK-001.sysreq.md?version=1#REQ-BRK-001).
+The brake controller component shall perform initialization at startup including: loading and validating the braking distance table from vehicle parameters, verifying table structure and data ranges, initializing all controller state variables to zero, establishing subscriptions to required input topics, and beginning to publish brake commands. If initialization fails due to invalid parameters or inability to establish communication, the component shall report an error and not enter operational mode.
 
 ---

--- a/examples/vehicle_status/doc/vehicle_status.swreq.md
+++ b/examples/vehicle_status/doc/vehicle_status.swreq.md
@@ -8,50 +8,70 @@ This document contains the software requirements for the Vehicle Status componen
 
 ## REQ_VS_READ_SENSORS
 
-- **ID**: REQ_VS_READ_SENSORS
-- **Parent**: /examples/requirements/REQ-VEL-001.sysreq.md#REQ-VEL-001
-- **SIL**: ASIL-D
-- **Sec**: false
-- **Description**: The vehicle status component shall read wheel speed sensor data from all four wheels via the CAN bus at a rate of 100 Hz. Each wheel speed sensor provides rotational speed in RPM (revolutions per minute) with valid range [0, 2000] RPM. The component shall reject any sensor readings older than 20 milliseconds.
+```yaml
+parent: /examples/requirements/REQ-VEL-001.sysreq.md#REQ-VEL-001
+parent_version: 1
+sil: ASIL-D
+sec: false
+```
+
+Derived from [REQ-VEL-001](/examples/requirements/REQ-VEL-001.sysreq.md?version=1#REQ-VEL-001).
+The vehicle status component shall read wheel speed sensor data from all four wheels via the CAN bus at a rate of 100 Hz. Each wheel speed sensor provides rotational speed in RPM (revolutions per minute) with valid range [0, 2000] RPM. The component shall reject any sensor readings older than 20 milliseconds.
 
 ---
 
 ## REQ_VS_CALCULATE_SPEED
 
-- **ID**: REQ_VS_CALCULATE_SPEED
-- **Parent**: /examples/requirements/REQ-VEL-001.sysreq.md#REQ-VEL-001
-- **SIL**: ASIL-D
-- **Sec**: false
-- **Description**: The vehicle status component shall calculate vehicle linear speed by converting each valid wheel speed from RPM to meters per second using the configured wheel radius parameter, then averaging the converted speeds from all valid wheels. The calculation shall use the formula: linear_velocity = (RPM × 2π × wheel_radius) / 60. The component shall validate sensor readings per REQ_VS_VALIDATE_SENSORS before including them in the average.
+```yaml
+parent: /examples/requirements/REQ-VEL-001.sysreq.md#REQ-VEL-001
+parent_version: 1
+sil: ASIL-D
+sec: false
+```
+
+Derived from [REQ-VEL-001](/examples/requirements/REQ-VEL-001.sysreq.md?version=1#REQ-VEL-001).
+The vehicle status component shall calculate vehicle linear speed by converting each valid wheel speed from RPM to meters per second using the configured wheel radius parameter, then averaging the converted speeds from all valid wheels. The calculation shall use the formula: linear_velocity = (RPM × 2π × wheel_radius) / 60. The component shall validate sensor readings per REQ_VS_VALIDATE_SENSORS before including them in the average.
 
 ---
 
 ## REQ_VS_CALCULATE_ACCELERATION
 
-- **ID**: REQ_VS_CALCULATE_ACCELERATION
-- **Parent**: /examples/requirements/REQ-VEL-001.sysreq.md#REQ-VEL-001
-- **SIL**: ASIL-D
-- **Sec**: false
-- **Description**: The vehicle status component shall calculate vehicle acceleration by computing the rate of change of vehicle speed over time. The raw acceleration shall be calculated as (current_speed - previous_speed) / time_delta. To reduce measurement noise, the component shall apply a first-order low-pass filter with coefficient alpha = 0.3 according to the formula: filtered_accel = 0.3 × raw_accel + 0.7 × previous_filtered_accel.
+```yaml
+parent: /examples/requirements/REQ-VEL-001.sysreq.md#REQ-VEL-001
+parent_version: 1
+sil: ASIL-D
+sec: false
+```
+
+Derived from [REQ-VEL-001](/examples/requirements/REQ-VEL-001.sysreq.md?version=1#REQ-VEL-001).
+The vehicle status component shall calculate vehicle acceleration by computing the rate of change of vehicle speed over time. The raw acceleration shall be calculated as (current_speed - previous_speed) / time_delta. To reduce measurement noise, the component shall apply a first-order low-pass filter with coefficient alpha = 0.3 according to the formula: filtered_accel = 0.3 × raw_accel + 0.7 × previous_filtered_accel.
 
 ---
 
 ## REQ_VS_PUBLISH_STATUS
 
-- **ID**: REQ_VS_PUBLISH_STATUS
-- **Parent**: /examples/requirements/REQ-VEL-001.sysreq.md#REQ-VEL-001
-- **SIL**: ASIL-D
-- **Sec**: false
-- **Description**: The vehicle status component shall publish vehicle status messages at a rate of 100 Hz (10 millisecond period) with maximum jitter of 1 millisecond. Each status message shall include: vehicle speed in meters per second, vehicle acceleration in meters per second squared, timestamp in nanoseconds, and status field (VALID, DEGRADED, or INVALID) as determined by REQ_VS_VALIDATE_SENSORS. The maximum latency from sensor read to publish shall be 2 milliseconds.
+```yaml
+parent: /examples/requirements/REQ-VEL-001.sysreq.md#REQ-VEL-001
+parent_version: 1
+sil: ASIL-D
+sec: false
+```
+
+Derived from [REQ-VEL-001](/examples/requirements/REQ-VEL-001.sysreq.md?version=1#REQ-VEL-001).
+The vehicle status component shall publish vehicle status messages at a rate of 100 Hz (10 millisecond period) with maximum jitter of 1 millisecond. Each status message shall include: vehicle speed in meters per second, vehicle acceleration in meters per second squared, timestamp in nanoseconds, and status field (VALID, DEGRADED, or INVALID) as determined by REQ_VS_VALIDATE_SENSORS. The maximum latency from sensor read to publish shall be 2 milliseconds.
 
 ---
 
 ## REQ_VS_VALIDATE_SENSORS
 
-- **ID**: REQ_VS_VALIDATE_SENSORS
-- **Parent**: /examples/requirements/REQ-VEL-001.sysreq.md#REQ-VEL-001
-- **SIL**: ASIL-D
-- **Sec**: false
-- **Description**: The vehicle status component shall validate wheel speed sensors by performing plausibility checks. For each sensor reading: (1) check that RPM value is within valid range [0, 2000], (2) check that sensor data age is less than 20 milliseconds, (3) calculate the mean of all sensor readings and check that each sensor deviates from the mean by no more than 30 percent. If any sensor fails validation, exclude it from speed calculation. If a sensor deviates by 20-30 percent, mark status as DEGRADED. If fewer than 3 sensors pass validation, mark status as INVALID and publish zero speed and acceleration.
+```yaml
+parent: /examples/requirements/REQ-VEL-001.sysreq.md#REQ-VEL-001
+parent_version: 1
+sil: ASIL-D
+sec: false
+```
+
+Derived from [REQ-VEL-001](/examples/requirements/REQ-VEL-001.sysreq.md?version=1#REQ-VEL-001).
+The vehicle status component shall validate wheel speed sensors by performing plausibility checks. For each sensor reading: (1) check that RPM value is within valid range [0, 2000], (2) check that sensor data age is less than 20 milliseconds, (3) calculate the mean of all sensor readings and check that each sensor deviates from the mean by no more than 30 percent. If any sensor fails validation, exclude it from speed calculation. If a sensor deviates by 20-30 percent, mark status as DEGRADED. If fewer than 3 sensors pass validation, mark status as INVALID and publish zero speed and acceleration.
 
 ---

--- a/fire/starlark/swreq_validator.bzl
+++ b/fire/starlark/swreq_validator.bzl
@@ -131,6 +131,23 @@ def _validate_description(description, req_id):
 
     return None
 
+def _validate_parent_version(parent_version):
+    """Validate parent requirement version number.
+
+    Args:
+        parent_version: Parent version number (should be positive integer)
+
+    Returns:
+        None if valid, error message if invalid
+    """
+    if type(parent_version) != "int":
+        return "parent_version must be an integer, got {}".format(type(parent_version))
+
+    if parent_version <= 0:
+        return "parent_version must be positive, got {}".format(parent_version)
+
+    return None
+
 def _validate_frontmatter(frontmatter):
     """Validate software requirements frontmatter.
 
@@ -172,7 +189,7 @@ def _validate_requirement(req, all_req_ids):
     """
 
     # Check required fields
-    required_fields = ["id", "parent", "sil", "sec", "description"]
+    required_fields = ["id", "parent", "parent_version", "sil", "sec", "description"]
     for field in required_fields:
         if field not in req:
             return "requirement missing required field: {}".format(field)
@@ -191,6 +208,11 @@ def _validate_requirement(req, all_req_ids):
 
     # Validate parent reference
     err = _validate_parent_reference(req["parent"])
+    if err:
+        return "requirement '{}': {}".format(req_id, err)
+
+    # Validate parent_version
+    err = _validate_parent_version(req["parent_version"])
     if err:
         return "requirement '{}': {}".format(req_id, err)
 

--- a/fire/starlark/swreq_validator_test.bzl
+++ b/fire/starlark/swreq_validator_test.bzl
@@ -24,21 +24,29 @@ system_function: sys_eng/software_architecture/hzm.sysarch.md
 
 ## REQ_HZM_HZ
 
-- **ID**: REQ_HZM_HZ
-- **Parent**: sys_eng/sysreq/hzm.sysreq.md#ATS_867
-- **SIL**: SIL-2
-- **Sec**: true
-- **Description**: The HZM hazard_zone component shall output a no-steering sector.
+```yaml
+parent: sys_eng/sysreq/hzm.sysreq.md#ATS_867
+parent_version: 1
+sil: SIL-2
+sec: true
+```
+
+Derived from [ATS_867](sys_eng/sysreq/hzm.sysreq.md?version=1#ATS_867).
+The HZM hazard_zone component shall output a no-steering sector.
 
 ---
 
 ## REQ_HZM_NOT_HZ
 
-- **ID**: REQ_HZM_NOT_HZ
-- **Parent**: sys_eng/sysreq/hzm.sysreq.md#ATS_871
-- **SIL**: SIL-2
-- **Sec**: true
-- **Description**: The HZM hazard_zone component shall output a not-hazard-zone as a list of polygons.
+```yaml
+parent: sys_eng/sysreq/hzm.sysreq.md#ATS_871
+parent_version: 1
+sil: SIL-2
+sec: true
+```
+
+Derived from [ATS_871](sys_eng/sysreq/hzm.sysreq.md?version=1#ATS_871).
+The HZM hazard_zone component shall output a not-hazard-zone as a list of polygons.
 
 ---
 """
@@ -81,13 +89,17 @@ def _test_parse_multiline_description(ctx):
 
 ## REQ_TEST_001
 
-- **ID**: REQ_TEST_001
-- **Parent**: sysreq.md#SYS_001
-- **SIL**: SIL-2
-- **Sec**: true
-- **Description**: This is a very long description that spans
-  multiple lines and should be properly concatenated into a single
-  description field by the parser.
+```yaml
+parent: sysreq.md#SYS_001
+parent_version: 1
+sil: SIL-2
+sec: true
+```
+
+Derived from [SYS_001](sysreq.md?version=1#SYS_001).
+This is a very long description that spans
+multiple lines and should be properly concatenated into a single
+description field by the parser.
 
 ---
 """
@@ -116,11 +128,15 @@ def _test_parse_sil_none(ctx):
 
 ## REQ_TEST_001
 
-- **ID**: REQ_TEST_001
-- **Parent**: sysreq.md#SYS_001
-- **SIL**: None
-- **Sec**: false
-- **Description**: This requirement has no SIL level assigned.
+```yaml
+parent: sysreq.md#SYS_001
+parent_version: 1
+sil: none
+sec: false
+```
+
+Derived from [SYS_001](sysreq.md?version=1#SYS_001).
+This requirement has no SIL level assigned.
 
 ---
 """
@@ -153,11 +169,15 @@ def _test_validate_valid_swreq(ctx):
 
 ## REQ_HZM_HZ
 
-- **ID**: REQ_HZM_HZ
-- **Parent**: sys_eng/sysreq/hzm.md#ATS_867
-- **SIL**: SIL-2
-- **Sec**: true
-- **Description**: The component shall output a hazard zone sector.
+```yaml
+parent: sys_eng/sysreq/hzm.md#ATS_867
+parent_version: 1
+sil: SIL-2
+sec: true
+```
+
+Derived from [ATS_867](sys_eng/sysreq/hzm.md?version=1#ATS_867).
+The component shall output a hazard zone sector.
 
 ---
 """
@@ -182,31 +202,43 @@ def _test_validate_multiple_requirements(ctx):
 
 ## REQ_TEST_001
 
-- **ID**: REQ_TEST_001
-- **Parent**: sysreq.md#SYS_001
-- **SIL**: ASIL-D
-- **Sec**: true
-- **Description**: First requirement description with sufficient length.
+```yaml
+parent: sysreq.md#SYS_001
+parent_version: 1
+sil: ASIL-D
+sec: true
+```
+
+Derived from [SYS_001](sysreq.md?version=1#SYS_001).
+First requirement description with sufficient length.
 
 ---
 
 ## REQ_TEST_002
 
-- **ID**: REQ_TEST_002
-- **Parent**: sysreq.md#SYS_002
-- **SIL**: ASIL-C
-- **Sec**: false
-- **Description**: Second requirement description with sufficient length.
+```yaml
+parent: sysreq.md#SYS_002
+parent_version: 1
+sil: ASIL-C
+sec: false
+```
+
+Derived from [SYS_002](sysreq.md?version=1#SYS_002).
+Second requirement description with sufficient length.
 
 ---
 
 ## REQ_TEST_003
 
-- **ID**: REQ_TEST_003
-- **Parent**: sysreq.md#SYS_003
-- **SIL**: ASIL-D
-- **Sec**: true
-- **Description**: Third requirement description with sufficient length.
+```yaml
+parent: sysreq.md#SYS_003
+parent_version: 1
+sil: ASIL-D
+sec: true
+```
+
+Derived from [SYS_003](sysreq.md?version=1#SYS_003).
+Third requirement description with sufficient length.
 
 ---
 """
@@ -231,21 +263,29 @@ def _test_validate_internal_references(ctx):
 
 ## REQ_TEST_PRIMARY
 
-- **ID**: REQ_TEST_PRIMARY
-- **Parent**: sysreq.md#SYS_001
-- **SIL**: SIL-2
-- **Sec**: true
-- **Description**: This requirement references REQ_TEST_SECONDARY in its description.
+```yaml
+parent: sysreq.md#SYS_001
+parent_version: 1
+sil: SIL-2
+sec: true
+```
+
+Derived from [SYS_001](sysreq.md?version=1#SYS_001).
+This requirement references REQ_TEST_SECONDARY in its description.
 
 ---
 
 ## REQ_TEST_SECONDARY
 
-- **ID**: REQ_TEST_SECONDARY
-- **Parent**: sysreq.md#SYS_002
-- **SIL**: SIL-2
-- **Sec**: false
-- **Description**: This is the secondary requirement being referenced.
+```yaml
+parent: sysreq.md#SYS_002
+parent_version: 1
+sil: SIL-2
+sec: false
+```
+
+Derived from [SYS_002](sysreq.md?version=1#SYS_002).
+This is the secondary requirement being referenced.
 
 ---
 """
@@ -267,11 +307,15 @@ def _test_validate_missing_frontmatter(ctx):
 
 ## REQ_TEST_001
 
-- **ID**: REQ_TEST_001
-- **Parent**: sysreq.md#SYS_001
-- **SIL**: SIL-2
-- **Sec**: true
-- **Description**: This requirement has no frontmatter.
+```yaml
+parent: sysreq.md#SYS_001
+parent_version: 1
+sil: SIL-2
+sec: true
+```
+
+Derived from [SYS_001](sysreq.md?version=1#SYS_001).
+This requirement has no frontmatter.
 """
 
     err = swreq_validator.validate(content)
@@ -291,11 +335,15 @@ def _test_validate_missing_required_frontmatter_field(ctx):
 
 ## REQ_TEST_001
 
-- **ID**: REQ_TEST_001
-- **Parent**: sysreq.md#SYS_001
-- **SIL**: SIL-2
-- **Sec**: true
-- **Description**: Valid requirement description.
+```yaml
+parent: sysreq.md#SYS_001
+parent_version: 1
+sil: SIL-2
+sec: true
+```
+
+Derived from [SYS_001](sysreq.md?version=1#SYS_001).
+Valid requirement description.
 """
 
     err = swreq_validator.validate(content)
@@ -319,11 +367,15 @@ def _test_validate_invalid_requirement_id_format(ctx):
 
 ## req_test_001
 
-- **ID**: req_test_001
-- **Parent**: sysreq.md#SYS_001
-- **SIL**: SIL-2
-- **Sec**: true
-- **Description**: This has invalid ID format (lowercase).
+```yaml
+parent: sysreq.md#SYS_001
+parent_version: 1
+sil: SIL-2
+sec: true
+```
+
+Derived from [SYS_001](sysreq.md?version=1#SYS_001).
+This has invalid ID format (lowercase).
 """
 
     err = swreq_validator.validate(content)
@@ -347,11 +399,15 @@ def _test_validate_missing_req_prefix(ctx):
 
 ## TEST_001
 
-- **ID**: TEST_001
-- **Parent**: sysreq.md#SYS_001
-- **SIL**: SIL-2
-- **Sec**: true
-- **Description**: This ID doesn't start with REQ_.
+```yaml
+parent: sysreq.md#SYS_001
+parent_version: 1
+sil: SIL-2
+sec: true
+```
+
+Derived from [SYS_001](sysreq.md?version=1#SYS_001).
+This ID doesn't start with REQ_.
 """
 
     err = swreq_validator.validate(content)
@@ -376,11 +432,15 @@ def _test_validate_invalid_parent_reference(ctx):
 
 ## REQ_TEST_001
 
-- **ID**: REQ_TEST_001
-- **Parent**: sysreq.md
-- **SIL**: SIL-2
-- **Sec**: true
-- **Description**: Parent reference missing anchor.
+```yaml
+parent: sysreq.md
+parent_version: 1
+sil: SIL-2
+sec: true
+```
+
+Derived from parent requirement.
+Parent reference missing anchor.
 """
 
     err = swreq_validator.validate(content)
@@ -404,21 +464,29 @@ def _test_validate_duplicate_requirement_ids(ctx):
 
 ## REQ_TEST_001
 
-- **ID**: REQ_TEST_001
-- **Parent**: sysreq.md#SYS_001
-- **SIL**: SIL-2
-- **Sec**: true
-- **Description**: First requirement with this ID.
+```yaml
+parent: sysreq.md#SYS_001
+parent_version: 1
+sil: SIL-2
+sec: true
+```
+
+Derived from [SYS_001](sysreq.md?version=1#SYS_001).
+First requirement with this ID.
 
 ---
 
 ## REQ_TEST_001
 
-- **ID**: REQ_TEST_001
-- **Parent**: sysreq.md#SYS_002
-- **SIL**: SIL-2
-- **Sec**: true
-- **Description**: Duplicate requirement with same ID.
+```yaml
+parent: sysreq.md#SYS_002
+parent_version: 1
+sil: SIL-2
+sec: true
+```
+
+Derived from [SYS_002](sysreq.md?version=1#SYS_002).
+Duplicate requirement with same ID.
 """
 
     err = swreq_validator.validate(content)
@@ -443,10 +511,12 @@ def _test_validate_missing_requirement_field(ctx):
 
 ## REQ_TEST_001
 
-- **ID**: REQ_TEST_001
-- **Parent**: sysreq.md#SYS_001
-- **SIL**: SIL-2
-- **Sec**: true
+```yaml
+parent: sysreq.md#SYS_001
+parent_version: 1
+sil: SIL-2
+sec: true
+```
 """
 
     err = swreq_validator.validate(content)
@@ -470,11 +540,14 @@ def _test_validate_short_description(ctx):
 
 ## REQ_TEST_001
 
-- **ID**: REQ_TEST_001
-- **Parent**: sysreq.md#SYS_001
-- **SIL**: SIL-2
-- **Sec**: true
-- **Description**: Short.
+```yaml
+parent: sysreq.md#SYS_001
+parent_version: 1
+sil: SIL-2
+sec: true
+```
+
+Short.
 """
 
     err = swreq_validator.validate(content)
@@ -498,11 +571,15 @@ def _test_validate_invalid_internal_reference(ctx):
 
 ## REQ_TEST_001
 
-- **ID**: REQ_TEST_001
-- **Parent**: sysreq.md#SYS_001
-- **SIL**: SIL-2
-- **Sec**: true
-- **Description**: This requirement references REQ_NONEXISTENT which does not exist.
+```yaml
+parent: sysreq.md#SYS_001
+parent_version: 1
+sil: SIL-2
+sec: true
+```
+
+Derived from [SYS_001](sysreq.md?version=1#SYS_001).
+This requirement references REQ_NONEXISTENT which does not exist.
 """
 
     err = swreq_validator.validate(content)
@@ -549,11 +626,15 @@ def _test_validate_invalid_sec_type(ctx):
 
 ## REQ_TEST_001
 
-- **ID**: REQ_TEST_001
-- **Parent**: sysreq.md#SYS_001
-- **SIL**: SIL-2
-- **Sec**: yes
-- **Description**: Sec field should be boolean not string.
+```yaml
+parent: sysreq.md#SYS_001
+parent_version: 1
+sil: SIL-2
+sec: yes
+```
+
+Derived from [SYS_001](sysreq.md?version=1#SYS_001).
+Sec field should be boolean not string.
 """
 
     err = swreq_validator.validate(content)


### PR DESCRIPTION
## Summary

This PR migrates software requirements from the old markdown list format to a new YAML block format that supports multiple requirements per file. This is a major architectural change that enables more flexible requirement organization and better traceability.

## Changes

### Parser & Validator (`fire/starlark/`)

**swreq_parser.bzl:**
- Added `_parse_yaml_block()` function to extract YAML from ```yaml code blocks
- Rewrote `_parse_requirement_section()` to parse YAML blocks instead of markdown lists
- Modified `parse_swreq()` to use ## headers as requirement IDs
- Parser now extracts: `parent`, `parent_version`, `sil`, `sec` from YAML blocks
- Description extracted from markdown text after YAML block
- Removed unused `_extract_list_value()` and `_parse_bool()` functions

**swreq_validator.bzl:**
- Added `_validate_parent_version()` function to validate positive integer
- Updated `_validate_requirement()` to include `parent_version` in required fields
- Added validation call for parent_version field

### Example Files (18 requirements)

Updated all example software requirements files:
- `examples/brake_control/doc/brake_controller.swreq.md` (8 requirements)
- `examples/vehicle_status/doc/vehicle_status.swreq.md` (5 requirements)
- `examples/brake_actuator/doc/brake_actuator.swreq.md` (5 requirements)

**Old format:**
```markdown
- **ID**: REQ_BC_CALCULATE_FORCE
- **Parent**: /examples/requirements/REQ-BRK-001.sysreq.md#REQ-BRK-001
- **SIL**: ASIL-D
- **Sec**: false
- **Description**: The brake controller component shall...
```

**New format:**
````markdown
## REQ_BC_CALCULATE_FORCE

```yaml
parent: /examples/requirements/REQ-BRK-001.sysreq.md#REQ-BRK-001
parent_version: 1
sil: ASIL-D
sec: false
```

Derived from [REQ-BRK-001](/examples/requirements/REQ-BRK-001.sysreq.md?version=1#REQ-BRK-001).
The brake controller component shall...
````

### Tests (`fire/starlark/swreq_validator_test.bzl`)

- Updated all 21 test fixtures to use new YAML block format
- Fixed short description test to not include "Derived from" prefix
- All 119 tests passing

### Documentation (`examples/README.md`)

- Updated software requirements format documentation
- Added example showing new YAML block format
- Explained `parent_version` tracking and `?version=` query parameter convention

## Benefits

✅ **Multiple requirements per file** - Section-based approach allows many requirements in one file (not limited by frontmatter)

✅ **Structured metadata** - YAML blocks provide clear, parseable structure for each requirement

✅ **Clickable parent links** - "Derived from" links work in GitHub/GitLab with `?version=` convention

✅ **Parent version tracking** - New `parent_version` field tracks derivation lineage for change management

✅ **Strict structure** - Easy to read and validate, clear separation of metadata and description

## Format Details

### YAML Block Structure

Each requirement now uses a YAML code block for structured fields:
- `parent`: Path to parent requirement with anchor (e.g., `/examples/requirements/REQ-BRK-001.sysreq.md#REQ-BRK-001`)
- `parent_version`: Integer version of parent requirement being derived from
- `sil`: Safety Integrity Level (ASIL-D, SIL-2, DAL-A, etc., or `none`)
- `sec`: Boolean indicating if requirement is security-related

### Description Convention

Descriptions start with a "Derived from" link that:
- Makes the parent relationship **clickable** in GitHub/GitLab
- Uses `?version=X` query parameter convention to track version (GitHub ignores but tools can parse)
- Provides human-readable context about requirement derivation

## Test Plan

- [x] All 119 tests passing
- [x] Parser correctly extracts YAML blocks
- [x] Validator enforces `parent_version` requirements
- [x] Example files build successfully (`bazel build //examples/...`)
- [x] Documentation updated
- [x] Pre-commit hooks passing

## Migration Impact

This is a **breaking change** for existing `.swreq.md` files. All software requirement files must be migrated to the new format. The parser no longer supports the old markdown list format.

🤖 Generated with [Claude Code](https://claude.com/claude-code)