### PR TITLE
Remove parent and parent_version from software requirement YAML blocks

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -204,7 +204,7 @@ achieving deceleration according to [@braking_distance_table](/examples/vehicle_
 - Optional YAML frontmatter (system_function)
 - Section-based format with ## headers for each requirement ID
 - Each requirement contains:
-  - YAML code block with: parent, parent_version, sil, sec
+  - YAML code block with: sil, sec
   - Markdown description starting with "Derived from [PARENT](link?version=X#PARENT)" link
 
 Example format:
@@ -213,13 +213,11 @@ Example format:
 ## REQ_BC_CALCULATE_FORCE
 
 ```yaml
-parent: /examples/requirements/REQ-BRK-001.sysreq.md#REQ-BRK-001
-parent_version: 1
 sil: ASIL-D
 sec: false
 ```
 
-Derived from [REQ-BRK-001](/examples/requirements/REQ-BRK-001.sysreq.md?version=1#REQ-BRK-001).
+Derived from [REQ-BRK-001](/examples/requirements/braking_requirements.sysreq.md?version=1#REQ-BRK-001).
 The brake controller component shall calculate the required brake force...
 
 ````

--- a/examples/brake_actuator/doc/brake_actuator.swreq.md
+++ b/examples/brake_actuator/doc/brake_actuator.swreq.md
@@ -9,8 +9,6 @@ This document contains the software requirements for the Brake Actuator componen
 ## REQ_BA_RECEIVE_COMMANDS
 
 ```yaml
-parent: /examples/requirements/braking_requirements.sysreq.md#REQ-BRK-001
-parent_version: 1
 sil: ASIL-D
 sec: false
 ```
@@ -23,8 +21,6 @@ The brake actuator component shall subscribe to brake force commands at a rate o
 ## REQ_BA_CONVERT_FORCE
 
 ```yaml
-parent: /examples/requirements/braking_requirements.sysreq.md#REQ-BRK-001
-parent_version: 1
 sil: ASIL-D
 sec: false
 ```
@@ -37,8 +33,6 @@ The brake actuator component shall convert brake force percentage commands to hy
 ## REQ_BA_CONTROL_HYDRAULICS
 
 ```yaml
-parent: /examples/requirements/braking_requirements.sysreq.md#REQ-BRK-001
-parent_version: 1
 sil: ASIL-D
 sec: false
 ```
@@ -51,8 +45,6 @@ The brake actuator component shall control the electro-hydraulic valve using a P
 ## REQ_BA_MONITOR_PRESSURE
 
 ```yaml
-parent: /examples/requirements/braking_requirements.sysreq.md#REQ-BRK-001
-parent_version: 1
 sil: ASIL-D
 sec: false
 ```
@@ -65,8 +57,6 @@ The brake actuator component shall read the hydraulic pressure sensor at 1000 Hz
 ## REQ_BA_SAFETY_LIMITS
 
 ```yaml
-parent: /examples/requirements/braking_requirements.sysreq.md#REQ-BRK-001
-parent_version: 1
 sil: ASIL-D
 sec: false
 ```

--- a/examples/brake_control/doc/brake_controller.swreq.md
+++ b/examples/brake_control/doc/brake_controller.swreq.md
@@ -9,8 +9,6 @@ This document contains the software requirements for the Brake Controller compon
 ## REQ_BC_CALCULATE_FORCE
 
 ```yaml
-parent: /examples/requirements/braking_requirements.sysreq.md#REQ-BRK-001
-parent_version: 1
 sil: ASIL-D
 sec: false
 ```
@@ -23,8 +21,6 @@ The brake controller component shall calculate the required brake force based on
 ## REQ_BC_MONITOR_DECELERATION
 
 ```yaml
-parent: /examples/requirements/braking_requirements.sysreq.md#REQ-BRK-001
-parent_version: 1
 sil: ASIL-D
 sec: false
 ```
@@ -37,8 +33,6 @@ The brake controller component shall continuously monitor the actual vehicle dec
 ## REQ_BC_USE_BRAKING_TABLE
 
 ```yaml
-parent: /examples/requirements/braking_requirements.sysreq.md#REQ-BRK-001
-parent_version: 1
 sil: ASIL-D
 sec: false
 ```
@@ -51,8 +45,6 @@ The brake controller component shall use the braking distance table parameter to
 ## REQ_BC_EMERGENCY_BRAKE
 
 ```yaml
-parent: /examples/requirements/braking_requirements.sysreq.md#REQ-BRK-001
-parent_version: 1
 sil: ASIL-D
 sec: false
 ```
@@ -65,8 +57,6 @@ The brake controller component shall enter emergency braking mode and command ma
 ## REQ_BC_OUTPUT_RATE
 
 ```yaml
-parent: /examples/requirements/braking_requirements.sysreq.md#REQ-BRK-001
-parent_version: 1
 sil: ASIL-D
 sec: false
 ```
@@ -79,8 +69,6 @@ The brake controller component shall publish brake force commands at a rate of 5
 ## REQ_BC_INPUT_VALIDATION
 
 ```yaml
-parent: /examples/requirements/braking_requirements.sysreq.md#REQ-BRK-001
-parent_version: 1
 sil: ASIL-D
 sec: false
 ```
@@ -93,8 +81,6 @@ The brake controller component shall validate all input values at each processin
 ## REQ_BC_FORCE_LIMITS
 
 ```yaml
-parent: /examples/requirements/braking_requirements.sysreq.md#REQ-BRK-001
-parent_version: 1
 sil: ASIL-D
 sec: false
 ```
@@ -107,8 +93,6 @@ The brake controller component shall limit all calculated brake force values to 
 ## REQ_BC_INITIALIZATION
 
 ```yaml
-parent: /examples/requirements/braking_requirements.sysreq.md#REQ-BRK-001
-parent_version: 1
 sil: ASIL-D
 sec: false
 ```

--- a/examples/vehicle_status/doc/vehicle_status.swreq.md
+++ b/examples/vehicle_status/doc/vehicle_status.swreq.md
@@ -9,8 +9,6 @@ This document contains the software requirements for the Vehicle Status componen
 ## REQ_VS_READ_SENSORS
 
 ```yaml
-parent: /examples/requirements/velocity_requirements.sysreq.md#REQ-VEL-001
-parent_version: 1
 sil: ASIL-D
 sec: false
 ```
@@ -23,8 +21,6 @@ The vehicle status component shall read wheel speed sensor data from all four wh
 ## REQ_VS_CALCULATE_SPEED
 
 ```yaml
-parent: /examples/requirements/velocity_requirements.sysreq.md#REQ-VEL-001
-parent_version: 1
 sil: ASIL-D
 sec: false
 ```
@@ -37,8 +33,6 @@ The vehicle status component shall calculate vehicle linear speed by converting 
 ## REQ_VS_CALCULATE_ACCELERATION
 
 ```yaml
-parent: /examples/requirements/velocity_requirements.sysreq.md#REQ-VEL-001
-parent_version: 1
 sil: ASIL-D
 sec: false
 ```
@@ -51,8 +45,6 @@ The vehicle status component shall calculate vehicle acceleration by computing t
 ## REQ_VS_PUBLISH_STATUS
 
 ```yaml
-parent: /examples/requirements/velocity_requirements.sysreq.md#REQ-VEL-001
-parent_version: 1
 sil: ASIL-D
 sec: false
 ```
@@ -65,8 +57,6 @@ The vehicle status component shall publish vehicle status messages at a rate of 
 ## REQ_VS_VALIDATE_SENSORS
 
 ```yaml
-parent: /examples/requirements/velocity_requirements.sysreq.md#REQ-VEL-001
-parent_version: 1
 sil: ASIL-D
 sec: false
 ```

--- a/fire/starlark/swreq_parser.bzl
+++ b/fire/starlark/swreq_parser.bzl
@@ -154,13 +154,14 @@ def _parse_requirement_section(section_content):
 
     Expected format:
     ```yaml
-    parent: /path/to/parent.md#ANCHOR
-    parent_version: 2
     sil: ASIL-D
     sec: false
     ```
 
+    Derived from [PARENT](/path/to/parent.md?version=2#PARENT).
     Description text follows after YAML block...
+
+    Note: parent and parent_version fields are deprecated - use markdown links instead.
 
     Args:
         section_content: Content of one requirement section
@@ -220,8 +221,6 @@ def parse_swreq(content):
     ## REQ_ID_1
 
     ```yaml
-    parent: /path/to/sysreq.md#SYSREQ_ID
-    parent_version: 2
     sil: ASIL-D
     sec: false
     ```
@@ -234,12 +233,11 @@ def parse_swreq(content):
     ## REQ_ID_2
 
     ```yaml
-    parent: /path/to/sysreq.md#ANOTHER_ID
-    parent_version: 1
     sil: ASIL-C
     sec: true
     ```
 
+    Derived from [REQ-ANOTHER](/path/to/sysreq.md?version=1#ANOTHER_ID).
     Description text for REQ_ID_2...
     ```
 

--- a/fire/starlark/swreq_validator.bzl
+++ b/fire/starlark/swreq_validator.bzl
@@ -131,23 +131,6 @@ def _validate_description(description, req_id):
 
     return None
 
-def _validate_parent_version(parent_version):
-    """Validate parent requirement version number.
-
-    Args:
-        parent_version: Parent version number (should be positive integer)
-
-    Returns:
-        None if valid, error message if invalid
-    """
-    if type(parent_version) != "int":
-        return "parent_version must be an integer, got {}".format(type(parent_version))
-
-    if parent_version <= 0:
-        return "parent_version must be positive, got {}".format(parent_version)
-
-    return None
-
 def _validate_frontmatter(frontmatter):
     """Validate software requirements frontmatter.
 
@@ -189,7 +172,8 @@ def _validate_requirement(req, all_req_ids):
     """
 
     # Check required fields
-    required_fields = ["id", "parent", "parent_version", "sil", "sec", "description"]
+    # Note: parent and parent_version removed - these are now in markdown links
+    required_fields = ["id", "sil", "sec", "description"]
     for field in required_fields:
         if field not in req:
             return "requirement missing required field: {}".format(field)
@@ -205,16 +189,6 @@ def _validate_requirement(req, all_req_ids):
     if req_id in all_req_ids:
         return "duplicate requirement ID: '{}'".format(req_id)
     all_req_ids[req_id] = True
-
-    # Validate parent reference
-    err = _validate_parent_reference(req["parent"])
-    if err:
-        return "requirement '{}': {}".format(req_id, err)
-
-    # Validate parent_version
-    err = _validate_parent_version(req["parent_version"])
-    if err:
-        return "requirement '{}': {}".format(req_id, err)
 
     # Validate SIL
     err = _validate_sil(req["sil"])

--- a/fire/starlark/swreq_validator_test.bzl
+++ b/fire/starlark/swreq_validator_test.bzl
@@ -25,8 +25,6 @@ system_function: sys_eng/software_architecture/hzm.sysarch.md
 ## REQ_HZM_HZ
 
 ```yaml
-parent: sys_eng/sysreq/hzm.sysreq.md#ATS_867
-parent_version: 1
 sil: SIL-2
 sec: true
 ```
@@ -39,8 +37,6 @@ The HZM hazard_zone component shall output a no-steering sector.
 ## REQ_HZM_NOT_HZ
 
 ```yaml
-parent: sys_eng/sysreq/hzm.sysreq.md#ATS_871
-parent_version: 1
 sil: SIL-2
 sec: true
 ```
@@ -62,7 +58,6 @@ The HZM hazard_zone component shall output a not-hazard-zone as a list of polygo
     # Check first requirement
     req1 = requirements[0]
     asserts.equals(env, "REQ_HZM_HZ", req1["id"])
-    asserts.equals(env, "sys_eng/sysreq/hzm.sysreq.md#ATS_867", req1["parent"])
     asserts.equals(env, "SIL-2", req1["sil"])
     asserts.equals(env, True, req1["sec"])
     asserts.true(env, "no-steering sector" in req1["description"])
@@ -70,7 +65,6 @@ The HZM hazard_zone component shall output a not-hazard-zone as a list of polygo
     # Check second requirement
     req2 = requirements[1]
     asserts.equals(env, "REQ_HZM_NOT_HZ", req2["id"])
-    asserts.equals(env, "sys_eng/sysreq/hzm.sysreq.md#ATS_871", req2["parent"])
 
     return unittest.end(env)
 
@@ -90,8 +84,6 @@ def _test_parse_multiline_description(ctx):
 ## REQ_TEST_001
 
 ```yaml
-parent: sysreq.md#SYS_001
-parent_version: 1
 sil: SIL-2
 sec: true
 ```
@@ -129,8 +121,6 @@ def _test_parse_sil_none(ctx):
 ## REQ_TEST_001
 
 ```yaml
-parent: sysreq.md#SYS_001
-parent_version: 1
 sil: none
 sec: false
 ```
@@ -170,8 +160,6 @@ def _test_validate_valid_swreq(ctx):
 ## REQ_HZM_HZ
 
 ```yaml
-parent: sys_eng/sysreq/hzm.md#ATS_867
-parent_version: 1
 sil: SIL-2
 sec: true
 ```
@@ -203,8 +191,6 @@ def _test_validate_multiple_requirements(ctx):
 ## REQ_TEST_001
 
 ```yaml
-parent: sysreq.md#SYS_001
-parent_version: 1
 sil: ASIL-D
 sec: true
 ```
@@ -217,8 +203,6 @@ First requirement description with sufficient length.
 ## REQ_TEST_002
 
 ```yaml
-parent: sysreq.md#SYS_002
-parent_version: 1
 sil: ASIL-C
 sec: false
 ```
@@ -231,8 +215,6 @@ Second requirement description with sufficient length.
 ## REQ_TEST_003
 
 ```yaml
-parent: sysreq.md#SYS_003
-parent_version: 1
 sil: ASIL-D
 sec: true
 ```
@@ -264,8 +246,6 @@ def _test_validate_internal_references(ctx):
 ## REQ_TEST_PRIMARY
 
 ```yaml
-parent: sysreq.md#SYS_001
-parent_version: 1
 sil: SIL-2
 sec: true
 ```
@@ -278,8 +258,6 @@ This requirement references REQ_TEST_SECONDARY in its description.
 ## REQ_TEST_SECONDARY
 
 ```yaml
-parent: sysreq.md#SYS_002
-parent_version: 1
 sil: SIL-2
 sec: false
 ```
@@ -308,8 +286,6 @@ def _test_validate_missing_frontmatter(ctx):
 ## REQ_TEST_001
 
 ```yaml
-parent: sysreq.md#SYS_001
-parent_version: 1
 sil: SIL-2
 sec: true
 ```
@@ -336,8 +312,6 @@ def _test_validate_missing_required_frontmatter_field(ctx):
 ## REQ_TEST_001
 
 ```yaml
-parent: sysreq.md#SYS_001
-parent_version: 1
 sil: SIL-2
 sec: true
 ```
@@ -368,8 +342,6 @@ def _test_validate_invalid_requirement_id_format(ctx):
 ## req_test_001
 
 ```yaml
-parent: sysreq.md#SYS_001
-parent_version: 1
 sil: SIL-2
 sec: true
 ```
@@ -400,8 +372,6 @@ def _test_validate_missing_req_prefix(ctx):
 ## TEST_001
 
 ```yaml
-parent: sysreq.md#SYS_001
-parent_version: 1
 sil: SIL-2
 sec: true
 ```
@@ -416,38 +386,8 @@ This ID doesn't start with REQ_.
 
     return unittest.end(env)
 
-def _test_validate_invalid_parent_reference(ctx):
-    """Test validation fails with invalid parent reference format."""
-    env = unittest.begin(ctx)
-
-    # Missing anchor
-    content = """---
-# component field removed - redundant
-# version field removed - redundant
-# sil field removed - redundant
-# security_related field removed - redundant
----
-
-# Software Requirements
-
-## REQ_TEST_001
-
-```yaml
-parent: sysreq.md
-parent_version: 1
-sil: SIL-2
-sec: true
-```
-
-Derived from parent requirement.
-Parent reference missing anchor.
-"""
-
-    err = swreq_validator.validate(content)
-    asserts.true(env, err != None)
-    asserts.true(env, "anchor" in err)
-
-    return unittest.end(env)
+# Removed: _test_validate_invalid_parent_reference
+# Parent field is no longer required in YAML blocks - it's in markdown links instead
 
 def _test_validate_duplicate_requirement_ids(ctx):
     """Test validation fails with duplicate requirement IDs."""
@@ -465,8 +405,6 @@ def _test_validate_duplicate_requirement_ids(ctx):
 ## REQ_TEST_001
 
 ```yaml
-parent: sysreq.md#SYS_001
-parent_version: 1
 sil: SIL-2
 sec: true
 ```
@@ -479,8 +417,6 @@ First requirement with this ID.
 ## REQ_TEST_001
 
 ```yaml
-parent: sysreq.md#SYS_002
-parent_version: 1
 sil: SIL-2
 sec: true
 ```
@@ -512,8 +448,6 @@ def _test_validate_missing_requirement_field(ctx):
 ## REQ_TEST_001
 
 ```yaml
-parent: sysreq.md#SYS_001
-parent_version: 1
 sil: SIL-2
 sec: true
 ```
@@ -541,8 +475,6 @@ def _test_validate_short_description(ctx):
 ## REQ_TEST_001
 
 ```yaml
-parent: sysreq.md#SYS_001
-parent_version: 1
 sil: SIL-2
 sec: true
 ```
@@ -572,8 +504,6 @@ def _test_validate_invalid_internal_reference(ctx):
 ## REQ_TEST_001
 
 ```yaml
-parent: sysreq.md#SYS_001
-parent_version: 1
 sil: SIL-2
 sec: true
 ```
@@ -627,8 +557,6 @@ def _test_validate_invalid_sec_type(ctx):
 ## REQ_TEST_001
 
 ```yaml
-parent: sysreq.md#SYS_001
-parent_version: 1
 sil: SIL-2
 sec: yes
 ```
@@ -738,7 +666,8 @@ validate_missing_frontmatter_test = unittest.make(_test_validate_missing_frontma
 validate_missing_required_frontmatter_field_test = unittest.make(_test_validate_missing_required_frontmatter_field)
 validate_invalid_requirement_id_format_test = unittest.make(_test_validate_invalid_requirement_id_format)
 validate_missing_req_prefix_test = unittest.make(_test_validate_missing_req_prefix)
-validate_invalid_parent_reference_test = unittest.make(_test_validate_invalid_parent_reference)
+
+# Removed: validate_invalid_parent_reference_test - parent field no longer required
 validate_duplicate_requirement_ids_test = unittest.make(_test_validate_duplicate_requirement_ids)
 validate_missing_requirement_field_test = unittest.make(_test_validate_missing_requirement_field)
 validate_short_description_test = unittest.make(_test_validate_short_description)
@@ -768,7 +697,7 @@ def swreq_validator_test_suite(name):
         validate_missing_required_frontmatter_field_test,
         validate_invalid_requirement_id_format_test,
         validate_missing_req_prefix_test,
-        validate_invalid_parent_reference_test,
+        # Removed: validate_invalid_parent_reference_test - parent field no longer required
         validate_duplicate_requirement_ids_test,
         validate_missing_requirement_field_test,
         validate_short_description_test,


### PR DESCRIPTION
## Summary
Removed `parent` and `parent_version` fields from software requirement YAML blocks, keeping only `sil` and `sec`. Parent references are already in markdown links, so having them in structured data was redundant.

This completes the structured data cleanup started in PR #25 for system requirements.

## Changes

### Validator Updates

**fire/starlark/swreq_validator.bzl:**
- Removed `parent` and `parent_version` from required fields list
- Removed parent reference and parent_version validation calls
- Removed unused `_validate_parent_version()` function
- Now only validates: `id`, `sil`, `sec`, `description`

**fire/starlark/swreq_parser.bzl:**
- Updated docstrings to show new expected format without parent fields
- Parser still accepts parent/parent_version if present (backward compatibility)

### File Updates

Removed parent and parent_version from YAML blocks in all software requirements:
- `examples/brake_control/doc/brake_controller.swreq.md` (8 requirements)
- `examples/brake_actuator/doc/brake_actuator.swreq.md` (5 requirements)
- `examples/vehicle_status/doc/vehicle_status.swreq.md` (5 requirements)

**Before:**
```yaml
parent: /examples/requirements/braking_requirements.sysreq.md#REQ-BRK-001
parent_version: 1
sil: ASIL-D
sec: false
```

**After:**
```yaml
sil: ASIL-D
sec: false
```

Parent reference remains in markdown link:
```markdown
Derived from [REQ-BRK-001](/examples/requirements/braking_requirements.sysreq.md?version=1#REQ-BRK-001).
```

### Test Updates

**fire/starlark/swreq_validator_test.bzl:**
- Removed parent and parent_version lines from all test fixtures
- Removed parent field assertions from parser tests
- Removed `_test_validate_invalid_parent_reference` test (no longer applicable)
- Kept unit tests for `validate_parent_reference()` function itself
- Total tests: 114 (down from 115)

### Documentation

**examples/README.md:**
- Updated software requirements section to remove parent/parent_version from description
- Updated example to show only sil and sec in YAML blocks

## Benefits

✅ **Consistency**: Software requirements now match system requirements format (only essential fields in YAML)
✅ **No duplication**: Parent reference only in markdown link, not duplicated in YAML
✅ **Simplicity**: Only 2 YAML fields (sil, sec) instead of 4
✅ **Maintainability**: Single source of truth for parent references

## Comparison: Before vs After

| Aspect | Before | After |
|--------|--------|-------|
| **System Requirements YAML** | `sil`, `sec`, `version` | `sil`, `sec`, `version` |
| **Software Requirements YAML** | `parent`, `parent_version`, `sil`, `sec` | `sil`, `sec` |
| **Parent References** | YAML + markdown link | Markdown link only |
| **Consistency** | Different formats | Same approach for both |

## Test Plan

- [x] All 114 tests passing (down from 115)
- [x] Pre-commit hooks passing (buildifier, markdownlint, etc.)
- [x] Successfully built all example targets
- [x] Cross-references validated in software requirements
- [x] Parser backward compatible with old format (accepts but ignores parent fields)

## Breaking Changes

⚠️ **Field removal**: `parent` and `parent_version` removed from YAML blocks

**Migration**: Tools that parse YAML blocks should:
1. Stop requiring parent/parent_version fields
2. Ignore these fields if present (for backward compatibility)
3. Extract parent references from markdown links instead

## Related PRs

- PR #25: Migrated system requirements to YAML block format
- PR #24: Migrated software requirements to YAML block format
- This PR: Removes redundant parent fields from software requirements

🤖 Generated with [Claude Code](https://claude.com/claude-code)