### PR TITLE
Update MODULE.bazel dependencies to resolved versions

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -9,13 +9,13 @@ module(
 )
 
 # C++ rules for generated code
-bazel_dep(name = "rules_cc", version = "0.0.9")
+bazel_dep(name = "rules_cc", version = "0.1.1")
 
 # Rust rules for generated code
 bazel_dep(name = "rules_rust", version = "0.54.1")
 
 # Skylib for unittest framework
-bazel_dep(name = "bazel_skylib", version = "1.5.0")
+bazel_dep(name = "bazel_skylib", version = "1.7.1")
 
 # Rust toolchain setup
 rust = use_extension("@rules_rust//rust:extensions.bzl", "rust")


### PR DESCRIPTION
## Summary
Fixes Bazel warnings about version mismatches by updating MODULE.bazel dependencies to match the resolved dependency graph.

## Changes

### MODULE.bazel
Updated dependency versions:
- `rules_cc`: 0.0.9 → 0.1.1
- `bazel_skylib`: 1.5.0 → 1.7.1

## Problem

On every fresh build, Bazel was showing warnings:
```
WARNING: For repository 'rules_cc', the root module requires module version rules_cc@0.0.9, but got rules_cc@0.1.1 in the resolved dependency graph. Please update the version in your MODULE.bazel or set --check_direct_dependencies=off
WARNING: For repository 'bazel_skylib', the root module requires module version bazel_skylib@1.5.0, but got bazel_skylib@1.7.1 in the resolved dependency graph. Please update the version in your MODULE.bazel or set --check_direct_dependencies=off
```

## Solution

Updated the versions in MODULE.bazel to match what Bazel's dependency resolution actually uses. This eliminates the warnings and ensures we're explicitly using the versions that other dependencies require.

## Test Results
✅ No warnings on fresh build
✅ All tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)