### PR TITLE
Phase 1: Add deps parameter and enforce strict dependency checking [BREAKS BUILD]

### DIFF
--- a/fire/starlark/requirements.bzl
+++ b/fire/starlark/requirements.bzl
@@ -10,13 +10,18 @@ def _validate_requirements_impl(ctx):
     # Use "." as workspace root - the sandbox will have the right structure
     workspace_root = "."
 
-    # Build command
-    cmd = "python3 {script} {workspace}".format(
+    # Build command with --allowed-deps flag (always pass it to enable strict checking)
+    cmd = "python3 {script} {workspace} --allowed-deps".format(
         script = script.path,
         workspace = workspace_root,
     )
 
+    # Add allowed dependency paths (short_path format)
+    for dep in ctx.files.deps:
+        cmd += " " + dep.short_path
+
     # Add requirement files (using short_path which is relative to workspace)
+    cmd += " --"
     for src in ctx.files.srcs:
         cmd += " " + src.short_path
     cmd += " && touch " + output.path
@@ -24,7 +29,7 @@ def _validate_requirements_impl(ctx):
     # Run validation script
     # Note: We need to disable sandbox or make all potential reference targets available
     ctx.actions.run_shell(
-        inputs = ctx.files.srcs + [script],
+        inputs = ctx.files.srcs + ctx.files.deps + [script],
         outputs = [output],
         command = cmd,
         mnemonic = "ValidateRequirements",
@@ -40,6 +45,11 @@ def _validate_requirements_impl(ctx):
 _validate_requirements = rule(
     implementation = _validate_requirements_impl,
     attrs = {
+        "deps": attr.label_list(
+            allow_files = [".md"],
+            default = [],
+            doc = "Dependencies: other requirement files referenced by srcs",
+        ),
         "out": attr.output(
             mandatory = True,
         ),
@@ -56,7 +66,7 @@ _validate_requirements = rule(
     doc = "Validates cross-references in requirement documents",
 )
 
-def requirement_library(name, srcs, visibility = None):
+def requirement_library(name, srcs, deps = [], visibility = None):
     """Validates requirement documents and creates a filegroup.
 
     This validates that all cross-references (parameters, requirements, tests)
@@ -65,12 +75,19 @@ def requirement_library(name, srcs, visibility = None):
     Args:
         name: Name of the target
         srcs: List of requirement markdown files
+        deps: List of other requirement_library targets that srcs references
         visibility: Visibility of the target
 
     Example:
         requirement_library(
             name = "safety_requirements",
             srcs = glob(["requirements/safety/*.md"]),
+        )
+
+        requirement_library(
+            name = "component_requirements",
+            srcs = glob(["components/**/*.swreq.md"]),
+            deps = [":safety_requirements"],  # References system requirements
         )
     """
 
@@ -79,6 +96,7 @@ def requirement_library(name, srcs, visibility = None):
     _validate_requirements(
         name = validation_name,
         srcs = srcs,
+        deps = deps,
         out = validation_name + ".marker",
     )
 

--- a/fire/starlark/validate_cross_references.py
+++ b/fire/starlark/validate_cross_references.py
@@ -392,9 +392,17 @@ def validate_test_reference(test_name, test_label, workspace_root):
         return False, f"Error validating test target {test_label}: {e}"
 
 
-def validate_requirement_file(file_path, workspace_root):
-    """Validate all cross-references in a single requirement file."""
+def validate_requirement_file(file_path, workspace_root, allowed_deps=None):
+    """Validate all cross-references in a single requirement file.
+
+    Args:
+        file_path: Path to the requirement file to validate
+        workspace_root: Workspace root directory
+        allowed_deps: Set of allowed dependency file paths (for strict validation)
+    """
     errors = []
+    if allowed_deps is None:
+        allowed_deps = set()
 
     try:
         with open(file_path, 'r') as f:
@@ -540,6 +548,21 @@ def validate_requirement_file(file_path, workspace_root):
 
     # Validate requirement references exist and check versions
     for req_id, req_path, ref_version in req_refs:
+        # Check if this requirement is in allowed_deps (strict dependency checking)
+        # Only enforce if allowed_deps is not None (i.e., was explicitly passed)
+        if allowed_deps is not None:
+            # Strip leading slash and fragment for comparison
+            normalized_path = req_path[1:] if req_path.startswith('/') else req_path
+            normalized_path = normalized_path.split('#')[0] if '#' in normalized_path else normalized_path
+
+            if normalized_path not in allowed_deps:
+                errors.append(
+                    f"{file_path}: References requirement '{req_path}' which is not in declared dependencies.\n"
+                    f"       Add the target containing '{normalized_path}' to 'deps' in your requirement_library().\n"
+                    f"       Example: deps = [\":vehicle_requirements\"]"
+                )
+                continue  # Skip further validation for this requirement
+
         valid, error = validate_requirement_reference(req_id, req_path, workspace_root, ref_version, file_path)
         if not valid:
             errors.append(f"{file_path}: {error}")
@@ -554,17 +577,24 @@ def validate_requirement_file(file_path, workspace_root):
 
 
 def main():
-    if len(sys.argv) < 3:
-        print("Usage: validate_cross_references.py <workspace_root> <requirement_files...>")
-        sys.exit(1)
+    import argparse
 
-    workspace_root = sys.argv[1]
-    requirement_files = sys.argv[2:]
+    parser = argparse.ArgumentParser(description='Validate cross-references in requirement documents')
+    parser.add_argument('workspace_root', help='Workspace root directory')
+    parser.add_argument('--allowed-deps', nargs='*', default=None, help='Allowed dependency file paths')
+    parser.add_argument('requirement_files', nargs='+', help='Requirement files to validate')
+
+    args = parser.parse_args()
+
+    workspace_root = args.workspace_root
+    # Convert to set for faster lookup, or keep as None if not provided
+    allowed_deps = set(args.allowed_deps) if args.allowed_deps is not None else None
+    requirement_files = args.requirement_files
 
     all_errors = []
 
     for req_file in requirement_files:
-        errors = validate_requirement_file(req_file, workspace_root)
+        errors = validate_requirement_file(req_file, workspace_root, allowed_deps)
         all_errors.extend(errors)
 
     if all_errors:


### PR DESCRIPTION
## ⚠️ WARNING: THIS PR BREAKS THE BUILD INTENTIONALLY

This is Phase 1 of a 3-phase migration to proper Bazel dependency handling.
**Do not merge until Phase 2 is ready.**

## Problem

Currently, requirement validation uses `no-sandbox` execution and accesses
ALL files in the workspace, hiding true dependencies from Bazel. This breaks:
- Hermetic builds
- Build caching
- Reproducibility
- Correct dependency tracking

## This PR (Phase 1): Make It Fail

Add explicit `deps` parameter to `requirement_library()` and enforce strict
dependency checking. **All builds now fail** to expose hidden dependencies.

### Changes

#### fire/starlark/requirements.bzl
- Added `deps` parameter to `_validate_requirements` rule and `requirement_library()` macro
- Always pass `--allowed-deps` flag to validation script
- Include deps files in action inputs

#### fire/starlark/validate_cross_references.py  
- Added `--allowed-deps` command-line argument
- Check if referenced requirements are in `allowed_deps`
- Fail with actionable error when dependency not declared

### Example Failure (Expected!)

```
ERROR: examples/brake_actuator/doc/brake_actuator.swreq.md: References requirement '/examples/requirements/braking_requirements.sysreq.md#REQ-BRK-001' which is not in declared dependencies.
       Add the target containing 'examples/requirements/braking_requirements.sysreq.md' to 'deps' in your requirement_library().
       Example: deps = [":vehicle_requirements"]
```

### Test Plan
- [x] `//examples:component_requirements` - ❌ FAILS (expected)
- [x] `//examples:vehicle_requirements` - ❌ FAILS (expected)  
- [x] Error messages are clear and actionable

## Migration Plan

1. **Phase 1** (this PR): Add deps parameter, make builds fail ← WE ARE HERE
2. **Phase 2**: Add deps declarations to BUILD files, builds pass again
3. **Phase 3**: Remove `no-sandbox`, use execroot with file mapping

## Do Not Merge

Wait for Phase 2 PR which adds the deps declarations and makes builds pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)