### PR TITLE
Simplify CI workflow by removing redundant integration tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -57,53 +57,14 @@ jobs:
       - name: Build all targets
         run: bazel build //...
 
-  integration:
-    name: Integration Tests
+  failure-tests:
+    name: Run Failure Tests
     runs-on: ubuntu-latest
     needs: [pre-commit, test]
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Mount bazel cache
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cache/bazel
-          key: bazel-integration-${{ hashFiles('MODULE.bazel', 'WORKSPACE', '**/*.bzl') }}
-          restore-keys: |
-            bazel-integration-
-
-      - name: Run all tests
-        run: bazel test //... --test_output=errors
-
-      - name: Verify generated header
-        run: |
-          bazel build //examples:vehicle_params_header
-          if [ ! -f bazel-bin/examples/vehicle_params_header.h ]; then
-            echo "Generated header not found!"
-            exit 1
-          fi
-          echo "Generated header:"
-          cat bazel-bin/examples/vehicle_params_header.h
-
-      - name: Verify generated Rust module
-        run: |
-          bazel build //examples:vehicle_params_rust
-          if [ ! -f bazel-bin/examples/vehicle_params_rust.rs ]; then
-            echo "Generated Rust module not found!"
-            exit 1
-          fi
-          echo "Generated Rust module:"
-          cat bazel-bin/examples/vehicle_params_rust.rs
-
       - name: Run failure tests
         run: |
           ./fire/starlark/failure_test/run_failure_tests.sh
-
-      - name: Upload test results
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: test-results
-          path: bazel-testlogs/


### PR DESCRIPTION
## Summary
Replaced the "Integration Tests" job with a focused "Run Failure Tests" job, removing redundant test steps.

## Changes

### Before (Integration Tests job):
- ❌ Re-run all tests (`bazel test //...`) - redundant with test job
- ❌ Verify generated C++ header - redundant (consumption tests would fail)
- ❌ Verify generated Rust module - redundant (consumption tests would fail)
- ✅ Run failure tests
- ❌ Upload test results artifacts

### After (Run Failure Tests job):
- ✅ Run failure tests

## Rationale

The integration tests were mostly redundant:

1. **Code generation verification is unnecessary**: If code generation fails, the consumption tests (`vehicle_params_test`, `vehicle_params_rust_test`) would fail anyway.

2. **Running `bazel test //...` twice adds no value**: The `test` job already runs all tests on both Ubuntu and macOS.

3. **Failure tests aren't integration tests**: They're negative tests that verify dependency errors and version warnings are detected correctly.

## Benefits
- ✅ Faster CI runs (removed ~3 unnecessary steps)
- ✅ Clearer job names and purposes
- ✅ Less maintenance burden
- ✅ Same test coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)