### PR TITLE
Add comprehensive integration test for fire as a Bazel dependency

### DIFF
--- a/.bazelignore
+++ b/.bazelignore
@@ -1,0 +1,1 @@
+integration_test

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -68,3 +68,25 @@ jobs:
       - name: Run failure tests
         run: |
           ./fire/starlark/failure_test/run_failure_tests.sh
+
+  integration-test:
+    name: Integration Test
+    runs-on: ubuntu-latest
+    needs: [pre-commit, test]
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Mount bazel cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/bazel
+          key: bazel-integration-${{ hashFiles('MODULE.bazel', 'WORKSPACE', '**/*.bzl') }}
+          restore-keys: |
+            bazel-integration-
+
+      - name: Run integration test
+        run: |
+          cd integration_test
+          ./run.sh

--- a/examples/vehicle_params_test.cc
+++ b/examples/vehicle_params_test.cc
@@ -1,6 +1,6 @@
 // Integration test for parameter code generation
 
-#include "vehicle_params_header.h"
+#include "examples/vehicle_params_header.h"
 #include <cassert>
 #include <cstring>
 #include <iostream>

--- a/fire/starlark/parameters.bzl
+++ b/fire/starlark/parameters.bzl
@@ -154,11 +154,15 @@ def cc_parameter_library(name, parameter_library, **kwargs):
         name: Name of the cc_library
         parameter_library: Label of the parameter_library (the generated .h file)
         **kwargs: Additional arguments for cc_library
+
+    Note:
+        Headers should be included using repository-relative paths.
+        For example, if the header is in package "examples", use:
+            #include "examples/header_name.h"
     """
     cc_library(
         name = name,
         hdrs = [parameter_library],
-        includes = ["."],
         **kwargs
     )
 

--- a/integration_test/BUILD.bazel
+++ b/integration_test/BUILD.bazel
@@ -1,0 +1,71 @@
+"""Integration test for fire requirements management system."""
+
+load(
+    "@fire//fire/starlark:parameters.bzl",
+    "cc_parameter_library",
+    "parameter_library",
+    "rust_parameter_library",
+)
+load("@fire//fire/starlark:reports.bzl", "generate_report")
+load(":test_params.bzl", "TEST_PARAMS")
+
+exports_files(["test_params.bzl"])
+
+# Define parameters
+parameter_library(
+    name = "test_params_header",
+    parameters = TEST_PARAMS,
+)
+
+# Generate C++ parameters
+cc_parameter_library(
+    name = "test_params_cc",
+    parameter_library = ":test_params_header",
+    visibility = ["//visibility:public"],
+)
+
+# Generate Rust parameters
+rust_parameter_library(
+    name = "test_params_rust",
+    parameters = TEST_PARAMS,
+)
+
+# Generate compliance report
+generate_report(
+    name = "compliance_report",
+    srcs = ["//requirements:integration_requirements"],
+    out = "compliance_report.md",
+    report_type = "compliance",
+)
+
+# Generate coverage report
+generate_report(
+    name = "coverage_report",
+    srcs = ["//requirements:integration_requirements"],
+    out = "coverage_report.md",
+    report_type = "coverage",
+)
+
+# Generate traceability report
+generate_report(
+    name = "traceability_report",
+    srcs = ["//requirements:integration_requirements"],
+    out = "traceability_report.md",
+    report_type = "traceability",
+)
+
+# Dummy test targets referenced in requirements
+sh_test(
+    name = "test_speed_limit",
+    srcs = ["test_dummy.sh"],
+)
+
+sh_test(
+    name = "test_braking",
+    srcs = ["test_dummy.sh"],
+)
+
+sh_test(
+    name = "test_update_rate",
+    srcs = ["test_dummy.sh"],
+)

--- a/integration_test/MODULE.bazel
+++ b/integration_test/MODULE.bazel
@@ -1,0 +1,31 @@
+"""
+Integration Test for Fire Requirements Management System
+
+This workspace consumes fire as an external Bazel module to test
+end-to-end integration as users would experience it.
+"""
+
+module(
+    name = "fire_integration_test",
+    version = "0.0.0",
+)
+
+# Depend on fire project
+bazel_dep(name = "fire", version = "0.1.0")
+
+# Override to use local development version
+local_path_override(
+    module_name = "fire",
+    path = "..",
+)
+
+# C++ rules for consuming generated code
+bazel_dep(name = "rules_cc", version = "0.1.1")
+
+# Rust rules for consuming generated code
+bazel_dep(name = "rules_rust", version = "0.54.1")
+
+# Rust toolchain setup
+rust = use_extension("@rules_rust//rust:extensions.bzl", "rust")
+rust.toolchain(edition = "2021")
+use_repo(rust, "rust_toolchains")

--- a/integration_test/MODULE.bazel.lock
+++ b/integration_test/MODULE.bazel.lock
@@ -1,0 +1,10277 @@
+{
+  "lockFileVersion": 18,
+  "registryFileHashes": {
+    "https://bcr.bazel.build/bazel_registry.json": "8a28e4aff06ee60aed2a8c281907fb8bcbf3b753c91fb5a5c57da3215d5b3497",
+    "https://bcr.bazel.build/modules/abseil-cpp/20210324.2/MODULE.bazel": "7cd0312e064fde87c8d1cd79ba06c876bd23630c83466e9500321be55c96ace2",
+    "https://bcr.bazel.build/modules/abseil-cpp/20211102.0/MODULE.bazel": "70390338f7a5106231d20620712f7cccb659cd0e9d073d1991c038eb9fc57589",
+    "https://bcr.bazel.build/modules/abseil-cpp/20230125.1/MODULE.bazel": "89047429cb0207707b2dface14ba7f8df85273d484c2572755be4bab7ce9c3a0",
+    "https://bcr.bazel.build/modules/abseil-cpp/20230802.0.bcr.1/MODULE.bazel": "1c8cec495288dccd14fdae6e3f95f772c1c91857047a098fad772034264cc8cb",
+    "https://bcr.bazel.build/modules/abseil-cpp/20230802.0/MODULE.bazel": "d253ae36a8bd9ee3c5955384096ccb6baf16a1b1e93e858370da0a3b94f77c16",
+    "https://bcr.bazel.build/modules/abseil-cpp/20230802.1/MODULE.bazel": "fa92e2eb41a04df73cdabeec37107316f7e5272650f81d6cc096418fe647b915",
+    "https://bcr.bazel.build/modules/abseil-cpp/20240116.1/MODULE.bazel": "37bcdb4440fbb61df6a1c296ae01b327f19e9bb521f9b8e26ec854b6f97309ed",
+    "https://bcr.bazel.build/modules/abseil-cpp/20240116.1/source.json": "9be551b8d4e3ef76875c0d744b5d6a504a27e3ae67bc6b28f46415fd2d2957da",
+    "https://bcr.bazel.build/modules/apple_support/1.13.0/MODULE.bazel": "7c8cdea7e031b7f9f67f0b497adf6d2c6a2675e9304ca93a9af6ed84eef5a524",
+    "https://bcr.bazel.build/modules/apple_support/1.23.1/MODULE.bazel": "53763fed456a968cf919b3240427cf3a9d5481ec5466abc9d5dc51bc70087442",
+    "https://bcr.bazel.build/modules/apple_support/1.23.1/source.json": "d888b44312eb0ad2c21a91d026753f330caa48a25c9b2102fae75eb2b0dcfdd2",
+    "https://bcr.bazel.build/modules/aspect_bazel_lib/1.31.2/MODULE.bazel": "7bee702b4862612f29333590f4b658a5832d433d6f8e4395f090e8f4e85d442f",
+    "https://bcr.bazel.build/modules/aspect_bazel_lib/1.38.0/MODULE.bazel": "6307fec451ba9962c1c969eb516ebfe1e46528f7fa92e1c9ac8646bef4cdaa3f",
+    "https://bcr.bazel.build/modules/aspect_bazel_lib/1.40.3/MODULE.bazel": "668e6bcb4d957fc0e284316dba546b705c8d43c857f87119619ee83c4555b859",
+    "https://bcr.bazel.build/modules/aspect_bazel_lib/1.40.3/source.json": "f5a28b1320e5f444e798b4afc1465c8b720bfaec7522cca38a23583dffe85e6d",
+    "https://bcr.bazel.build/modules/aspect_rules_js/1.33.1/MODULE.bazel": "db3e7f16e471cf6827059d03af7c21859e7a0d2bc65429a3a11f005d46fc501b",
+    "https://bcr.bazel.build/modules/aspect_rules_js/1.39.0/MODULE.bazel": "aece421d479e3c31dc3e5f6d49a12acc2700457c03c556650ec7a0ff23fc0d95",
+    "https://bcr.bazel.build/modules/aspect_rules_js/1.39.0/source.json": "a8f93e4ad8843e8aa407fa5fd7c8b63a63846c0ce255371ff23384582813b13d",
+    "https://bcr.bazel.build/modules/aspect_rules_lint/0.12.0/MODULE.bazel": "e767c5dbfeb254ec03275a7701b5cfde2c4d2873676804bc7cb27ddff3728fed",
+    "https://bcr.bazel.build/modules/aspect_rules_lint/0.12.0/source.json": "9a3668e1ee219170e22c0e7f3ab959724c6198fdd12cd503fa10b1c6923a2559",
+    "https://bcr.bazel.build/modules/bazel_features/0.1.0/MODULE.bazel": "47011d645b0f949f42ee67f2e8775188a9cf4a0a1528aa2fa4952f2fd00906fd",
+    "https://bcr.bazel.build/modules/bazel_features/1.1.1/MODULE.bazel": "27b8c79ef57efe08efccbd9dd6ef70d61b4798320b8d3c134fd571f78963dbcd",
+    "https://bcr.bazel.build/modules/bazel_features/1.11.0/MODULE.bazel": "f9382337dd5a474c3b7d334c2f83e50b6eaedc284253334cf823044a26de03e8",
+    "https://bcr.bazel.build/modules/bazel_features/1.15.0/MODULE.bazel": "d38ff6e517149dc509406aca0db3ad1efdd890a85e049585b7234d04238e2a4d",
+    "https://bcr.bazel.build/modules/bazel_features/1.17.0/MODULE.bazel": "039de32d21b816b47bd42c778e0454217e9c9caac4a3cf8e15c7231ee3ddee4d",
+    "https://bcr.bazel.build/modules/bazel_features/1.18.0/MODULE.bazel": "1be0ae2557ab3a72a57aeb31b29be347bcdc5d2b1eb1e70f39e3851a7e97041a",
+    "https://bcr.bazel.build/modules/bazel_features/1.19.0/MODULE.bazel": "59adcdf28230d220f0067b1f435b8537dd033bfff8db21335ef9217919c7fb58",
+    "https://bcr.bazel.build/modules/bazel_features/1.27.0/MODULE.bazel": "621eeee06c4458a9121d1f104efb80f39d34deff4984e778359c60eaf1a8cb65",
+    "https://bcr.bazel.build/modules/bazel_features/1.30.0/MODULE.bazel": "a14b62d05969a293b80257e72e597c2da7f717e1e69fa8b339703ed6731bec87",
+    "https://bcr.bazel.build/modules/bazel_features/1.30.0/source.json": "b07e17f067fe4f69f90b03b36ef1e08fe0d1f3cac254c1241a1818773e3423bc",
+    "https://bcr.bazel.build/modules/bazel_features/1.4.1/MODULE.bazel": "e45b6bb2350aff3e442ae1111c555e27eac1d915e77775f6fdc4b351b758b5d7",
+    "https://bcr.bazel.build/modules/bazel_features/1.9.1/MODULE.bazel": "8f679097876a9b609ad1f60249c49d68bfab783dd9be012faf9d82547b14815a",
+    "https://bcr.bazel.build/modules/bazel_skylib/1.0.3/MODULE.bazel": "bcb0fd896384802d1ad283b4e4eb4d718eebd8cb820b0a2c3a347fb971afd9d8",
+    "https://bcr.bazel.build/modules/bazel_skylib/1.1.1/MODULE.bazel": "1add3e7d93ff2e6998f9e118022c84d163917d912f5afafb3058e3d2f1545b5e",
+    "https://bcr.bazel.build/modules/bazel_skylib/1.2.0/MODULE.bazel": "44fe84260e454ed94ad326352a698422dbe372b21a1ac9f3eab76eb531223686",
+    "https://bcr.bazel.build/modules/bazel_skylib/1.2.1/MODULE.bazel": "f35baf9da0efe45fa3da1696ae906eea3d615ad41e2e3def4aeb4e8bc0ef9a7a",
+    "https://bcr.bazel.build/modules/bazel_skylib/1.3.0/MODULE.bazel": "20228b92868bf5cfc41bda7afc8a8ba2a543201851de39d990ec957b513579c5",
+    "https://bcr.bazel.build/modules/bazel_skylib/1.4.1/MODULE.bazel": "a0dcb779424be33100dcae821e9e27e4f2901d9dfd5333efe5ac6a8d7ab75e1d",
+    "https://bcr.bazel.build/modules/bazel_skylib/1.4.2/MODULE.bazel": "3bd40978e7a1fac911d5989e6b09d8f64921865a45822d8b09e815eaa726a651",
+    "https://bcr.bazel.build/modules/bazel_skylib/1.5.0/MODULE.bazel": "32880f5e2945ce6a03d1fbd588e9198c0a959bb42297b2cfaf1685b7bc32e138",
+    "https://bcr.bazel.build/modules/bazel_skylib/1.6.1/MODULE.bazel": "8fdee2dbaace6c252131c00e1de4b165dc65af02ea278476187765e1a617b917",
+    "https://bcr.bazel.build/modules/bazel_skylib/1.7.0/MODULE.bazel": "0db596f4563de7938de764cc8deeabec291f55e8ec15299718b93c4423e9796d",
+    "https://bcr.bazel.build/modules/bazel_skylib/1.7.1/MODULE.bazel": "3120d80c5861aa616222ec015332e5f8d3171e062e3e804a2a0253e1be26e59b",
+    "https://bcr.bazel.build/modules/bazel_skylib/1.7.1/source.json": "f121b43eeefc7c29efbd51b83d08631e2347297c95aac9764a701f2a6a2bb953",
+    "https://bcr.bazel.build/modules/buildozer/7.1.2/MODULE.bazel": "2e8dd40ede9c454042645fd8d8d0cd1527966aa5c919de86661e62953cd73d84",
+    "https://bcr.bazel.build/modules/buildozer/7.1.2/source.json": "c9028a501d2db85793a6996205c8de120944f50a0d570438fcae0457a5f9d1f8",
+    "https://bcr.bazel.build/modules/gazelle/0.27.0/MODULE.bazel": "3446abd608295de6d90b4a8a118ed64a9ce11dcb3dda2dc3290a22056bd20996",
+    "https://bcr.bazel.build/modules/gazelle/0.30.0/MODULE.bazel": "f888a1effe338491f35f0e0e85003b47bb9d8295ccba73c37e07702d8d31c65b",
+    "https://bcr.bazel.build/modules/gazelle/0.30.0/source.json": "7af0779f99120aafc73be127615d224f26da2fc5a606b52bdffb221fd9efb737",
+    "https://bcr.bazel.build/modules/google_benchmark/1.8.2/MODULE.bazel": "a70cf1bba851000ba93b58ae2f6d76490a9feb74192e57ab8e8ff13c34ec50cb",
+    "https://bcr.bazel.build/modules/googletest/1.11.0/MODULE.bazel": "3a83f095183f66345ca86aa13c58b59f9f94a2f81999c093d4eeaa2d262d12f4",
+    "https://bcr.bazel.build/modules/googletest/1.14.0.bcr.1/MODULE.bazel": "22c31a561553727960057361aa33bf20fb2e98584bc4fec007906e27053f80c6",
+    "https://bcr.bazel.build/modules/googletest/1.14.0.bcr.1/source.json": "41e9e129f80d8c8bf103a7acc337b76e54fad1214ac0a7084bf24f4cd924b8b4",
+    "https://bcr.bazel.build/modules/googletest/1.14.0/MODULE.bazel": "cfbcbf3e6eac06ef9d85900f64424708cc08687d1b527f0ef65aa7517af8118f",
+    "https://bcr.bazel.build/modules/jsoncpp/1.9.5/MODULE.bazel": "31271aedc59e815656f5736f282bb7509a97c7ecb43e927ac1a37966e0578075",
+    "https://bcr.bazel.build/modules/jsoncpp/1.9.5/source.json": "4108ee5085dd2885a341c7fab149429db457b3169b86eb081fa245eadf69169d",
+    "https://bcr.bazel.build/modules/libpfm/4.11.0/MODULE.bazel": "45061ff025b301940f1e30d2c16bea596c25b176c8b6b3087e92615adbd52902",
+    "https://bcr.bazel.build/modules/platforms/0.0.10/MODULE.bazel": "8cb8efaf200bdeb2150d93e162c40f388529a25852b332cec879373771e48ed5",
+    "https://bcr.bazel.build/modules/platforms/0.0.11/MODULE.bazel": "0daefc49732e227caa8bfa834d65dc52e8cc18a2faf80df25e8caea151a9413f",
+    "https://bcr.bazel.build/modules/platforms/0.0.11/source.json": "f7e188b79ebedebfe75e9e1d098b8845226c7992b307e28e1496f23112e8fc29",
+    "https://bcr.bazel.build/modules/platforms/0.0.4/MODULE.bazel": "9b328e31ee156f53f3c416a64f8491f7eb731742655a47c9eec4703a71644aee",
+    "https://bcr.bazel.build/modules/platforms/0.0.5/MODULE.bazel": "5733b54ea419d5eaf7997054bb55f6a1d0b5ff8aedf0176fef9eea44f3acda37",
+    "https://bcr.bazel.build/modules/platforms/0.0.6/MODULE.bazel": "ad6eeef431dc52aefd2d77ed20a4b353f8ebf0f4ecdd26a807d2da5aa8cd0615",
+    "https://bcr.bazel.build/modules/platforms/0.0.7/MODULE.bazel": "72fd4a0ede9ee5c021f6a8dd92b503e089f46c227ba2813ff183b71616034814",
+    "https://bcr.bazel.build/modules/platforms/0.0.8/MODULE.bazel": "9f142c03e348f6d263719f5074b21ef3adf0b139ee4c5133e2aa35664da9eb2d",
+    "https://bcr.bazel.build/modules/platforms/0.0.9/MODULE.bazel": "4a87a60c927b56ddd67db50c89acaa62f4ce2a1d2149ccb63ffd871d5ce29ebc",
+    "https://bcr.bazel.build/modules/protobuf/21.7/MODULE.bazel": "a5a29bb89544f9b97edce05642fac225a808b5b7be74038ea3640fae2f8e66a7",
+    "https://bcr.bazel.build/modules/protobuf/27.0/MODULE.bazel": "7873b60be88844a0a1d8f80b9d5d20cfbd8495a689b8763e76c6372998d3f64c",
+    "https://bcr.bazel.build/modules/protobuf/27.1/MODULE.bazel": "703a7b614728bb06647f965264967a8ef1c39e09e8f167b3ca0bb1fd80449c0d",
+    "https://bcr.bazel.build/modules/protobuf/29.0-rc2/MODULE.bazel": "6241d35983510143049943fc0d57937937122baf1b287862f9dc8590fc4c37df",
+    "https://bcr.bazel.build/modules/protobuf/29.0/MODULE.bazel": "319dc8bf4c679ff87e71b1ccfb5a6e90a6dbc4693501d471f48662ac46d04e4e",
+    "https://bcr.bazel.build/modules/protobuf/29.0/source.json": "b857f93c796750eef95f0d61ee378f3420d00ee1dd38627b27193aa482f4f981",
+    "https://bcr.bazel.build/modules/protobuf/3.19.0/MODULE.bazel": "6b5fbb433f760a99a22b18b6850ed5784ef0e9928a72668b66e4d7ccd47db9b0",
+    "https://bcr.bazel.build/modules/protobuf/3.19.2/MODULE.bazel": "532ffe5f2186b69fdde039efe6df13ba726ff338c6bc82275ad433013fa10573",
+    "https://bcr.bazel.build/modules/protobuf/3.19.6/MODULE.bazel": "9233edc5e1f2ee276a60de3eaa47ac4132302ef9643238f23128fea53ea12858",
+    "https://bcr.bazel.build/modules/pybind11_bazel/2.11.1/MODULE.bazel": "88af1c246226d87e65be78ed49ecd1e6f5e98648558c14ce99176da041dc378e",
+    "https://bcr.bazel.build/modules/pybind11_bazel/2.11.1/source.json": "be4789e951dd5301282729fe3d4938995dc4c1a81c2ff150afc9f1b0504c6022",
+    "https://bcr.bazel.build/modules/re2/2023-09-01/MODULE.bazel": "cb3d511531b16cfc78a225a9e2136007a48cf8a677e4264baeab57fe78a80206",
+    "https://bcr.bazel.build/modules/re2/2023-09-01/source.json": "e044ce89c2883cd957a2969a43e79f7752f9656f6b20050b62f90ede21ec6eb4",
+    "https://bcr.bazel.build/modules/rules_android/0.1.1/MODULE.bazel": "48809ab0091b07ad0182defb787c4c5328bd3a278938415c00a7b69b50c4d3a8",
+    "https://bcr.bazel.build/modules/rules_android/0.1.1/source.json": "e6986b41626ee10bdc864937ffb6d6bf275bb5b9c65120e6137d56e6331f089e",
+    "https://bcr.bazel.build/modules/rules_buf/0.1.1/MODULE.bazel": "6189aec18a4f7caff599ad41b851ab7645d4f1e114aa6431acf9b0666eb92162",
+    "https://bcr.bazel.build/modules/rules_buf/0.1.1/source.json": "021363d254f7438f3f10725355969c974bb2c67e0c28667782ade31a9cdb747f",
+    "https://bcr.bazel.build/modules/rules_cc/0.0.1/MODULE.bazel": "cb2aa0747f84c6c3a78dad4e2049c154f08ab9d166b1273835a8174940365647",
+    "https://bcr.bazel.build/modules/rules_cc/0.0.10/MODULE.bazel": "ec1705118f7eaedd6e118508d3d26deba2a4e76476ada7e0e3965211be012002",
+    "https://bcr.bazel.build/modules/rules_cc/0.0.13/MODULE.bazel": "0e8529ed7b323dad0775ff924d2ae5af7640b23553dfcd4d34344c7e7a867191",
+    "https://bcr.bazel.build/modules/rules_cc/0.0.14/MODULE.bazel": "5e343a3aac88b8d7af3b1b6d2093b55c347b8eefc2e7d1442f7a02dc8fea48ac",
+    "https://bcr.bazel.build/modules/rules_cc/0.0.15/MODULE.bazel": "6704c35f7b4a72502ee81f61bf88706b54f06b3cbe5558ac17e2e14666cd5dcc",
+    "https://bcr.bazel.build/modules/rules_cc/0.0.16/MODULE.bazel": "7661303b8fc1b4d7f532e54e9d6565771fea666fbdf839e0a86affcd02defe87",
+    "https://bcr.bazel.build/modules/rules_cc/0.0.2/MODULE.bazel": "6915987c90970493ab97393024c156ea8fb9f3bea953b2f3ec05c34f19b5695c",
+    "https://bcr.bazel.build/modules/rules_cc/0.0.6/MODULE.bazel": "abf360251023dfe3efcef65ab9d56beefa8394d4176dd29529750e1c57eaa33f",
+    "https://bcr.bazel.build/modules/rules_cc/0.0.8/MODULE.bazel": "964c85c82cfeb6f3855e6a07054fdb159aced38e99a5eecf7bce9d53990afa3e",
+    "https://bcr.bazel.build/modules/rules_cc/0.0.9/MODULE.bazel": "836e76439f354b89afe6a911a7adf59a6b2518fafb174483ad78a2a2fde7b1c5",
+    "https://bcr.bazel.build/modules/rules_cc/0.1.1/MODULE.bazel": "2f0222a6f229f0bf44cd711dc13c858dad98c62d52bd51d8fc3a764a83125513",
+    "https://bcr.bazel.build/modules/rules_cc/0.1.1/source.json": "d61627377bd7dd1da4652063e368d9366fc9a73920bfa396798ad92172cf645c",
+    "https://bcr.bazel.build/modules/rules_foreign_cc/0.9.0/MODULE.bazel": "c9e8c682bf75b0e7c704166d79b599f93b72cfca5ad7477df596947891feeef6",
+    "https://bcr.bazel.build/modules/rules_fuzzing/0.5.2/MODULE.bazel": "40c97d1144356f52905566c55811f13b299453a14ac7769dfba2ac38192337a8",
+    "https://bcr.bazel.build/modules/rules_fuzzing/0.5.2/source.json": "c8b1e2c717646f1702290959a3302a178fb639d987ab61d548105019f11e527e",
+    "https://bcr.bazel.build/modules/rules_go/0.33.0/MODULE.bazel": "a2b11b64cd24bf94f57454f53288a5dacfe6cb86453eee7761b7637728c1910c",
+    "https://bcr.bazel.build/modules/rules_go/0.38.1/MODULE.bazel": "fb8e73dd3b6fc4ff9d260ceacd830114891d49904f5bda1c16bc147bcc254f71",
+    "https://bcr.bazel.build/modules/rules_go/0.39.1/MODULE.bazel": "d34fb2a249403a5f4339c754f1e63dc9e5ad70b47c5e97faee1441fc6636cd61",
+    "https://bcr.bazel.build/modules/rules_go/0.39.1/source.json": "f21e042154010ae2c944ab230d572b17d71cdb27c5255806d61df6ccaed4354c",
+    "https://bcr.bazel.build/modules/rules_java/4.0.0/MODULE.bazel": "5a78a7ae82cd1a33cef56dc578c7d2a46ed0dca12643ee45edbb8417899e6f74",
+    "https://bcr.bazel.build/modules/rules_java/5.3.5/MODULE.bazel": "a4ec4f2db570171e3e5eb753276ee4b389bae16b96207e9d3230895c99644b86",
+    "https://bcr.bazel.build/modules/rules_java/6.0.0/MODULE.bazel": "8a43b7df601a7ec1af61d79345c17b31ea1fedc6711fd4abfd013ea612978e39",
+    "https://bcr.bazel.build/modules/rules_java/6.4.0/MODULE.bazel": "e986a9fe25aeaa84ac17ca093ef13a4637f6107375f64667a15999f77db6c8f6",
+    "https://bcr.bazel.build/modules/rules_java/6.5.2/MODULE.bazel": "1d440d262d0e08453fa0c4d8f699ba81609ed0e9a9a0f02cd10b3e7942e61e31",
+    "https://bcr.bazel.build/modules/rules_java/7.10.0/MODULE.bazel": "530c3beb3067e870561739f1144329a21c851ff771cd752a49e06e3dc9c2e71a",
+    "https://bcr.bazel.build/modules/rules_java/7.12.2/MODULE.bazel": "579c505165ee757a4280ef83cda0150eea193eed3bef50b1004ba88b99da6de6",
+    "https://bcr.bazel.build/modules/rules_java/7.2.0/MODULE.bazel": "06c0334c9be61e6cef2c8c84a7800cef502063269a5af25ceb100b192453d4ab",
+    "https://bcr.bazel.build/modules/rules_java/7.3.2/MODULE.bazel": "50dece891cfdf1741ea230d001aa9c14398062f2b7c066470accace78e412bc2",
+    "https://bcr.bazel.build/modules/rules_java/7.6.1/MODULE.bazel": "2f14b7e8a1aa2f67ae92bc69d1ec0fa8d9f827c4e17ff5e5f02e91caa3b2d0fe",
+    "https://bcr.bazel.build/modules/rules_java/8.14.0/MODULE.bazel": "717717ed40cc69994596a45aec6ea78135ea434b8402fb91b009b9151dd65615",
+    "https://bcr.bazel.build/modules/rules_java/8.14.0/source.json": "8a88c4ca9e8759da53cddc88123880565c520503321e2566b4e33d0287a3d4bc",
+    "https://bcr.bazel.build/modules/rules_jvm_external/4.4.2/MODULE.bazel": "a56b85e418c83eb1839819f0b515c431010160383306d13ec21959ac412d2fe7",
+    "https://bcr.bazel.build/modules/rules_jvm_external/5.1/MODULE.bazel": "33f6f999e03183f7d088c9be518a63467dfd0be94a11d0055fe2d210f89aa909",
+    "https://bcr.bazel.build/modules/rules_jvm_external/5.2/MODULE.bazel": "d9351ba35217ad0de03816ef3ed63f89d411349353077348a45348b096615036",
+    "https://bcr.bazel.build/modules/rules_jvm_external/5.3/MODULE.bazel": "bf93870767689637164657731849fb887ad086739bd5d360d90007a581d5527d",
+    "https://bcr.bazel.build/modules/rules_jvm_external/6.1/MODULE.bazel": "75b5fec090dbd46cf9b7d8ea08cf84a0472d92ba3585b476f44c326eda8059c4",
+    "https://bcr.bazel.build/modules/rules_jvm_external/6.3/MODULE.bazel": "c998e060b85f71e00de5ec552019347c8bca255062c990ac02d051bb80a38df0",
+    "https://bcr.bazel.build/modules/rules_jvm_external/6.3/source.json": "6f5f5a5a4419ae4e37c35a5bb0a6ae657ed40b7abc5a5189111b47fcebe43197",
+    "https://bcr.bazel.build/modules/rules_kotlin/1.9.0/MODULE.bazel": "ef85697305025e5a61f395d4eaede272a5393cee479ace6686dba707de804d59",
+    "https://bcr.bazel.build/modules/rules_kotlin/1.9.6/MODULE.bazel": "d269a01a18ee74d0335450b10f62c9ed81f2321d7958a2934e44272fe82dcef3",
+    "https://bcr.bazel.build/modules/rules_kotlin/1.9.6/source.json": "2faa4794364282db7c06600b7e5e34867a564ae91bda7cae7c29c64e9466b7d5",
+    "https://bcr.bazel.build/modules/rules_license/0.0.3/MODULE.bazel": "627e9ab0247f7d1e05736b59dbb1b6871373de5ad31c3011880b4133cafd4bd0",
+    "https://bcr.bazel.build/modules/rules_license/0.0.7/MODULE.bazel": "088fbeb0b6a419005b89cf93fe62d9517c0a2b8bb56af3244af65ecfe37e7d5d",
+    "https://bcr.bazel.build/modules/rules_license/0.0.8/MODULE.bazel": "5669c6fe49b5134dbf534db681ad3d67a2d49cfc197e4a95f1ca2fd7f3aebe96",
+    "https://bcr.bazel.build/modules/rules_license/1.0.0/MODULE.bazel": "a7fda60eefdf3d8c827262ba499957e4df06f659330bbe6cdbdb975b768bb65c",
+    "https://bcr.bazel.build/modules/rules_license/1.0.0/source.json": "a52c89e54cc311196e478f8382df91c15f7a2bfdf4c6cd0e2675cc2ff0b56efb",
+    "https://bcr.bazel.build/modules/rules_nodejs/5.8.2/MODULE.bazel": "6bc03c8f37f69401b888023bf511cb6ee4781433b0cb56236b2e55a21e3a026a",
+    "https://bcr.bazel.build/modules/rules_nodejs/5.8.2/source.json": "6e82cf5753d835ea18308200bc79b9c2e782efe2e2a4edc004a9162ca93382ca",
+    "https://bcr.bazel.build/modules/rules_pkg/0.7.0/MODULE.bazel": "df99f03fc7934a4737122518bb87e667e62d780b610910f0447665a7e2be62dc",
+    "https://bcr.bazel.build/modules/rules_pkg/1.0.1/MODULE.bazel": "5b1df97dbc29623bccdf2b0dcd0f5cb08e2f2c9050aab1092fd39a41e82686ff",
+    "https://bcr.bazel.build/modules/rules_pkg/1.0.1/source.json": "bd82e5d7b9ce2d31e380dd9f50c111d678c3bdaca190cb76b0e1c71b05e1ba8a",
+    "https://bcr.bazel.build/modules/rules_proto/4.0.0/MODULE.bazel": "a7a7b6ce9bee418c1a760b3d84f83a299ad6952f9903c67f19e4edd964894e06",
+    "https://bcr.bazel.build/modules/rules_proto/5.3.0-21.7/MODULE.bazel": "e8dff86b0971688790ae75528fe1813f71809b5afd57facb44dad9e8eca631b7",
+    "https://bcr.bazel.build/modules/rules_proto/6.0.2/MODULE.bazel": "ce916b775a62b90b61888052a416ccdda405212b6aaeb39522f7dc53431a5e73",
+    "https://bcr.bazel.build/modules/rules_proto/7.0.2/MODULE.bazel": "bf81793bd6d2ad89a37a40693e56c61b0ee30f7a7fdbaf3eabbf5f39de47dea2",
+    "https://bcr.bazel.build/modules/rules_proto/7.0.2/source.json": "1e5e7260ae32ef4f2b52fd1d0de8d03b606a44c91b694d2f1afb1d3b28a48ce1",
+    "https://bcr.bazel.build/modules/rules_python/0.10.2/MODULE.bazel": "cc82bc96f2997baa545ab3ce73f196d040ffb8756fd2d66125a530031cd90e5f",
+    "https://bcr.bazel.build/modules/rules_python/0.23.1/MODULE.bazel": "49ffccf0511cb8414de28321f5fcf2a31312b47c40cc21577144b7447f2bf300",
+    "https://bcr.bazel.build/modules/rules_python/0.25.0/MODULE.bazel": "72f1506841c920a1afec76975b35312410eea3aa7b63267436bfb1dd91d2d382",
+    "https://bcr.bazel.build/modules/rules_python/0.28.0/MODULE.bazel": "cba2573d870babc976664a912539b320cbaa7114cd3e8f053c720171cde331ed",
+    "https://bcr.bazel.build/modules/rules_python/0.31.0/MODULE.bazel": "93a43dc47ee570e6ec9f5779b2e64c1476a6ce921c48cc9a1678a91dd5f8fd58",
+    "https://bcr.bazel.build/modules/rules_python/0.4.0/MODULE.bazel": "9208ee05fd48bf09ac60ed269791cf17fb343db56c8226a720fbb1cdf467166c",
+    "https://bcr.bazel.build/modules/rules_python/0.40.0/MODULE.bazel": "9d1a3cd88ed7d8e39583d9ffe56ae8a244f67783ae89b60caafc9f5cf318ada7",
+    "https://bcr.bazel.build/modules/rules_python/0.40.0/source.json": "939d4bd2e3110f27bfb360292986bb79fd8dcefb874358ccd6cdaa7bda029320",
+    "https://bcr.bazel.build/modules/rules_rust/0.54.1/MODULE.bazel": "388547bb0cd6a751437bb15c94c6725226f50100eec576e4354c3a8b48c754fb",
+    "https://bcr.bazel.build/modules/rules_rust/0.54.1/source.json": "9c5481b1abe4943457e6b2a475592d2e504b6b4355df603f24f64cde0a7f0f2d",
+    "https://bcr.bazel.build/modules/rules_shell/0.2.0/MODULE.bazel": "fda8a652ab3c7d8fee214de05e7a9916d8b28082234e8d2c0094505c5268ed3c",
+    "https://bcr.bazel.build/modules/rules_shell/0.2.0/source.json": "7f27af3c28037d9701487c4744b5448d26537cc66cdef0d8df7ae85411f8de95",
+    "https://bcr.bazel.build/modules/stardoc/0.5.0/MODULE.bazel": "f9f1f46ba8d9c3362648eea571c6f9100680efc44913618811b58cc9c02cd678",
+    "https://bcr.bazel.build/modules/stardoc/0.5.1/MODULE.bazel": "1a05d92974d0c122f5ccf09291442580317cdd859f07a8655f1db9a60374f9f8",
+    "https://bcr.bazel.build/modules/stardoc/0.5.3/MODULE.bazel": "c7f6948dae6999bf0db32c1858ae345f112cacf98f174c7a8bb707e41b974f1c",
+    "https://bcr.bazel.build/modules/stardoc/0.5.4/MODULE.bazel": "6569966df04610b8520957cb8e97cf2e9faac2c0309657c537ab51c16c18a2a4",
+    "https://bcr.bazel.build/modules/stardoc/0.5.6/MODULE.bazel": "c43dabc564990eeab55e25ed61c07a1aadafe9ece96a4efabb3f8bf9063b71ef",
+    "https://bcr.bazel.build/modules/stardoc/0.7.0/MODULE.bazel": "05e3d6d30c099b6770e97da986c53bd31844d7f13d41412480ea265ac9e8079c",
+    "https://bcr.bazel.build/modules/stardoc/0.7.1/MODULE.bazel": "3548faea4ee5dda5580f9af150e79d0f6aea934fc60c1cc50f4efdd9420759e7",
+    "https://bcr.bazel.build/modules/stardoc/0.7.1/source.json": "b6500ffcd7b48cd72c29bb67bcac781e12701cc0d6d55d266a652583cfcdab01",
+    "https://bcr.bazel.build/modules/upb/0.0.0-20220923-a547704/MODULE.bazel": "7298990c00040a0e2f121f6c32544bab27d4452f80d9ce51349b1a28f3005c43",
+    "https://bcr.bazel.build/modules/zlib/1.2.11/MODULE.bazel": "07b389abc85fdbca459b69e2ec656ae5622873af3f845e1c9d80fe179f3effa0",
+    "https://bcr.bazel.build/modules/zlib/1.2.12/MODULE.bazel": "3b1a8834ada2a883674be8cbd36ede1b6ec481477ada359cd2d3ddc562340b27",
+    "https://bcr.bazel.build/modules/zlib/1.3.1.bcr.5/MODULE.bazel": "eec517b5bbe5492629466e11dae908d043364302283de25581e3eb944326c4ca",
+    "https://bcr.bazel.build/modules/zlib/1.3.1.bcr.5/source.json": "22bc55c47af97246cfc093d0acf683a7869377de362b5d1c552c2c2e16b7a806",
+    "https://bcr.bazel.build/modules/zlib/1.3.1/MODULE.bazel": "751c9940dcfe869f5f7274e1295422a34623555916eb98c174c1e945594bf198"
+  },
+  "selectedYankedVersions": {},
+  "moduleExtensions": {
+    "@@aspect_bazel_lib+//lib:extensions.bzl%toolchains": {
+      "general": {
+        "bzlTransitiveDigest": "I7lR2e1GWfBvzbQsXwenRtuzsqRuls0uKmYdO50EzVY=",
+        "usagesDigest": "HyCD/AMcHKcynL86oRSbi4rhw9cjPb8yfXrC363gBKE=",
+        "recordedFileInputs": {},
+        "recordedDirentsInputs": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "copy_directory_darwin_amd64": {
+            "repoRuleId": "@@aspect_bazel_lib+//lib/private:copy_directory_toolchain.bzl%copy_directory_platform_repo",
+            "attributes": {
+              "platform": "darwin_amd64"
+            }
+          },
+          "copy_directory_darwin_arm64": {
+            "repoRuleId": "@@aspect_bazel_lib+//lib/private:copy_directory_toolchain.bzl%copy_directory_platform_repo",
+            "attributes": {
+              "platform": "darwin_arm64"
+            }
+          },
+          "copy_directory_freebsd_amd64": {
+            "repoRuleId": "@@aspect_bazel_lib+//lib/private:copy_directory_toolchain.bzl%copy_directory_platform_repo",
+            "attributes": {
+              "platform": "freebsd_amd64"
+            }
+          },
+          "copy_directory_linux_amd64": {
+            "repoRuleId": "@@aspect_bazel_lib+//lib/private:copy_directory_toolchain.bzl%copy_directory_platform_repo",
+            "attributes": {
+              "platform": "linux_amd64"
+            }
+          },
+          "copy_directory_linux_arm64": {
+            "repoRuleId": "@@aspect_bazel_lib+//lib/private:copy_directory_toolchain.bzl%copy_directory_platform_repo",
+            "attributes": {
+              "platform": "linux_arm64"
+            }
+          },
+          "copy_directory_windows_amd64": {
+            "repoRuleId": "@@aspect_bazel_lib+//lib/private:copy_directory_toolchain.bzl%copy_directory_platform_repo",
+            "attributes": {
+              "platform": "windows_amd64"
+            }
+          },
+          "copy_directory_toolchains": {
+            "repoRuleId": "@@aspect_bazel_lib+//lib/private:copy_directory_toolchain.bzl%copy_directory_toolchains_repo",
+            "attributes": {
+              "user_repository_name": "copy_directory"
+            }
+          },
+          "copy_to_directory_darwin_amd64": {
+            "repoRuleId": "@@aspect_bazel_lib+//lib/private:copy_to_directory_toolchain.bzl%copy_to_directory_platform_repo",
+            "attributes": {
+              "platform": "darwin_amd64"
+            }
+          },
+          "copy_to_directory_darwin_arm64": {
+            "repoRuleId": "@@aspect_bazel_lib+//lib/private:copy_to_directory_toolchain.bzl%copy_to_directory_platform_repo",
+            "attributes": {
+              "platform": "darwin_arm64"
+            }
+          },
+          "copy_to_directory_freebsd_amd64": {
+            "repoRuleId": "@@aspect_bazel_lib+//lib/private:copy_to_directory_toolchain.bzl%copy_to_directory_platform_repo",
+            "attributes": {
+              "platform": "freebsd_amd64"
+            }
+          },
+          "copy_to_directory_linux_amd64": {
+            "repoRuleId": "@@aspect_bazel_lib+//lib/private:copy_to_directory_toolchain.bzl%copy_to_directory_platform_repo",
+            "attributes": {
+              "platform": "linux_amd64"
+            }
+          },
+          "copy_to_directory_linux_arm64": {
+            "repoRuleId": "@@aspect_bazel_lib+//lib/private:copy_to_directory_toolchain.bzl%copy_to_directory_platform_repo",
+            "attributes": {
+              "platform": "linux_arm64"
+            }
+          },
+          "copy_to_directory_windows_amd64": {
+            "repoRuleId": "@@aspect_bazel_lib+//lib/private:copy_to_directory_toolchain.bzl%copy_to_directory_platform_repo",
+            "attributes": {
+              "platform": "windows_amd64"
+            }
+          },
+          "copy_to_directory_toolchains": {
+            "repoRuleId": "@@aspect_bazel_lib+//lib/private:copy_to_directory_toolchain.bzl%copy_to_directory_toolchains_repo",
+            "attributes": {
+              "user_repository_name": "copy_to_directory"
+            }
+          },
+          "jq_darwin_amd64": {
+            "repoRuleId": "@@aspect_bazel_lib+//lib/private:jq_toolchain.bzl%jq_platform_repo",
+            "attributes": {
+              "platform": "darwin_amd64",
+              "version": "1.6"
+            }
+          },
+          "jq_darwin_arm64": {
+            "repoRuleId": "@@aspect_bazel_lib+//lib/private:jq_toolchain.bzl%jq_platform_repo",
+            "attributes": {
+              "platform": "darwin_arm64",
+              "version": "1.6"
+            }
+          },
+          "jq_linux_amd64": {
+            "repoRuleId": "@@aspect_bazel_lib+//lib/private:jq_toolchain.bzl%jq_platform_repo",
+            "attributes": {
+              "platform": "linux_amd64",
+              "version": "1.6"
+            }
+          },
+          "jq_windows_amd64": {
+            "repoRuleId": "@@aspect_bazel_lib+//lib/private:jq_toolchain.bzl%jq_platform_repo",
+            "attributes": {
+              "platform": "windows_amd64",
+              "version": "1.6"
+            }
+          },
+          "jq": {
+            "repoRuleId": "@@aspect_bazel_lib+//lib/private:jq_toolchain.bzl%jq_host_alias_repo",
+            "attributes": {}
+          },
+          "jq_toolchains": {
+            "repoRuleId": "@@aspect_bazel_lib+//lib/private:jq_toolchain.bzl%jq_toolchains_repo",
+            "attributes": {
+              "user_repository_name": "jq"
+            }
+          },
+          "yq_darwin_amd64": {
+            "repoRuleId": "@@aspect_bazel_lib+//lib/private:yq_toolchain.bzl%yq_platform_repo",
+            "attributes": {
+              "platform": "darwin_amd64",
+              "version": "4.25.2"
+            }
+          },
+          "yq_darwin_arm64": {
+            "repoRuleId": "@@aspect_bazel_lib+//lib/private:yq_toolchain.bzl%yq_platform_repo",
+            "attributes": {
+              "platform": "darwin_arm64",
+              "version": "4.25.2"
+            }
+          },
+          "yq_linux_amd64": {
+            "repoRuleId": "@@aspect_bazel_lib+//lib/private:yq_toolchain.bzl%yq_platform_repo",
+            "attributes": {
+              "platform": "linux_amd64",
+              "version": "4.25.2"
+            }
+          },
+          "yq_linux_arm64": {
+            "repoRuleId": "@@aspect_bazel_lib+//lib/private:yq_toolchain.bzl%yq_platform_repo",
+            "attributes": {
+              "platform": "linux_arm64",
+              "version": "4.25.2"
+            }
+          },
+          "yq_linux_s390x": {
+            "repoRuleId": "@@aspect_bazel_lib+//lib/private:yq_toolchain.bzl%yq_platform_repo",
+            "attributes": {
+              "platform": "linux_s390x",
+              "version": "4.25.2"
+            }
+          },
+          "yq_linux_ppc64le": {
+            "repoRuleId": "@@aspect_bazel_lib+//lib/private:yq_toolchain.bzl%yq_platform_repo",
+            "attributes": {
+              "platform": "linux_ppc64le",
+              "version": "4.25.2"
+            }
+          },
+          "yq_windows_amd64": {
+            "repoRuleId": "@@aspect_bazel_lib+//lib/private:yq_toolchain.bzl%yq_platform_repo",
+            "attributes": {
+              "platform": "windows_amd64",
+              "version": "4.25.2"
+            }
+          },
+          "yq": {
+            "repoRuleId": "@@aspect_bazel_lib+//lib/private:yq_toolchain.bzl%yq_host_alias_repo",
+            "attributes": {}
+          },
+          "yq_toolchains": {
+            "repoRuleId": "@@aspect_bazel_lib+//lib/private:yq_toolchain.bzl%yq_toolchains_repo",
+            "attributes": {
+              "user_repository_name": "yq"
+            }
+          },
+          "coreutils_darwin_amd64": {
+            "repoRuleId": "@@aspect_bazel_lib+//lib/private:coreutils_toolchain.bzl%coreutils_platform_repo",
+            "attributes": {
+              "platform": "darwin_amd64",
+              "version": "0.0.16"
+            }
+          },
+          "coreutils_darwin_arm64": {
+            "repoRuleId": "@@aspect_bazel_lib+//lib/private:coreutils_toolchain.bzl%coreutils_platform_repo",
+            "attributes": {
+              "platform": "darwin_arm64",
+              "version": "0.0.16"
+            }
+          },
+          "coreutils_linux_amd64": {
+            "repoRuleId": "@@aspect_bazel_lib+//lib/private:coreutils_toolchain.bzl%coreutils_platform_repo",
+            "attributes": {
+              "platform": "linux_amd64",
+              "version": "0.0.16"
+            }
+          },
+          "coreutils_linux_arm64": {
+            "repoRuleId": "@@aspect_bazel_lib+//lib/private:coreutils_toolchain.bzl%coreutils_platform_repo",
+            "attributes": {
+              "platform": "linux_arm64",
+              "version": "0.0.16"
+            }
+          },
+          "coreutils_windows_amd64": {
+            "repoRuleId": "@@aspect_bazel_lib+//lib/private:coreutils_toolchain.bzl%coreutils_platform_repo",
+            "attributes": {
+              "platform": "windows_amd64",
+              "version": "0.0.16"
+            }
+          },
+          "coreutils_toolchains": {
+            "repoRuleId": "@@aspect_bazel_lib+//lib/private:coreutils_toolchain.bzl%coreutils_toolchains_repo",
+            "attributes": {
+              "user_repository_name": "coreutils"
+            }
+          },
+          "expand_template_darwin_amd64": {
+            "repoRuleId": "@@aspect_bazel_lib+//lib/private:expand_template_toolchain.bzl%expand_template_platform_repo",
+            "attributes": {
+              "platform": "darwin_amd64"
+            }
+          },
+          "expand_template_darwin_arm64": {
+            "repoRuleId": "@@aspect_bazel_lib+//lib/private:expand_template_toolchain.bzl%expand_template_platform_repo",
+            "attributes": {
+              "platform": "darwin_arm64"
+            }
+          },
+          "expand_template_freebsd_amd64": {
+            "repoRuleId": "@@aspect_bazel_lib+//lib/private:expand_template_toolchain.bzl%expand_template_platform_repo",
+            "attributes": {
+              "platform": "freebsd_amd64"
+            }
+          },
+          "expand_template_linux_amd64": {
+            "repoRuleId": "@@aspect_bazel_lib+//lib/private:expand_template_toolchain.bzl%expand_template_platform_repo",
+            "attributes": {
+              "platform": "linux_amd64"
+            }
+          },
+          "expand_template_linux_arm64": {
+            "repoRuleId": "@@aspect_bazel_lib+//lib/private:expand_template_toolchain.bzl%expand_template_platform_repo",
+            "attributes": {
+              "platform": "linux_arm64"
+            }
+          },
+          "expand_template_windows_amd64": {
+            "repoRuleId": "@@aspect_bazel_lib+//lib/private:expand_template_toolchain.bzl%expand_template_platform_repo",
+            "attributes": {
+              "platform": "windows_amd64"
+            }
+          },
+          "expand_template_toolchains": {
+            "repoRuleId": "@@aspect_bazel_lib+//lib/private:expand_template_toolchain.bzl%expand_template_toolchains_repo",
+            "attributes": {
+              "user_repository_name": "expand_template"
+            }
+          }
+        },
+        "recordedRepoMappingEntries": [
+          [
+            "aspect_bazel_lib+",
+            "aspect_bazel_lib",
+            "aspect_bazel_lib+"
+          ],
+          [
+            "aspect_bazel_lib+",
+            "bazel_skylib",
+            "bazel_skylib+"
+          ],
+          [
+            "aspect_bazel_lib+",
+            "bazel_tools",
+            "bazel_tools"
+          ]
+        ]
+      }
+    },
+    "@@rules_buf+//buf:extensions.bzl%ext": {
+      "general": {
+        "bzlTransitiveDigest": "SDu9W4CQUvGE9A6LTAEbu5g75w34Inmz0/AX9wecDv4=",
+        "usagesDigest": "RTc2BMQ2b0wGU8CRvN3EoPz34m3LMe+K/oSkFkN83+M=",
+        "recordedFileInputs": {},
+        "recordedDirentsInputs": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "rules_buf_toolchains": {
+            "repoRuleId": "@@rules_buf+//buf/internal:toolchain.bzl%buf_download_releases",
+            "attributes": {
+              "version": "v1.27.0"
+            }
+          }
+        },
+        "recordedRepoMappingEntries": [
+          [
+            "rules_buf+",
+            "bazel_tools",
+            "bazel_tools"
+          ]
+        ]
+      }
+    },
+    "@@rules_go+//go:extensions.bzl%go_sdk": {
+      "general": {
+        "bzlTransitiveDigest": "SLgja/3zgS0SnRcsdHfQ8YfmP/nmv1nIPCqVEXPNrzw=",
+        "usagesDigest": "G0DymwAVABR+Olml5OAfLhVRqUVCU372GHdSQxQ1PJw=",
+        "recordedFileInputs": {},
+        "recordedDirentsInputs": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "go_default_sdk": {
+            "repoRuleId": "@@rules_go+//go/private:sdk.bzl%go_download_sdk_rule",
+            "attributes": {
+              "goos": "",
+              "goarch": "",
+              "sdks": {},
+              "urls": [
+                "https://dl.google.com/go/{}"
+              ],
+              "version": "1.19.8"
+            }
+          },
+          "go_toolchains": {
+            "repoRuleId": "@@rules_go+//go/private:sdk.bzl%go_multiple_toolchains",
+            "attributes": {
+              "prefixes": [
+                "_0000_go_default_sdk_"
+              ],
+              "geese": [
+                ""
+              ],
+              "goarchs": [
+                ""
+              ],
+              "sdk_repos": [
+                "go_default_sdk"
+              ],
+              "sdk_types": [
+                "remote"
+              ],
+              "sdk_versions": [
+                "1.19.8"
+              ]
+            }
+          }
+        },
+        "recordedRepoMappingEntries": [
+          [
+            "rules_go+",
+            "bazel_tools",
+            "bazel_tools"
+          ]
+        ]
+      }
+    },
+    "@@rules_kotlin+//src/main/starlark/core/repositories:bzlmod_setup.bzl%rules_kotlin_extensions": {
+      "general": {
+        "bzlTransitiveDigest": "OlvsB0HsvxbR8ZN+J9Vf00X/+WVz/Y/5Xrq2LgcVfdo=",
+        "usagesDigest": "QI2z8ZUR+mqtbwsf2fLqYdJAkPOHdOV+tF2yVAUgRzw=",
+        "recordedFileInputs": {},
+        "recordedDirentsInputs": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "com_github_jetbrains_kotlin_git": {
+            "repoRuleId": "@@rules_kotlin+//src/main/starlark/core/repositories:compiler.bzl%kotlin_compiler_git_repository",
+            "attributes": {
+              "urls": [
+                "https://github.com/JetBrains/kotlin/releases/download/v1.9.23/kotlin-compiler-1.9.23.zip"
+              ],
+              "sha256": "93137d3aab9afa9b27cb06a824c2324195c6b6f6179d8a8653f440f5bd58be88"
+            }
+          },
+          "com_github_jetbrains_kotlin": {
+            "repoRuleId": "@@rules_kotlin+//src/main/starlark/core/repositories:compiler.bzl%kotlin_capabilities_repository",
+            "attributes": {
+              "git_repository_name": "com_github_jetbrains_kotlin_git",
+              "compiler_version": "1.9.23"
+            }
+          },
+          "com_github_google_ksp": {
+            "repoRuleId": "@@rules_kotlin+//src/main/starlark/core/repositories:ksp.bzl%ksp_compiler_plugin_repository",
+            "attributes": {
+              "urls": [
+                "https://github.com/google/ksp/releases/download/1.9.23-1.0.20/artifacts.zip"
+              ],
+              "sha256": "ee0618755913ef7fd6511288a232e8fad24838b9af6ea73972a76e81053c8c2d",
+              "strip_version": "1.9.23-1.0.20"
+            }
+          },
+          "com_github_pinterest_ktlint": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
+            "attributes": {
+              "sha256": "01b2e0ef893383a50dbeb13970fe7fa3be36ca3e83259e01649945b09d736985",
+              "urls": [
+                "https://github.com/pinterest/ktlint/releases/download/1.3.0/ktlint"
+              ],
+              "executable": true
+            }
+          },
+          "rules_android": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "cd06d15dd8bb59926e4d65f9003bfc20f9da4b2519985c27e190cddc8b7a7806",
+              "strip_prefix": "rules_android-0.1.1",
+              "urls": [
+                "https://github.com/bazelbuild/rules_android/archive/v0.1.1.zip"
+              ]
+            }
+          }
+        },
+        "recordedRepoMappingEntries": [
+          [
+            "rules_kotlin+",
+            "bazel_tools",
+            "bazel_tools"
+          ]
+        ]
+      }
+    },
+    "@@rules_nodejs+//nodejs:extensions.bzl%node": {
+      "general": {
+        "bzlTransitiveDigest": "PlbDlTkTjipL4rJTSM7NFGKQWgR5KMJGAfophD4adeo=",
+        "usagesDigest": "CtwJeycIo1YVyKAUrO/7bkpB6yqctQd8XUnRtqUbwRI=",
+        "recordedFileInputs": {},
+        "recordedDirentsInputs": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "nodejs_linux_amd64": {
+            "repoRuleId": "@@rules_nodejs+//nodejs:repositories.bzl%node_repositories",
+            "attributes": {
+              "platform": "linux_amd64",
+              "node_version": "16.19.0"
+            }
+          },
+          "nodejs_linux_arm64": {
+            "repoRuleId": "@@rules_nodejs+//nodejs:repositories.bzl%node_repositories",
+            "attributes": {
+              "platform": "linux_arm64",
+              "node_version": "16.19.0"
+            }
+          },
+          "nodejs_linux_s390x": {
+            "repoRuleId": "@@rules_nodejs+//nodejs:repositories.bzl%node_repositories",
+            "attributes": {
+              "platform": "linux_s390x",
+              "node_version": "16.19.0"
+            }
+          },
+          "nodejs_linux_ppc64le": {
+            "repoRuleId": "@@rules_nodejs+//nodejs:repositories.bzl%node_repositories",
+            "attributes": {
+              "platform": "linux_ppc64le",
+              "node_version": "16.19.0"
+            }
+          },
+          "nodejs_darwin_amd64": {
+            "repoRuleId": "@@rules_nodejs+//nodejs:repositories.bzl%node_repositories",
+            "attributes": {
+              "platform": "darwin_amd64",
+              "node_version": "16.19.0"
+            }
+          },
+          "nodejs_darwin_arm64": {
+            "repoRuleId": "@@rules_nodejs+//nodejs:repositories.bzl%node_repositories",
+            "attributes": {
+              "platform": "darwin_arm64",
+              "node_version": "16.19.0"
+            }
+          },
+          "nodejs_windows_amd64": {
+            "repoRuleId": "@@rules_nodejs+//nodejs:repositories.bzl%node_repositories",
+            "attributes": {
+              "platform": "windows_amd64",
+              "node_version": "16.19.0"
+            }
+          },
+          "nodejs": {
+            "repoRuleId": "@@rules_nodejs+//nodejs/private:nodejs_repo_host_os_alias.bzl%nodejs_repo_host_os_alias",
+            "attributes": {
+              "user_node_repository_name": "nodejs"
+            }
+          },
+          "nodejs_host": {
+            "repoRuleId": "@@rules_nodejs+//nodejs/private:nodejs_repo_host_os_alias.bzl%nodejs_repo_host_os_alias",
+            "attributes": {
+              "user_node_repository_name": "nodejs"
+            }
+          },
+          "nodejs_toolchains": {
+            "repoRuleId": "@@rules_nodejs+//nodejs/private:toolchains_repo.bzl%toolchains_repo",
+            "attributes": {
+              "user_node_repository_name": "nodejs"
+            }
+          }
+        },
+        "recordedRepoMappingEntries": [
+          [
+            "rules_nodejs+",
+            "bazel_skylib",
+            "bazel_skylib+"
+          ],
+          [
+            "rules_nodejs+",
+            "bazel_tools",
+            "bazel_tools"
+          ]
+        ]
+      }
+    },
+    "@@rules_rust+//rust/private:extensions.bzl%i": {
+      "general": {
+        "bzlTransitiveDigest": "1vpcU6wViyZUreZmypGNxbkz7JDYRX8mU8NqOlRPuGo=",
+        "usagesDigest": "9lU8iZ3WLB7+RkWSk13CwAoTAFTYTBzfdF5J5OFFVuQ=",
+        "recordedFileInputs": {},
+        "recordedDirentsInputs": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "rules_rust_tinyjson": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "9ab95735ea2c8fd51154d01e39cf13912a78071c2d89abc49a7ef102a7dd725a",
+              "url": "https://static.crates.io/crates/tinyjson/tinyjson-2.5.1.crate",
+              "strip_prefix": "tinyjson-2.5.1",
+              "type": "tar.gz",
+              "build_file": "@@rules_rust+//util/process_wrapper:BUILD.tinyjson.bazel"
+            }
+          },
+          "cui": {
+            "repoRuleId": "@@rules_rust+//crate_universe/private:crates_vendor.bzl%crates_vendor_remote_repository",
+            "attributes": {
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.bazel",
+              "defs_module": "@@rules_rust+//crate_universe/3rdparty/crates:defs.bzl"
+            }
+          },
+          "cui__adler-1.0.2": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/adler/1.0.2/download"
+              ],
+              "strip_prefix": "adler-1.0.2",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.adler-1.0.2.bazel"
+            }
+          },
+          "cui__ahash-0.8.11": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/ahash/0.8.11/download"
+              ],
+              "strip_prefix": "ahash-0.8.11",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.ahash-0.8.11.bazel"
+            }
+          },
+          "cui__aho-corasick-1.0.2": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "43f6cb1bf222025340178f382c426f13757b2960e89779dfcb319c32542a5a41",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/aho-corasick/1.0.2/download"
+              ],
+              "strip_prefix": "aho-corasick-1.0.2",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.aho-corasick-1.0.2.bazel"
+            }
+          },
+          "cui__allocator-api2-0.2.18": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "5c6cb57a04249c6480766f7f7cef5467412af1490f8d1e243141daddada3264f",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/allocator-api2/0.2.18/download"
+              ],
+              "strip_prefix": "allocator-api2-0.2.18",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.allocator-api2-0.2.18.bazel"
+            }
+          },
+          "cui__anstream-0.3.2": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "0ca84f3628370c59db74ee214b3263d58f9aadd9b4fe7e711fd87dc452b7f163",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/anstream/0.3.2/download"
+              ],
+              "strip_prefix": "anstream-0.3.2",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.anstream-0.3.2.bazel"
+            }
+          },
+          "cui__anstyle-1.0.1": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "3a30da5c5f2d5e72842e00bcb57657162cdabef0931f40e2deb9b4140440cecd",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/anstyle/1.0.1/download"
+              ],
+              "strip_prefix": "anstyle-1.0.1",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.anstyle-1.0.1.bazel"
+            }
+          },
+          "cui__anstyle-parse-0.2.1": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "938874ff5980b03a87c5524b3ae5b59cf99b1d6bc836848df7bc5ada9643c333",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/anstyle-parse/0.2.1/download"
+              ],
+              "strip_prefix": "anstyle-parse-0.2.1",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.anstyle-parse-0.2.1.bazel"
+            }
+          },
+          "cui__anstyle-query-1.0.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "5ca11d4be1bab0c8bc8734a9aa7bf4ee8316d462a08c6ac5052f888fef5b494b",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/anstyle-query/1.0.0/download"
+              ],
+              "strip_prefix": "anstyle-query-1.0.0",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.anstyle-query-1.0.0.bazel"
+            }
+          },
+          "cui__anstyle-wincon-1.0.1": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "180abfa45703aebe0093f79badacc01b8fd4ea2e35118747e5811127f926e188",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/anstyle-wincon/1.0.1/download"
+              ],
+              "strip_prefix": "anstyle-wincon-1.0.1",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.anstyle-wincon-1.0.1.bazel"
+            }
+          },
+          "cui__anyhow-1.0.89": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "86fdf8605db99b54d3cd748a44c6d04df638eb5dafb219b135d0149bd0db01f6",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/anyhow/1.0.89/download"
+              ],
+              "strip_prefix": "anyhow-1.0.89",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.anyhow-1.0.89.bazel"
+            }
+          },
+          "cui__arc-swap-1.6.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "bddcadddf5e9015d310179a59bb28c4d4b9920ad0f11e8e14dbadf654890c9a6",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/arc-swap/1.6.0/download"
+              ],
+              "strip_prefix": "arc-swap-1.6.0",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.arc-swap-1.6.0.bazel"
+            }
+          },
+          "cui__arrayvec-0.7.4": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/arrayvec/0.7.4/download"
+              ],
+              "strip_prefix": "arrayvec-0.7.4",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.arrayvec-0.7.4.bazel"
+            }
+          },
+          "cui__autocfg-1.1.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/autocfg/1.1.0/download"
+              ],
+              "strip_prefix": "autocfg-1.1.0",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.autocfg-1.1.0.bazel"
+            }
+          },
+          "cui__bitflags-1.3.2": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/bitflags/1.3.2/download"
+              ],
+              "strip_prefix": "bitflags-1.3.2",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.bitflags-1.3.2.bazel"
+            }
+          },
+          "cui__bitflags-2.4.1": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "327762f6e5a765692301e5bb513e0d9fef63be86bbc14528052b1cd3e6f03e07",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/bitflags/2.4.1/download"
+              ],
+              "strip_prefix": "bitflags-2.4.1",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.bitflags-2.4.1.bazel"
+            }
+          },
+          "cui__block-buffer-0.10.4": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/block-buffer/0.10.4/download"
+              ],
+              "strip_prefix": "block-buffer-0.10.4",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.block-buffer-0.10.4.bazel"
+            }
+          },
+          "cui__bstr-1.6.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "6798148dccfbff0fae41c7574d2fa8f1ef3492fba0face179de5d8d447d67b05",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/bstr/1.6.0/download"
+              ],
+              "strip_prefix": "bstr-1.6.0",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.bstr-1.6.0.bazel"
+            }
+          },
+          "cui__camino-1.1.9": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "8b96ec4966b5813e2c0507c1f86115c8c5abaadc3980879c3424042a02fd1ad3",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/camino/1.1.9/download"
+              ],
+              "strip_prefix": "camino-1.1.9",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.camino-1.1.9.bazel"
+            }
+          },
+          "cui__cargo-lock-10.0.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "49f8d8bb8836f681fe20ad10faa7796a11e67dbb6125e5a38f88ddd725c217e8",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/cargo-lock/10.0.0/download"
+              ],
+              "strip_prefix": "cargo-lock-10.0.0",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.cargo-lock-10.0.0.bazel"
+            }
+          },
+          "cui__cargo-platform-0.1.7": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "694c8807f2ae16faecc43dc17d74b3eb042482789fd0eb64b39a2e04e087053f",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/cargo-platform/0.1.7/download"
+              ],
+              "strip_prefix": "cargo-platform-0.1.7",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.cargo-platform-0.1.7.bazel"
+            }
+          },
+          "cui__cargo_metadata-0.18.1": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "2d886547e41f740c616ae73108f6eb70afe6d940c7bc697cb30f13daec073037",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/cargo_metadata/0.18.1/download"
+              ],
+              "strip_prefix": "cargo_metadata-0.18.1",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.cargo_metadata-0.18.1.bazel"
+            }
+          },
+          "cui__cargo_toml-0.20.5": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "88da5a13c620b4ca0078845707ea9c3faf11edbc3ffd8497d11d686211cd1ac0",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/cargo_toml/0.20.5/download"
+              ],
+              "strip_prefix": "cargo_toml-0.20.5",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.cargo_toml-0.20.5.bazel"
+            }
+          },
+          "cui__cfg-expr-0.17.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "d0890061c4d3223e7267f3bad2ec40b997d64faac1c2815a4a9d95018e2b9e9c",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/cfg-expr/0.17.0/download"
+              ],
+              "strip_prefix": "cfg-expr-0.17.0",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.cfg-expr-0.17.0.bazel"
+            }
+          },
+          "cui__cfg-if-1.0.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/cfg-if/1.0.0/download"
+              ],
+              "strip_prefix": "cfg-if-1.0.0",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.cfg-if-1.0.0.bazel"
+            }
+          },
+          "cui__clap-4.3.11": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "1640e5cc7fb47dbb8338fd471b105e7ed6c3cb2aeb00c2e067127ffd3764a05d",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/clap/4.3.11/download"
+              ],
+              "strip_prefix": "clap-4.3.11",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.clap-4.3.11.bazel"
+            }
+          },
+          "cui__clap_builder-4.3.11": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "98c59138d527eeaf9b53f35a77fcc1fad9d883116070c63d5de1c7dc7b00c72b",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/clap_builder/4.3.11/download"
+              ],
+              "strip_prefix": "clap_builder-4.3.11",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.clap_builder-4.3.11.bazel"
+            }
+          },
+          "cui__clap_derive-4.3.2": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "b8cd2b2a819ad6eec39e8f1d6b53001af1e5469f8c177579cdaeb313115b825f",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/clap_derive/4.3.2/download"
+              ],
+              "strip_prefix": "clap_derive-4.3.2",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.clap_derive-4.3.2.bazel"
+            }
+          },
+          "cui__clap_lex-0.5.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "2da6da31387c7e4ef160ffab6d5e7f00c42626fe39aea70a7b0f1773f7dd6c1b",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/clap_lex/0.5.0/download"
+              ],
+              "strip_prefix": "clap_lex-0.5.0",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.clap_lex-0.5.0.bazel"
+            }
+          },
+          "cui__clru-0.6.1": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "b8191fa7302e03607ff0e237d4246cc043ff5b3cb9409d995172ba3bea16b807",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/clru/0.6.1/download"
+              ],
+              "strip_prefix": "clru-0.6.1",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.clru-0.6.1.bazel"
+            }
+          },
+          "cui__colorchoice-1.0.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/colorchoice/1.0.0/download"
+              ],
+              "strip_prefix": "colorchoice-1.0.0",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.colorchoice-1.0.0.bazel"
+            }
+          },
+          "cui__cpufeatures-0.2.9": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "a17b76ff3a4162b0b27f354a0c87015ddad39d35f9c0c36607a3bdd175dde1f1",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/cpufeatures/0.2.9/download"
+              ],
+              "strip_prefix": "cpufeatures-0.2.9",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.cpufeatures-0.2.9.bazel"
+            }
+          },
+          "cui__crates-index-3.2.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "45fbf3a2a2f3435363fb343f30ee31d9f63ea3862d6eab639446c1393d82cd32",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/crates-index/3.2.0/download"
+              ],
+              "strip_prefix": "crates-index-3.2.0",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.crates-index-3.2.0.bazel"
+            }
+          },
+          "cui__crc32fast-1.3.2": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/crc32fast/1.3.2/download"
+              ],
+              "strip_prefix": "crc32fast-1.3.2",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.crc32fast-1.3.2.bazel"
+            }
+          },
+          "cui__crossbeam-channel-0.5.8": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "a33c2bf77f2df06183c3aa30d1e96c0695a313d4f9c453cc3762a6db39f99200",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/crossbeam-channel/0.5.8/download"
+              ],
+              "strip_prefix": "crossbeam-channel-0.5.8",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.crossbeam-channel-0.5.8.bazel"
+            }
+          },
+          "cui__crossbeam-utils-0.8.16": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "5a22b2d63d4d1dc0b7f1b6b2747dd0088008a9be28b6ddf0b1e7d335e3037294",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/crossbeam-utils/0.8.16/download"
+              ],
+              "strip_prefix": "crossbeam-utils-0.8.16",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.crossbeam-utils-0.8.16.bazel"
+            }
+          },
+          "cui__crypto-common-0.1.6": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/crypto-common/0.1.6/download"
+              ],
+              "strip_prefix": "crypto-common-0.1.6",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.crypto-common-0.1.6.bazel"
+            }
+          },
+          "cui__digest-0.10.7": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/digest/0.10.7/download"
+              ],
+              "strip_prefix": "digest-0.10.7",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.digest-0.10.7.bazel"
+            }
+          },
+          "cui__dunce-1.0.4": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "56ce8c6da7551ec6c462cbaf3bfbc75131ebbfa1c944aeaa9dab51ca1c5f0c3b",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/dunce/1.0.4/download"
+              ],
+              "strip_prefix": "dunce-1.0.4",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.dunce-1.0.4.bazel"
+            }
+          },
+          "cui__either-1.9.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/either/1.9.0/download"
+              ],
+              "strip_prefix": "either-1.9.0",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.either-1.9.0.bazel"
+            }
+          },
+          "cui__encoding_rs-0.8.33": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "7268b386296a025e474d5140678f75d6de9493ae55a5d709eeb9dd08149945e1",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/encoding_rs/0.8.33/download"
+              ],
+              "strip_prefix": "encoding_rs-0.8.33",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.encoding_rs-0.8.33.bazel"
+            }
+          },
+          "cui__equivalent-1.0.1": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/equivalent/1.0.1/download"
+              ],
+              "strip_prefix": "equivalent-1.0.1",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.equivalent-1.0.1.bazel"
+            }
+          },
+          "cui__errno-0.3.9": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "534c5cf6194dfab3db3242765c03bbe257cf92f22b38f6bc0c58d59108a820ba",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/errno/0.3.9/download"
+              ],
+              "strip_prefix": "errno-0.3.9",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.errno-0.3.9.bazel"
+            }
+          },
+          "cui__faster-hex-0.9.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "a2a2b11eda1d40935b26cf18f6833c526845ae8c41e58d09af6adeb6f0269183",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/faster-hex/0.9.0/download"
+              ],
+              "strip_prefix": "faster-hex-0.9.0",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.faster-hex-0.9.0.bazel"
+            }
+          },
+          "cui__fastrand-2.1.1": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "e8c02a5121d4ea3eb16a80748c74f5549a5665e4c21333c6098f283870fbdea6",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/fastrand/2.1.1/download"
+              ],
+              "strip_prefix": "fastrand-2.1.1",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.fastrand-2.1.1.bazel"
+            }
+          },
+          "cui__filetime-0.2.22": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "d4029edd3e734da6fe05b6cd7bd2960760a616bd2ddd0d59a0124746d6272af0",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/filetime/0.2.22/download"
+              ],
+              "strip_prefix": "filetime-0.2.22",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.filetime-0.2.22.bazel"
+            }
+          },
+          "cui__flate2-1.0.28": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "46303f565772937ffe1d394a4fac6f411c6013172fadde9dcdb1e147a086940e",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/flate2/1.0.28/download"
+              ],
+              "strip_prefix": "flate2-1.0.28",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.flate2-1.0.28.bazel"
+            }
+          },
+          "cui__fnv-1.0.7": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/fnv/1.0.7/download"
+              ],
+              "strip_prefix": "fnv-1.0.7",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.fnv-1.0.7.bazel"
+            }
+          },
+          "cui__form_urlencoded-1.2.1": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/form_urlencoded/1.2.1/download"
+              ],
+              "strip_prefix": "form_urlencoded-1.2.1",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.form_urlencoded-1.2.1.bazel"
+            }
+          },
+          "cui__generic-array-0.14.7": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/generic-array/0.14.7/download"
+              ],
+              "strip_prefix": "generic-array-0.14.7",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.generic-array-0.14.7.bazel"
+            }
+          },
+          "cui__gix-0.66.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "9048b8d1ae2104f045cb37e5c450fc49d5d8af22609386bfc739c11ba88995eb",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/gix/0.66.0/download"
+              ],
+              "strip_prefix": "gix-0.66.0",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.gix-0.66.0.bazel"
+            }
+          },
+          "cui__gix-actor-0.32.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "fc19e312cd45c4a66cd003f909163dc2f8e1623e30a0c0c6df3776e89b308665",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/gix-actor/0.32.0/download"
+              ],
+              "strip_prefix": "gix-actor-0.32.0",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.gix-actor-0.32.0.bazel"
+            }
+          },
+          "cui__gix-attributes-0.22.5": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "ebccbf25aa4a973dd352564a9000af69edca90623e8a16dad9cbc03713131311",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/gix-attributes/0.22.5/download"
+              ],
+              "strip_prefix": "gix-attributes-0.22.5",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.gix-attributes-0.22.5.bazel"
+            }
+          },
+          "cui__gix-bitmap-0.2.11": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "a371db66cbd4e13f0ed9dc4c0fea712d7276805fccc877f77e96374d317e87ae",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/gix-bitmap/0.2.11/download"
+              ],
+              "strip_prefix": "gix-bitmap-0.2.11",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.gix-bitmap-0.2.11.bazel"
+            }
+          },
+          "cui__gix-chunk-0.4.8": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "45c8751169961ba7640b513c3b24af61aa962c967aaf04116734975cd5af0c52",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/gix-chunk/0.4.8/download"
+              ],
+              "strip_prefix": "gix-chunk-0.4.8",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.gix-chunk-0.4.8.bazel"
+            }
+          },
+          "cui__gix-command-0.3.9": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "dff2e692b36bbcf09286c70803006ca3fd56551a311de450be317a0ab8ea92e7",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/gix-command/0.3.9/download"
+              ],
+              "strip_prefix": "gix-command-0.3.9",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.gix-command-0.3.9.bazel"
+            }
+          },
+          "cui__gix-commitgraph-0.24.3": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "133b06f67f565836ec0c473e2116a60fb74f80b6435e21d88013ac0e3c60fc78",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/gix-commitgraph/0.24.3/download"
+              ],
+              "strip_prefix": "gix-commitgraph-0.24.3",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.gix-commitgraph-0.24.3.bazel"
+            }
+          },
+          "cui__gix-config-0.40.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "78e797487e6ca3552491de1131b4f72202f282fb33f198b1c34406d765b42bb0",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/gix-config/0.40.0/download"
+              ],
+              "strip_prefix": "gix-config-0.40.0",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.gix-config-0.40.0.bazel"
+            }
+          },
+          "cui__gix-config-value-0.14.8": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "03f76169faa0dec598eac60f83d7fcdd739ec16596eca8fb144c88973dbe6f8c",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/gix-config-value/0.14.8/download"
+              ],
+              "strip_prefix": "gix-config-value-0.14.8",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.gix-config-value-0.14.8.bazel"
+            }
+          },
+          "cui__gix-credentials-0.24.5": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "8ce391d305968782f1ae301c4a3d42c5701df7ff1d8bc03740300f6fd12bce78",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/gix-credentials/0.24.5/download"
+              ],
+              "strip_prefix": "gix-credentials-0.24.5",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.gix-credentials-0.24.5.bazel"
+            }
+          },
+          "cui__gix-date-0.9.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "35c84b7af01e68daf7a6bb8bb909c1ff5edb3ce4326f1f43063a5a96d3c3c8a5",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/gix-date/0.9.0/download"
+              ],
+              "strip_prefix": "gix-date-0.9.0",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.gix-date-0.9.0.bazel"
+            }
+          },
+          "cui__gix-diff-0.46.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "92c9afd80fff00f8b38b1c1928442feb4cd6d2232a6ed806b6b193151a3d336c",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/gix-diff/0.46.0/download"
+              ],
+              "strip_prefix": "gix-diff-0.46.0",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.gix-diff-0.46.0.bazel"
+            }
+          },
+          "cui__gix-discover-0.35.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "0577366b9567376bc26e815fd74451ebd0e6218814e242f8e5b7072c58d956d2",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/gix-discover/0.35.0/download"
+              ],
+              "strip_prefix": "gix-discover-0.35.0",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.gix-discover-0.35.0.bazel"
+            }
+          },
+          "cui__gix-features-0.38.2": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "ac7045ac9fe5f9c727f38799d002a7ed3583cd777e3322a7c4b43e3cf437dc69",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/gix-features/0.38.2/download"
+              ],
+              "strip_prefix": "gix-features-0.38.2",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.gix-features-0.38.2.bazel"
+            }
+          },
+          "cui__gix-filter-0.13.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "4121790ae140066e5b953becc72e7496278138d19239be2e63b5067b0843119e",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/gix-filter/0.13.0/download"
+              ],
+              "strip_prefix": "gix-filter-0.13.0",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.gix-filter-0.13.0.bazel"
+            }
+          },
+          "cui__gix-fs-0.11.3": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "f2bfe6249cfea6d0c0e0990d5226a4cb36f030444ba9e35e0639275db8f98575",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/gix-fs/0.11.3/download"
+              ],
+              "strip_prefix": "gix-fs-0.11.3",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.gix-fs-0.11.3.bazel"
+            }
+          },
+          "cui__gix-glob-0.16.5": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "74908b4bbc0a0a40852737e5d7889f676f081e340d5451a16e5b4c50d592f111",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/gix-glob/0.16.5/download"
+              ],
+              "strip_prefix": "gix-glob-0.16.5",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.gix-glob-0.16.5.bazel"
+            }
+          },
+          "cui__gix-hash-0.14.2": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "f93d7df7366121b5018f947a04d37f034717e113dcf9ccd85c34b58e57a74d5e",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/gix-hash/0.14.2/download"
+              ],
+              "strip_prefix": "gix-hash-0.14.2",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.gix-hash-0.14.2.bazel"
+            }
+          },
+          "cui__gix-hashtable-0.5.2": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "7ddf80e16f3c19ac06ce415a38b8591993d3f73aede049cb561becb5b3a8e242",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/gix-hashtable/0.5.2/download"
+              ],
+              "strip_prefix": "gix-hashtable-0.5.2",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.gix-hashtable-0.5.2.bazel"
+            }
+          },
+          "cui__gix-ignore-0.11.4": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "e447cd96598460f5906a0f6c75e950a39f98c2705fc755ad2f2020c9e937fab7",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/gix-ignore/0.11.4/download"
+              ],
+              "strip_prefix": "gix-ignore-0.11.4",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.gix-ignore-0.11.4.bazel"
+            }
+          },
+          "cui__gix-index-0.35.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "0cd4203244444017682176e65fd0180be9298e58ed90bd4a8489a357795ed22d",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/gix-index/0.35.0/download"
+              ],
+              "strip_prefix": "gix-index-0.35.0",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.gix-index-0.35.0.bazel"
+            }
+          },
+          "cui__gix-lock-14.0.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "e3bc7fe297f1f4614774989c00ec8b1add59571dc9b024b4c00acb7dedd4e19d",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/gix-lock/14.0.0/download"
+              ],
+              "strip_prefix": "gix-lock-14.0.0",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.gix-lock-14.0.0.bazel"
+            }
+          },
+          "cui__gix-negotiate-0.15.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "b4063bf329a191a9e24b6f948a17ccf6698c0380297f5e169cee4f1d2ab9475b",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/gix-negotiate/0.15.0/download"
+              ],
+              "strip_prefix": "gix-negotiate-0.15.0",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.gix-negotiate-0.15.0.bazel"
+            }
+          },
+          "cui__gix-object-0.44.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "2f5b801834f1de7640731820c2df6ba88d95480dc4ab166a5882f8ff12b88efa",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/gix-object/0.44.0/download"
+              ],
+              "strip_prefix": "gix-object-0.44.0",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.gix-object-0.44.0.bazel"
+            }
+          },
+          "cui__gix-odb-0.63.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "a3158068701c17df54f0ab2adda527f5a6aca38fd5fd80ceb7e3c0a2717ec747",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/gix-odb/0.63.0/download"
+              ],
+              "strip_prefix": "gix-odb-0.63.0",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.gix-odb-0.63.0.bazel"
+            }
+          },
+          "cui__gix-pack-0.53.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "3223aa342eee21e1e0e403cad8ae9caf9edca55ef84c347738d10681676fd954",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/gix-pack/0.53.0/download"
+              ],
+              "strip_prefix": "gix-pack-0.53.0",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.gix-pack-0.53.0.bazel"
+            }
+          },
+          "cui__gix-packetline-0.17.6": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "8c43ef4d5fe2fa222c606731c8bdbf4481413ee4ef46d61340ec39e4df4c5e49",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/gix-packetline/0.17.6/download"
+              ],
+              "strip_prefix": "gix-packetline-0.17.6",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.gix-packetline-0.17.6.bazel"
+            }
+          },
+          "cui__gix-packetline-blocking-0.17.5": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "b9802304baa798dd6f5ff8008a2b6516d54b74a69ca2d3a2b9e2d6c3b5556b40",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/gix-packetline-blocking/0.17.5/download"
+              ],
+              "strip_prefix": "gix-packetline-blocking-0.17.5",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.gix-packetline-blocking-0.17.5.bazel"
+            }
+          },
+          "cui__gix-path-0.10.11": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "ebfc4febd088abdcbc9f1246896e57e37b7a34f6909840045a1767c6dafac7af",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/gix-path/0.10.11/download"
+              ],
+              "strip_prefix": "gix-path-0.10.11",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.gix-path-0.10.11.bazel"
+            }
+          },
+          "cui__gix-pathspec-0.7.7": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "5d23bf239532b4414d0e63b8ab3a65481881f7237ed9647bb10c1e3cc54c5ceb",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/gix-pathspec/0.7.7/download"
+              ],
+              "strip_prefix": "gix-pathspec-0.7.7",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.gix-pathspec-0.7.7.bazel"
+            }
+          },
+          "cui__gix-prompt-0.8.7": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "74fde865cdb46b30d8dad1293385d9bcf998d3a39cbf41bee67d0dab026fe6b1",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/gix-prompt/0.8.7/download"
+              ],
+              "strip_prefix": "gix-prompt-0.8.7",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.gix-prompt-0.8.7.bazel"
+            }
+          },
+          "cui__gix-protocol-0.45.3": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "cc43a1006f01b5efee22a003928c9eb83dde2f52779ded9d4c0732ad93164e3e",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/gix-protocol/0.45.3/download"
+              ],
+              "strip_prefix": "gix-protocol-0.45.3",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.gix-protocol-0.45.3.bazel"
+            }
+          },
+          "cui__gix-quote-0.4.12": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "cbff4f9b9ea3fa7a25a70ee62f545143abef624ac6aa5884344e70c8b0a1d9ff",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/gix-quote/0.4.12/download"
+              ],
+              "strip_prefix": "gix-quote-0.4.12",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.gix-quote-0.4.12.bazel"
+            }
+          },
+          "cui__gix-ref-0.47.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "ae0d8406ebf9aaa91f55a57f053c5a1ad1a39f60fdf0303142b7be7ea44311e5",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/gix-ref/0.47.0/download"
+              ],
+              "strip_prefix": "gix-ref-0.47.0",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.gix-ref-0.47.0.bazel"
+            }
+          },
+          "cui__gix-refspec-0.25.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "ebb005f82341ba67615ffdd9f7742c87787544441c88090878393d0682869ca6",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/gix-refspec/0.25.0/download"
+              ],
+              "strip_prefix": "gix-refspec-0.25.0",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.gix-refspec-0.25.0.bazel"
+            }
+          },
+          "cui__gix-revision-0.29.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "ba4621b219ac0cdb9256883030c3d56a6c64a6deaa829a92da73b9a576825e1e",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/gix-revision/0.29.0/download"
+              ],
+              "strip_prefix": "gix-revision-0.29.0",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.gix-revision-0.29.0.bazel"
+            }
+          },
+          "cui__gix-revwalk-0.15.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "b41e72544b93084ee682ef3d5b31b1ba4d8fa27a017482900e5e044d5b1b3984",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/gix-revwalk/0.15.0/download"
+              ],
+              "strip_prefix": "gix-revwalk-0.15.0",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.gix-revwalk-0.15.0.bazel"
+            }
+          },
+          "cui__gix-sec-0.10.8": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "0fe4d52f30a737bbece5276fab5d3a8b276dc2650df963e293d0673be34e7a5f",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/gix-sec/0.10.8/download"
+              ],
+              "strip_prefix": "gix-sec-0.10.8",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.gix-sec-0.10.8.bazel"
+            }
+          },
+          "cui__gix-submodule-0.14.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "529d0af78cc2f372b3218f15eb1e3d1635a21c8937c12e2dd0b6fc80c2ca874b",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/gix-submodule/0.14.0/download"
+              ],
+              "strip_prefix": "gix-submodule-0.14.0",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.gix-submodule-0.14.0.bazel"
+            }
+          },
+          "cui__gix-tempfile-14.0.2": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "046b4927969fa816a150a0cda2e62c80016fe11fb3c3184e4dddf4e542f108aa",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/gix-tempfile/14.0.2/download"
+              ],
+              "strip_prefix": "gix-tempfile-14.0.2",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.gix-tempfile-14.0.2.bazel"
+            }
+          },
+          "cui__gix-trace-0.1.10": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "6cae0e8661c3ff92688ce1c8b8058b3efb312aba9492bbe93661a21705ab431b",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/gix-trace/0.1.10/download"
+              ],
+              "strip_prefix": "gix-trace-0.1.10",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.gix-trace-0.1.10.bazel"
+            }
+          },
+          "cui__gix-transport-0.42.3": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "421dcccab01b41a15d97b226ad97a8f9262295044e34fbd37b10e493b0a6481f",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/gix-transport/0.42.3/download"
+              ],
+              "strip_prefix": "gix-transport-0.42.3",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.gix-transport-0.42.3.bazel"
+            }
+          },
+          "cui__gix-traverse-0.41.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "030da39af94e4df35472e9318228f36530989327906f38e27807df305fccb780",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/gix-traverse/0.41.0/download"
+              ],
+              "strip_prefix": "gix-traverse-0.41.0",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.gix-traverse-0.41.0.bazel"
+            }
+          },
+          "cui__gix-url-0.27.5": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "fd280c5e84fb22e128ed2a053a0daeacb6379469be6a85e3d518a0636e160c89",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/gix-url/0.27.5/download"
+              ],
+              "strip_prefix": "gix-url-0.27.5",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.gix-url-0.27.5.bazel"
+            }
+          },
+          "cui__gix-utils-0.1.12": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "35192df7fd0fa112263bad8021e2df7167df4cc2a6e6d15892e1e55621d3d4dc",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/gix-utils/0.1.12/download"
+              ],
+              "strip_prefix": "gix-utils-0.1.12",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.gix-utils-0.1.12.bazel"
+            }
+          },
+          "cui__gix-validate-0.9.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "81f2badbb64e57b404593ee26b752c26991910fd0d81fe6f9a71c1a8309b6c86",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/gix-validate/0.9.0/download"
+              ],
+              "strip_prefix": "gix-validate-0.9.0",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.gix-validate-0.9.0.bazel"
+            }
+          },
+          "cui__gix-worktree-0.36.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "c312ad76a3f2ba8e865b360d5cb3aa04660971d16dec6dd0ce717938d903149a",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/gix-worktree/0.36.0/download"
+              ],
+              "strip_prefix": "gix-worktree-0.36.0",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.gix-worktree-0.36.0.bazel"
+            }
+          },
+          "cui__globset-0.4.11": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "1391ab1f92ffcc08911957149833e682aa3fe252b9f45f966d2ef972274c97df",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/globset/0.4.11/download"
+              ],
+              "strip_prefix": "globset-0.4.11",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.globset-0.4.11.bazel"
+            }
+          },
+          "cui__globwalk-0.8.1": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "93e3af942408868f6934a7b85134a3230832b9977cf66125df2f9edcfce4ddcc",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/globwalk/0.8.1/download"
+              ],
+              "strip_prefix": "globwalk-0.8.1",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.globwalk-0.8.1.bazel"
+            }
+          },
+          "cui__hashbrown-0.14.3": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/hashbrown/0.14.3/download"
+              ],
+              "strip_prefix": "hashbrown-0.14.3",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.hashbrown-0.14.3.bazel"
+            }
+          },
+          "cui__hashbrown-0.15.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "1e087f84d4f86bf4b218b927129862374b72199ae7d8657835f1e89000eea4fb",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/hashbrown/0.15.0/download"
+              ],
+              "strip_prefix": "hashbrown-0.15.0",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.hashbrown-0.15.0.bazel"
+            }
+          },
+          "cui__heck-0.4.1": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/heck/0.4.1/download"
+              ],
+              "strip_prefix": "heck-0.4.1",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.heck-0.4.1.bazel"
+            }
+          },
+          "cui__hermit-abi-0.3.2": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "443144c8cdadd93ebf52ddb4056d257f5b52c04d3c804e657d19eb73fc33668b",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/hermit-abi/0.3.2/download"
+              ],
+              "strip_prefix": "hermit-abi-0.3.2",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.hermit-abi-0.3.2.bazel"
+            }
+          },
+          "cui__hex-0.4.3": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/hex/0.4.3/download"
+              ],
+              "strip_prefix": "hex-0.4.3",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.hex-0.4.3.bazel"
+            }
+          },
+          "cui__home-0.5.5": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "5444c27eef6923071f7ebcc33e3444508466a76f7a2b93da00ed6e19f30c1ddb",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/home/0.5.5/download"
+              ],
+              "strip_prefix": "home-0.5.5",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.home-0.5.5.bazel"
+            }
+          },
+          "cui__idna-0.5.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "634d9b1461af396cad843f47fdba5597a4f9e6ddd4bfb6ff5d85028c25cb12f6",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/idna/0.5.0/download"
+              ],
+              "strip_prefix": "idna-0.5.0",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.idna-0.5.0.bazel"
+            }
+          },
+          "cui__ignore-0.4.18": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "713f1b139373f96a2e0ce3ac931cd01ee973c3c5dd7c40c0c2efe96ad2b6751d",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/ignore/0.4.18/download"
+              ],
+              "strip_prefix": "ignore-0.4.18",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.ignore-0.4.18.bazel"
+            }
+          },
+          "cui__indexmap-2.6.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "707907fe3c25f5424cce2cb7e1cbcafee6bdbe735ca90ef77c29e84591e5b9da",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/indexmap/2.6.0/download"
+              ],
+              "strip_prefix": "indexmap-2.6.0",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.indexmap-2.6.0.bazel"
+            }
+          },
+          "cui__indoc-2.0.5": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "b248f5224d1d606005e02c97f5aa4e88eeb230488bcc03bc9ca4d7991399f2b5",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/indoc/2.0.5/download"
+              ],
+              "strip_prefix": "indoc-2.0.5",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.indoc-2.0.5.bazel"
+            }
+          },
+          "cui__io-lifetimes-1.0.11": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/io-lifetimes/1.0.11/download"
+              ],
+              "strip_prefix": "io-lifetimes-1.0.11",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.io-lifetimes-1.0.11.bazel"
+            }
+          },
+          "cui__is-terminal-0.4.7": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "adcf93614601c8129ddf72e2d5633df827ba6551541c6d8c59520a371475be1f",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/is-terminal/0.4.7/download"
+              ],
+              "strip_prefix": "is-terminal-0.4.7",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.is-terminal-0.4.7.bazel"
+            }
+          },
+          "cui__itertools-0.13.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/itertools/0.13.0/download"
+              ],
+              "strip_prefix": "itertools-0.13.0",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.itertools-0.13.0.bazel"
+            }
+          },
+          "cui__itoa-1.0.8": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "62b02a5381cc465bd3041d84623d0fa3b66738b52b8e2fc3bab8ad63ab032f4a",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/itoa/1.0.8/download"
+              ],
+              "strip_prefix": "itoa-1.0.8",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.itoa-1.0.8.bazel"
+            }
+          },
+          "cui__jiff-0.1.13": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "8a45489186a6123c128fdf6016183fcfab7113e1820eb813127e036e287233fb",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/jiff/0.1.13/download"
+              ],
+              "strip_prefix": "jiff-0.1.13",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.jiff-0.1.13.bazel"
+            }
+          },
+          "cui__jiff-tzdb-0.1.1": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "91335e575850c5c4c673b9bd467b0e025f164ca59d0564f69d0c2ee0ffad4653",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/jiff-tzdb/0.1.1/download"
+              ],
+              "strip_prefix": "jiff-tzdb-0.1.1",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.jiff-tzdb-0.1.1.bazel"
+            }
+          },
+          "cui__jiff-tzdb-platform-0.1.1": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "9835f0060a626fe59f160437bc725491a6af23133ea906500027d1bd2f8f4329",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/jiff-tzdb-platform/0.1.1/download"
+              ],
+              "strip_prefix": "jiff-tzdb-platform-0.1.1",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.jiff-tzdb-platform-0.1.1.bazel"
+            }
+          },
+          "cui__kstring-2.0.2": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "558bf9508a558512042d3095138b1f7b8fe90c5467d94f9f1da28b3731c5dbd1",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/kstring/2.0.2/download"
+              ],
+              "strip_prefix": "kstring-2.0.2",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.kstring-2.0.2.bazel"
+            }
+          },
+          "cui__lazy_static-1.4.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/lazy_static/1.4.0/download"
+              ],
+              "strip_prefix": "lazy_static-1.4.0",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.lazy_static-1.4.0.bazel"
+            }
+          },
+          "cui__libc-0.2.161": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "8e9489c2807c139ffd9c1794f4af0ebe86a828db53ecdc7fea2111d0fed085d1",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/libc/0.2.161/download"
+              ],
+              "strip_prefix": "libc-0.2.161",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.libc-0.2.161.bazel"
+            }
+          },
+          "cui__linux-raw-sys-0.3.8": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/linux-raw-sys/0.3.8/download"
+              ],
+              "strip_prefix": "linux-raw-sys-0.3.8",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.linux-raw-sys-0.3.8.bazel"
+            }
+          },
+          "cui__linux-raw-sys-0.4.14": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/linux-raw-sys/0.4.14/download"
+              ],
+              "strip_prefix": "linux-raw-sys-0.4.14",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.linux-raw-sys-0.4.14.bazel"
+            }
+          },
+          "cui__lock_api-0.4.11": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "3c168f8615b12bc01f9c17e2eb0cc07dcae1940121185446edc3744920e8ef45",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/lock_api/0.4.11/download"
+              ],
+              "strip_prefix": "lock_api-0.4.11",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.lock_api-0.4.11.bazel"
+            }
+          },
+          "cui__log-0.4.19": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "b06a4cde4c0f271a446782e3eff8de789548ce57dbc8eca9292c27f4a42004b4",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/log/0.4.19/download"
+              ],
+              "strip_prefix": "log-0.4.19",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.log-0.4.19.bazel"
+            }
+          },
+          "cui__maplit-1.0.2": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/maplit/1.0.2/download"
+              ],
+              "strip_prefix": "maplit-1.0.2",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.maplit-1.0.2.bazel"
+            }
+          },
+          "cui__maybe-async-0.2.7": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "0f1b8c13cb1f814b634a96b2c725449fe7ed464a7b8781de8688be5ffbd3f305",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/maybe-async/0.2.7/download"
+              ],
+              "strip_prefix": "maybe-async-0.2.7",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.maybe-async-0.2.7.bazel"
+            }
+          },
+          "cui__memchr-2.6.4": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "f665ee40bc4a3c5590afb1e9677db74a508659dfd71e126420da8274909a0167",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/memchr/2.6.4/download"
+              ],
+              "strip_prefix": "memchr-2.6.4",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.memchr-2.6.4.bazel"
+            }
+          },
+          "cui__memmap2-0.9.5": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "fd3f7eed9d3848f8b98834af67102b720745c4ec028fcd0aa0239277e7de374f",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/memmap2/0.9.5/download"
+              ],
+              "strip_prefix": "memmap2-0.9.5",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.memmap2-0.9.5.bazel"
+            }
+          },
+          "cui__miniz_oxide-0.7.1": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "e7810e0be55b428ada41041c41f32c9f1a42817901b4ccf45fa3d4b6561e74c7",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/miniz_oxide/0.7.1/download"
+              ],
+              "strip_prefix": "miniz_oxide-0.7.1",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.miniz_oxide-0.7.1.bazel"
+            }
+          },
+          "cui__normpath-1.3.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "c8911957c4b1549ac0dc74e30db9c8b0e66ddcd6d7acc33098f4c63a64a6d7ed",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/normpath/1.3.0/download"
+              ],
+              "strip_prefix": "normpath-1.3.0",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.normpath-1.3.0.bazel"
+            }
+          },
+          "cui__nu-ansi-term-0.46.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/nu-ansi-term/0.46.0/download"
+              ],
+              "strip_prefix": "nu-ansi-term-0.46.0",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.nu-ansi-term-0.46.0.bazel"
+            }
+          },
+          "cui__once_cell-1.20.2": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/once_cell/1.20.2/download"
+              ],
+              "strip_prefix": "once_cell-1.20.2",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.once_cell-1.20.2.bazel"
+            }
+          },
+          "cui__overload-0.1.1": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/overload/0.1.1/download"
+              ],
+              "strip_prefix": "overload-0.1.1",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.overload-0.1.1.bazel"
+            }
+          },
+          "cui__parking_lot-0.12.1": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/parking_lot/0.12.1/download"
+              ],
+              "strip_prefix": "parking_lot-0.12.1",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.parking_lot-0.12.1.bazel"
+            }
+          },
+          "cui__parking_lot_core-0.9.9": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "4c42a9226546d68acdd9c0a280d17ce19bfe27a46bf68784e4066115788d008e",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/parking_lot_core/0.9.9/download"
+              ],
+              "strip_prefix": "parking_lot_core-0.9.9",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.parking_lot_core-0.9.9.bazel"
+            }
+          },
+          "cui__pathdiff-0.2.2": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "d61c5ce1153ab5b689d0c074c4e7fc613e942dfb7dd9eea5ab202d2ad91fe361",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/pathdiff/0.2.2/download"
+              ],
+              "strip_prefix": "pathdiff-0.2.2",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.pathdiff-0.2.2.bazel"
+            }
+          },
+          "cui__percent-encoding-2.3.1": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/percent-encoding/2.3.1/download"
+              ],
+              "strip_prefix": "percent-encoding-2.3.1",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.percent-encoding-2.3.1.bazel"
+            }
+          },
+          "cui__pest-2.7.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "f73935e4d55e2abf7f130186537b19e7a4abc886a0252380b59248af473a3fc9",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/pest/2.7.0/download"
+              ],
+              "strip_prefix": "pest-2.7.0",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.pest-2.7.0.bazel"
+            }
+          },
+          "cui__pest_derive-2.7.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "aef623c9bbfa0eedf5a0efba11a5ee83209c326653ca31ff019bec3a95bfff2b",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/pest_derive/2.7.0/download"
+              ],
+              "strip_prefix": "pest_derive-2.7.0",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.pest_derive-2.7.0.bazel"
+            }
+          },
+          "cui__pest_generator-2.7.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "b3e8cba4ec22bada7fc55ffe51e2deb6a0e0db2d0b7ab0b103acc80d2510c190",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/pest_generator/2.7.0/download"
+              ],
+              "strip_prefix": "pest_generator-2.7.0",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.pest_generator-2.7.0.bazel"
+            }
+          },
+          "cui__pest_meta-2.7.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "a01f71cb40bd8bb94232df14b946909e14660e33fc05db3e50ae2a82d7ea0ca0",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/pest_meta/2.7.0/download"
+              ],
+              "strip_prefix": "pest_meta-2.7.0",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.pest_meta-2.7.0.bazel"
+            }
+          },
+          "cui__pin-project-lite-0.2.13": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "8afb450f006bf6385ca15ef45d71d2288452bc3683ce2e2cacc0d18e4be60b58",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/pin-project-lite/0.2.13/download"
+              ],
+              "strip_prefix": "pin-project-lite-0.2.13",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.pin-project-lite-0.2.13.bazel"
+            }
+          },
+          "cui__proc-macro2-1.0.88": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "7c3a7fc5db1e57d5a779a352c8cdb57b29aa4c40cc69c3a68a7fedc815fbf2f9",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/proc-macro2/1.0.88/download"
+              ],
+              "strip_prefix": "proc-macro2-1.0.88",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.proc-macro2-1.0.88.bazel"
+            }
+          },
+          "cui__prodash-28.0.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "744a264d26b88a6a7e37cbad97953fa233b94d585236310bcbc88474b4092d79",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/prodash/28.0.0/download"
+              ],
+              "strip_prefix": "prodash-28.0.0",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.prodash-28.0.0.bazel"
+            }
+          },
+          "cui__quote-1.0.37": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/quote/1.0.37/download"
+              ],
+              "strip_prefix": "quote-1.0.37",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.quote-1.0.37.bazel"
+            }
+          },
+          "cui__redox_syscall-0.3.5": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/redox_syscall/0.3.5/download"
+              ],
+              "strip_prefix": "redox_syscall-0.3.5",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.redox_syscall-0.3.5.bazel"
+            }
+          },
+          "cui__redox_syscall-0.4.1": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/redox_syscall/0.4.1/download"
+              ],
+              "strip_prefix": "redox_syscall-0.4.1",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.redox_syscall-0.4.1.bazel"
+            }
+          },
+          "cui__regex-1.11.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "38200e5ee88914975b69f657f0801b6f6dccafd44fd9326302a4aaeecfacb1d8",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/regex/1.11.0/download"
+              ],
+              "strip_prefix": "regex-1.11.0",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.regex-1.11.0.bazel"
+            }
+          },
+          "cui__regex-automata-0.3.3": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "39354c10dd07468c2e73926b23bb9c2caca74c5501e38a35da70406f1d923310",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/regex-automata/0.3.3/download"
+              ],
+              "strip_prefix": "regex-automata-0.3.3",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.regex-automata-0.3.3.bazel"
+            }
+          },
+          "cui__regex-automata-0.4.8": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "368758f23274712b504848e9d5a6f010445cc8b87a7cdb4d7cbee666c1288da3",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/regex-automata/0.4.8/download"
+              ],
+              "strip_prefix": "regex-automata-0.4.8",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.regex-automata-0.4.8.bazel"
+            }
+          },
+          "cui__regex-syntax-0.8.5": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/regex-syntax/0.8.5/download"
+              ],
+              "strip_prefix": "regex-syntax-0.8.5",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.regex-syntax-0.8.5.bazel"
+            }
+          },
+          "cui__rustc-hash-2.0.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "583034fd73374156e66797ed8e5b0d5690409c9226b22d87cb7f19821c05d152",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/rustc-hash/2.0.0/download"
+              ],
+              "strip_prefix": "rustc-hash-2.0.0",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.rustc-hash-2.0.0.bazel"
+            }
+          },
+          "cui__rustix-0.37.23": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "4d69718bf81c6127a49dc64e44a742e8bb9213c0ff8869a22c308f84c1d4ab06",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/rustix/0.37.23/download"
+              ],
+              "strip_prefix": "rustix-0.37.23",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.rustix-0.37.23.bazel"
+            }
+          },
+          "cui__rustix-0.38.37": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "8acb788b847c24f28525660c4d7758620a7210875711f79e7f663cc152726811",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/rustix/0.38.37/download"
+              ],
+              "strip_prefix": "rustix-0.38.37",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.rustix-0.38.37.bazel"
+            }
+          },
+          "cui__ryu-1.0.14": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "fe232bdf6be8c8de797b22184ee71118d63780ea42ac85b61d1baa6d3b782ae9",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/ryu/1.0.14/download"
+              ],
+              "strip_prefix": "ryu-1.0.14",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.ryu-1.0.14.bazel"
+            }
+          },
+          "cui__same-file-1.0.6": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/same-file/1.0.6/download"
+              ],
+              "strip_prefix": "same-file-1.0.6",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.same-file-1.0.6.bazel"
+            }
+          },
+          "cui__scopeguard-1.2.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/scopeguard/1.2.0/download"
+              ],
+              "strip_prefix": "scopeguard-1.2.0",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.scopeguard-1.2.0.bazel"
+            }
+          },
+          "cui__semver-1.0.23": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/semver/1.0.23/download"
+              ],
+              "strip_prefix": "semver-1.0.23",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.semver-1.0.23.bazel"
+            }
+          },
+          "cui__serde-1.0.210": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "c8e3592472072e6e22e0a54d5904d9febf8508f65fb8552499a1abc7d1078c3a",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/serde/1.0.210/download"
+              ],
+              "strip_prefix": "serde-1.0.210",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.serde-1.0.210.bazel"
+            }
+          },
+          "cui__serde_derive-1.0.210": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "243902eda00fad750862fc144cea25caca5e20d615af0a81bee94ca738f1df1f",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/serde_derive/1.0.210/download"
+              ],
+              "strip_prefix": "serde_derive-1.0.210",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.serde_derive-1.0.210.bazel"
+            }
+          },
+          "cui__serde_json-1.0.129": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "6dbcf9b78a125ee667ae19388837dd12294b858d101fdd393cb9d5501ef09eb2",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/serde_json/1.0.129/download"
+              ],
+              "strip_prefix": "serde_json-1.0.129",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.serde_json-1.0.129.bazel"
+            }
+          },
+          "cui__serde_spanned-0.6.8": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "87607cb1398ed59d48732e575a4c28a7a8ebf2454b964fe3f224f2afc07909e1",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/serde_spanned/0.6.8/download"
+              ],
+              "strip_prefix": "serde_spanned-0.6.8",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.serde_spanned-0.6.8.bazel"
+            }
+          },
+          "cui__serde_starlark-0.1.16": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "43f25f26c1c853647016b862c1734e0ad68c4f9f752b5f792220d38b1369ed4a",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/serde_starlark/0.1.16/download"
+              ],
+              "strip_prefix": "serde_starlark-0.1.16",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.serde_starlark-0.1.16.bazel"
+            }
+          },
+          "cui__sha1_smol-1.0.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "ae1a47186c03a32177042e55dbc5fd5aee900b8e0069a8d70fba96a9375cd012",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/sha1_smol/1.0.0/download"
+              ],
+              "strip_prefix": "sha1_smol-1.0.0",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.sha1_smol-1.0.0.bazel"
+            }
+          },
+          "cui__sha2-0.10.8": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/sha2/0.10.8/download"
+              ],
+              "strip_prefix": "sha2-0.10.8",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.sha2-0.10.8.bazel"
+            }
+          },
+          "cui__sharded-slab-0.1.7": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/sharded-slab/0.1.7/download"
+              ],
+              "strip_prefix": "sharded-slab-0.1.7",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.sharded-slab-0.1.7.bazel"
+            }
+          },
+          "cui__shell-words-1.1.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "24188a676b6ae68c3b2cb3a01be17fbf7240ce009799bb56d5b1409051e78fde",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/shell-words/1.1.0/download"
+              ],
+              "strip_prefix": "shell-words-1.1.0",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.shell-words-1.1.0.bazel"
+            }
+          },
+          "cui__smallvec-1.11.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "62bb4feee49fdd9f707ef802e22365a35de4b7b299de4763d44bfea899442ff9",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/smallvec/1.11.0/download"
+              ],
+              "strip_prefix": "smallvec-1.11.0",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.smallvec-1.11.0.bazel"
+            }
+          },
+          "cui__smawk-0.3.1": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "f67ad224767faa3c7d8b6d91985b78e70a1324408abcb1cfcc2be4c06bc06043",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/smawk/0.3.1/download"
+              ],
+              "strip_prefix": "smawk-0.3.1",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.smawk-0.3.1.bazel"
+            }
+          },
+          "cui__smol_str-0.2.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "74212e6bbe9a4352329b2f68ba3130c15a3f26fe88ff22dbdc6cdd58fa85e99c",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/smol_str/0.2.0/download"
+              ],
+              "strip_prefix": "smol_str-0.2.0",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.smol_str-0.2.0.bazel"
+            }
+          },
+          "cui__spdx-0.10.6": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "47317bbaf63785b53861e1ae2d11b80d6b624211d42cb20efcd210ee6f8a14bc",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/spdx/0.10.6/download"
+              ],
+              "strip_prefix": "spdx-0.10.6",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.spdx-0.10.6.bazel"
+            }
+          },
+          "cui__static_assertions-1.1.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/static_assertions/1.1.0/download"
+              ],
+              "strip_prefix": "static_assertions-1.1.0",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.static_assertions-1.1.0.bazel"
+            }
+          },
+          "cui__strsim-0.10.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/strsim/0.10.0/download"
+              ],
+              "strip_prefix": "strsim-0.10.0",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.strsim-0.10.0.bazel"
+            }
+          },
+          "cui__syn-1.0.109": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/syn/1.0.109/download"
+              ],
+              "strip_prefix": "syn-1.0.109",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.syn-1.0.109.bazel"
+            }
+          },
+          "cui__syn-2.0.79": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "89132cd0bf050864e1d38dc3bbc07a0eb8e7530af26344d3d2bbbef83499f590",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/syn/2.0.79/download"
+              ],
+              "strip_prefix": "syn-2.0.79",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.syn-2.0.79.bazel"
+            }
+          },
+          "cui__tempfile-3.13.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "f0f2c9fc62d0beef6951ccffd757e241266a2c833136efbe35af6cd2567dca5b",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/tempfile/3.13.0/download"
+              ],
+              "strip_prefix": "tempfile-3.13.0",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.tempfile-3.13.0.bazel"
+            }
+          },
+          "cui__tera-1.19.1": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "970dff17c11e884a4a09bc76e3a17ef71e01bb13447a11e85226e254fe6d10b8",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/tera/1.19.1/download"
+              ],
+              "strip_prefix": "tera-1.19.1",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.tera-1.19.1.bazel"
+            }
+          },
+          "cui__textwrap-0.16.1": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "23d434d3f8967a09480fb04132ebe0a3e088c173e6d0ee7897abbdf4eab0f8b9",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/textwrap/0.16.1/download"
+              ],
+              "strip_prefix": "textwrap-0.16.1",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.textwrap-0.16.1.bazel"
+            }
+          },
+          "cui__thiserror-1.0.50": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "f9a7210f5c9a7156bb50aa36aed4c95afb51df0df00713949448cf9e97d382d2",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/thiserror/1.0.50/download"
+              ],
+              "strip_prefix": "thiserror-1.0.50",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.thiserror-1.0.50.bazel"
+            }
+          },
+          "cui__thiserror-impl-1.0.50": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "266b2e40bc00e5a6c09c3584011e08b06f123c00362c92b975ba9843aaaa14b8",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/thiserror-impl/1.0.50/download"
+              ],
+              "strip_prefix": "thiserror-impl-1.0.50",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.thiserror-impl-1.0.50.bazel"
+            }
+          },
+          "cui__thread_local-1.1.4": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "5516c27b78311c50bf42c071425c560ac799b11c30b31f87e3081965fe5e0180",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/thread_local/1.1.4/download"
+              ],
+              "strip_prefix": "thread_local-1.1.4",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.thread_local-1.1.4.bazel"
+            }
+          },
+          "cui__tinyvec-1.6.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "87cc5ceb3875bb20c2890005a4e226a4651264a5c75edb2421b52861a0a0cb50",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/tinyvec/1.6.0/download"
+              ],
+              "strip_prefix": "tinyvec-1.6.0",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.tinyvec-1.6.0.bazel"
+            }
+          },
+          "cui__tinyvec_macros-0.1.1": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/tinyvec_macros/0.1.1/download"
+              ],
+              "strip_prefix": "tinyvec_macros-0.1.1",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.tinyvec_macros-0.1.1.bazel"
+            }
+          },
+          "cui__toml-0.8.19": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "a1ed1f98e3fdc28d6d910e6737ae6ab1a93bf1985935a1193e68f93eeb68d24e",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/toml/0.8.19/download"
+              ],
+              "strip_prefix": "toml-0.8.19",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.toml-0.8.19.bazel"
+            }
+          },
+          "cui__toml_datetime-0.6.8": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/toml_datetime/0.6.8/download"
+              ],
+              "strip_prefix": "toml_datetime-0.6.8",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.toml_datetime-0.6.8.bazel"
+            }
+          },
+          "cui__toml_edit-0.22.22": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "4ae48d6208a266e853d946088ed816055e556cc6028c5e8e2b84d9fa5dd7c7f5",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/toml_edit/0.22.22/download"
+              ],
+              "strip_prefix": "toml_edit-0.22.22",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.toml_edit-0.22.22.bazel"
+            }
+          },
+          "cui__tracing-0.1.40": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/tracing/0.1.40/download"
+              ],
+              "strip_prefix": "tracing-0.1.40",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.tracing-0.1.40.bazel"
+            }
+          },
+          "cui__tracing-attributes-0.1.27": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/tracing-attributes/0.1.27/download"
+              ],
+              "strip_prefix": "tracing-attributes-0.1.27",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.tracing-attributes-0.1.27.bazel"
+            }
+          },
+          "cui__tracing-core-0.1.32": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/tracing-core/0.1.32/download"
+              ],
+              "strip_prefix": "tracing-core-0.1.32",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.tracing-core-0.1.32.bazel"
+            }
+          },
+          "cui__tracing-log-0.2.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/tracing-log/0.2.0/download"
+              ],
+              "strip_prefix": "tracing-log-0.2.0",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.tracing-log-0.2.0.bazel"
+            }
+          },
+          "cui__tracing-subscriber-0.3.18": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "ad0f048c97dbd9faa9b7df56362b8ebcaa52adb06b498c050d2f4e32f90a7a8b",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/tracing-subscriber/0.3.18/download"
+              ],
+              "strip_prefix": "tracing-subscriber-0.3.18",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.tracing-subscriber-0.3.18.bazel"
+            }
+          },
+          "cui__typenum-1.16.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/typenum/1.16.0/download"
+              ],
+              "strip_prefix": "typenum-1.16.0",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.typenum-1.16.0.bazel"
+            }
+          },
+          "cui__ucd-trie-0.1.6": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "ed646292ffc8188ef8ea4d1e0e0150fb15a5c2e12ad9b8fc191ae7a8a7f3c4b9",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/ucd-trie/0.1.6/download"
+              ],
+              "strip_prefix": "ucd-trie-0.1.6",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.ucd-trie-0.1.6.bazel"
+            }
+          },
+          "cui__uluru-3.0.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "794a32261a1f5eb6a4462c81b59cec87b5c27d5deea7dd1ac8fc781c41d226db",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/uluru/3.0.0/download"
+              ],
+              "strip_prefix": "uluru-3.0.0",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.uluru-3.0.0.bazel"
+            }
+          },
+          "cui__unic-char-property-0.9.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "a8c57a407d9b6fa02b4795eb81c5b6652060a15a7903ea981f3d723e6c0be221",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/unic-char-property/0.9.0/download"
+              ],
+              "strip_prefix": "unic-char-property-0.9.0",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.unic-char-property-0.9.0.bazel"
+            }
+          },
+          "cui__unic-char-range-0.9.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "0398022d5f700414f6b899e10b8348231abf9173fa93144cbc1a43b9793c1fbc",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/unic-char-range/0.9.0/download"
+              ],
+              "strip_prefix": "unic-char-range-0.9.0",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.unic-char-range-0.9.0.bazel"
+            }
+          },
+          "cui__unic-common-0.9.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "80d7ff825a6a654ee85a63e80f92f054f904f21e7d12da4e22f9834a4aaa35bc",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/unic-common/0.9.0/download"
+              ],
+              "strip_prefix": "unic-common-0.9.0",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.unic-common-0.9.0.bazel"
+            }
+          },
+          "cui__unic-segment-0.9.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "e4ed5d26be57f84f176157270c112ef57b86debac9cd21daaabbe56db0f88f23",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/unic-segment/0.9.0/download"
+              ],
+              "strip_prefix": "unic-segment-0.9.0",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.unic-segment-0.9.0.bazel"
+            }
+          },
+          "cui__unic-ucd-segment-0.9.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "2079c122a62205b421f499da10f3ee0f7697f012f55b675e002483c73ea34700",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/unic-ucd-segment/0.9.0/download"
+              ],
+              "strip_prefix": "unic-ucd-segment-0.9.0",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.unic-ucd-segment-0.9.0.bazel"
+            }
+          },
+          "cui__unic-ucd-version-0.9.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "96bd2f2237fe450fcd0a1d2f5f4e91711124f7857ba2e964247776ebeeb7b0c4",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/unic-ucd-version/0.9.0/download"
+              ],
+              "strip_prefix": "unic-ucd-version-0.9.0",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.unic-ucd-version-0.9.0.bazel"
+            }
+          },
+          "cui__unicode-bidi-0.3.13": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "92888ba5573ff080736b3648696b70cafad7d250551175acbaa4e0385b3e1460",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/unicode-bidi/0.3.13/download"
+              ],
+              "strip_prefix": "unicode-bidi-0.3.13",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.unicode-bidi-0.3.13.bazel"
+            }
+          },
+          "cui__unicode-bom-2.0.2": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "98e90c70c9f0d4d1ee6d0a7d04aa06cb9bbd53d8cfbdd62a0269a7c2eb640552",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/unicode-bom/2.0.2/download"
+              ],
+              "strip_prefix": "unicode-bom-2.0.2",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.unicode-bom-2.0.2.bazel"
+            }
+          },
+          "cui__unicode-ident-1.0.10": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "22049a19f4a68748a168c0fc439f9516686aa045927ff767eca0a85101fb6e73",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/unicode-ident/1.0.10/download"
+              ],
+              "strip_prefix": "unicode-ident-1.0.10",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.unicode-ident-1.0.10.bazel"
+            }
+          },
+          "cui__unicode-linebreak-0.1.5": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "3b09c83c3c29d37506a3e260c08c03743a6bb66a9cd432c6934ab501a190571f",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/unicode-linebreak/0.1.5/download"
+              ],
+              "strip_prefix": "unicode-linebreak-0.1.5",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.unicode-linebreak-0.1.5.bazel"
+            }
+          },
+          "cui__unicode-normalization-0.1.22": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/unicode-normalization/0.1.22/download"
+              ],
+              "strip_prefix": "unicode-normalization-0.1.22",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.unicode-normalization-0.1.22.bazel"
+            }
+          },
+          "cui__unicode-width-0.1.10": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/unicode-width/0.1.10/download"
+              ],
+              "strip_prefix": "unicode-width-0.1.10",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.unicode-width-0.1.10.bazel"
+            }
+          },
+          "cui__url-2.5.2": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "22784dbdf76fdde8af1aeda5622b546b422b6fc585325248a2bf9f5e41e94d6c",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/url/2.5.2/download"
+              ],
+              "strip_prefix": "url-2.5.2",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.url-2.5.2.bazel"
+            }
+          },
+          "cui__utf8parse-0.2.1": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/utf8parse/0.2.1/download"
+              ],
+              "strip_prefix": "utf8parse-0.2.1",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.utf8parse-0.2.1.bazel"
+            }
+          },
+          "cui__valuable-0.1.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/valuable/0.1.0/download"
+              ],
+              "strip_prefix": "valuable-0.1.0",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.valuable-0.1.0.bazel"
+            }
+          },
+          "cui__version_check-0.9.4": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/version_check/0.9.4/download"
+              ],
+              "strip_prefix": "version_check-0.9.4",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.version_check-0.9.4.bazel"
+            }
+          },
+          "cui__walkdir-2.3.3": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "36df944cda56c7d8d8b7496af378e6b16de9284591917d307c9b4d313c44e698",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/walkdir/2.3.3/download"
+              ],
+              "strip_prefix": "walkdir-2.3.3",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.walkdir-2.3.3.bazel"
+            }
+          },
+          "cui__winapi-0.3.9": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/winapi/0.3.9/download"
+              ],
+              "strip_prefix": "winapi-0.3.9",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.winapi-0.3.9.bazel"
+            }
+          },
+          "cui__winapi-i686-pc-windows-gnu-0.4.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/winapi-i686-pc-windows-gnu/0.4.0/download"
+              ],
+              "strip_prefix": "winapi-i686-pc-windows-gnu-0.4.0",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.winapi-i686-pc-windows-gnu-0.4.0.bazel"
+            }
+          },
+          "cui__winapi-util-0.1.5": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/winapi-util/0.1.5/download"
+              ],
+              "strip_prefix": "winapi-util-0.1.5",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.winapi-util-0.1.5.bazel"
+            }
+          },
+          "cui__winapi-x86_64-pc-windows-gnu-0.4.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/winapi-x86_64-pc-windows-gnu/0.4.0/download"
+              ],
+              "strip_prefix": "winapi-x86_64-pc-windows-gnu-0.4.0",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.winapi-x86_64-pc-windows-gnu-0.4.0.bazel"
+            }
+          },
+          "cui__windows-sys-0.48.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/windows-sys/0.48.0/download"
+              ],
+              "strip_prefix": "windows-sys-0.48.0",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.windows-sys-0.48.0.bazel"
+            }
+          },
+          "cui__windows-sys-0.52.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/windows-sys/0.52.0/download"
+              ],
+              "strip_prefix": "windows-sys-0.52.0",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.windows-sys-0.52.0.bazel"
+            }
+          },
+          "cui__windows-sys-0.59.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/windows-sys/0.59.0/download"
+              ],
+              "strip_prefix": "windows-sys-0.59.0",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.windows-sys-0.59.0.bazel"
+            }
+          },
+          "cui__windows-targets-0.48.1": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "05d4b17490f70499f20b9e791dcf6a299785ce8af4d709018206dc5b4953e95f",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/windows-targets/0.48.1/download"
+              ],
+              "strip_prefix": "windows-targets-0.48.1",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.windows-targets-0.48.1.bazel"
+            }
+          },
+          "cui__windows-targets-0.52.6": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/windows-targets/0.52.6/download"
+              ],
+              "strip_prefix": "windows-targets-0.52.6",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.windows-targets-0.52.6.bazel"
+            }
+          },
+          "cui__windows_aarch64_gnullvm-0.48.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "91ae572e1b79dba883e0d315474df7305d12f569b400fcf90581b06062f7e1bc",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/windows_aarch64_gnullvm/0.48.0/download"
+              ],
+              "strip_prefix": "windows_aarch64_gnullvm-0.48.0",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.windows_aarch64_gnullvm-0.48.0.bazel"
+            }
+          },
+          "cui__windows_aarch64_gnullvm-0.52.6": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/windows_aarch64_gnullvm/0.52.6/download"
+              ],
+              "strip_prefix": "windows_aarch64_gnullvm-0.52.6",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.windows_aarch64_gnullvm-0.52.6.bazel"
+            }
+          },
+          "cui__windows_aarch64_msvc-0.48.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "b2ef27e0d7bdfcfc7b868b317c1d32c641a6fe4629c171b8928c7b08d98d7cf3",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/windows_aarch64_msvc/0.48.0/download"
+              ],
+              "strip_prefix": "windows_aarch64_msvc-0.48.0",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.windows_aarch64_msvc-0.48.0.bazel"
+            }
+          },
+          "cui__windows_aarch64_msvc-0.52.6": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/windows_aarch64_msvc/0.52.6/download"
+              ],
+              "strip_prefix": "windows_aarch64_msvc-0.52.6",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.windows_aarch64_msvc-0.52.6.bazel"
+            }
+          },
+          "cui__windows_i686_gnu-0.48.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "622a1962a7db830d6fd0a69683c80a18fda201879f0f447f065a3b7467daa241",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/windows_i686_gnu/0.48.0/download"
+              ],
+              "strip_prefix": "windows_i686_gnu-0.48.0",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.windows_i686_gnu-0.48.0.bazel"
+            }
+          },
+          "cui__windows_i686_gnu-0.52.6": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/windows_i686_gnu/0.52.6/download"
+              ],
+              "strip_prefix": "windows_i686_gnu-0.52.6",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.windows_i686_gnu-0.52.6.bazel"
+            }
+          },
+          "cui__windows_i686_gnullvm-0.52.6": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/windows_i686_gnullvm/0.52.6/download"
+              ],
+              "strip_prefix": "windows_i686_gnullvm-0.52.6",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.windows_i686_gnullvm-0.52.6.bazel"
+            }
+          },
+          "cui__windows_i686_msvc-0.48.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "4542c6e364ce21bf45d69fdd2a8e455fa38d316158cfd43b3ac1c5b1b19f8e00",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/windows_i686_msvc/0.48.0/download"
+              ],
+              "strip_prefix": "windows_i686_msvc-0.48.0",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.windows_i686_msvc-0.48.0.bazel"
+            }
+          },
+          "cui__windows_i686_msvc-0.52.6": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/windows_i686_msvc/0.52.6/download"
+              ],
+              "strip_prefix": "windows_i686_msvc-0.52.6",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.windows_i686_msvc-0.52.6.bazel"
+            }
+          },
+          "cui__windows_x86_64_gnu-0.48.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "ca2b8a661f7628cbd23440e50b05d705db3686f894fc9580820623656af974b1",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/windows_x86_64_gnu/0.48.0/download"
+              ],
+              "strip_prefix": "windows_x86_64_gnu-0.48.0",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.windows_x86_64_gnu-0.48.0.bazel"
+            }
+          },
+          "cui__windows_x86_64_gnu-0.52.6": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/windows_x86_64_gnu/0.52.6/download"
+              ],
+              "strip_prefix": "windows_x86_64_gnu-0.52.6",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.windows_x86_64_gnu-0.52.6.bazel"
+            }
+          },
+          "cui__windows_x86_64_gnullvm-0.48.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "7896dbc1f41e08872e9d5e8f8baa8fdd2677f29468c4e156210174edc7f7b953",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/windows_x86_64_gnullvm/0.48.0/download"
+              ],
+              "strip_prefix": "windows_x86_64_gnullvm-0.48.0",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.windows_x86_64_gnullvm-0.48.0.bazel"
+            }
+          },
+          "cui__windows_x86_64_gnullvm-0.52.6": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/windows_x86_64_gnullvm/0.52.6/download"
+              ],
+              "strip_prefix": "windows_x86_64_gnullvm-0.52.6",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.windows_x86_64_gnullvm-0.52.6.bazel"
+            }
+          },
+          "cui__windows_x86_64_msvc-0.48.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/windows_x86_64_msvc/0.48.0/download"
+              ],
+              "strip_prefix": "windows_x86_64_msvc-0.48.0",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.windows_x86_64_msvc-0.48.0.bazel"
+            }
+          },
+          "cui__windows_x86_64_msvc-0.52.6": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/windows_x86_64_msvc/0.52.6/download"
+              ],
+              "strip_prefix": "windows_x86_64_msvc-0.52.6",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.windows_x86_64_msvc-0.52.6.bazel"
+            }
+          },
+          "cui__winnow-0.6.20": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "36c1fec1a2bb5866f07c25f68c26e565c4c200aebb96d7e55710c19d3e8ac49b",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/winnow/0.6.20/download"
+              ],
+              "strip_prefix": "winnow-0.6.20",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.winnow-0.6.20.bazel"
+            }
+          },
+          "cui__zerocopy-0.7.35": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/zerocopy/0.7.35/download"
+              ],
+              "strip_prefix": "zerocopy-0.7.35",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.zerocopy-0.7.35.bazel"
+            }
+          },
+          "cui__zerocopy-derive-0.7.35": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/zerocopy-derive/0.7.35/download"
+              ],
+              "strip_prefix": "zerocopy-derive-0.7.35",
+              "build_file": "@@rules_rust+//crate_universe/3rdparty/crates:BUILD.zerocopy-derive-0.7.35.bazel"
+            }
+          },
+          "cargo_bazel.buildifier-darwin-amd64": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
+            "attributes": {
+              "urls": [
+                "https://github.com/bazelbuild/buildtools/releases/download/v7.3.1/buildifier-darwin-amd64"
+              ],
+              "integrity": "sha256-N1+CMQPQFiCq7CCgwpxsvKmfT9ByWuMLk2VcZwT0TXE=",
+              "downloaded_file_path": "buildifier",
+              "executable": true
+            }
+          },
+          "cargo_bazel.buildifier-darwin-arm64": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
+            "attributes": {
+              "urls": [
+                "https://github.com/bazelbuild/buildtools/releases/download/v7.3.1/buildifier-darwin-arm64"
+              ],
+              "integrity": "sha256-Wmr8asegn1RVuguJvZnVriO0F03F3J1sDtXOjKrD+BM=",
+              "downloaded_file_path": "buildifier",
+              "executable": true
+            }
+          },
+          "cargo_bazel.buildifier-linux-amd64": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
+            "attributes": {
+              "urls": [
+                "https://github.com/bazelbuild/buildtools/releases/download/v7.3.1/buildifier-linux-amd64"
+              ],
+              "integrity": "sha256-VHTMUSinToBng9VAgfWBZixL6K5lAi9VfpKB7V3IgAk=",
+              "downloaded_file_path": "buildifier",
+              "executable": true
+            }
+          },
+          "cargo_bazel.buildifier-linux-arm64": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
+            "attributes": {
+              "urls": [
+                "https://github.com/bazelbuild/buildtools/releases/download/v7.3.1/buildifier-linux-arm64"
+              ],
+              "integrity": "sha256-C/hsS//69PCO7Xe95bIILkrlA5oR4uiwOYTBc8NKVhw=",
+              "downloaded_file_path": "buildifier",
+              "executable": true
+            }
+          },
+          "cargo_bazel.buildifier-linux-s390x": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
+            "attributes": {
+              "urls": [
+                "https://github.com/bazelbuild/buildtools/releases/download/v7.3.1/buildifier-linux-s390x"
+              ],
+              "integrity": "sha256-4tef9YhdRSdPdlMfGtvHtzoSn1nnZ/d36PveYz2dTi4=",
+              "downloaded_file_path": "buildifier",
+              "executable": true
+            }
+          },
+          "cargo_bazel.buildifier-windows-amd64.exe": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
+            "attributes": {
+              "urls": [
+                "https://github.com/bazelbuild/buildtools/releases/download/v7.3.1/buildifier-windows-amd64.exe"
+              ],
+              "integrity": "sha256-NwzVdgda0pkwqC9d4TLxod5AhMeEqCUUvU2oDIWs9Kg=",
+              "downloaded_file_path": "buildifier.exe",
+              "executable": true
+            }
+          },
+          "rules_rust_prost": {
+            "repoRuleId": "@@rules_rust+//crate_universe/private:crates_vendor.bzl%crates_vendor_remote_repository",
+            "attributes": {
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.bazel",
+              "defs_module": "@@rules_rust+//proto/prost/private/3rdparty/crates:defs.bzl"
+            }
+          },
+          "rules_rust_prost__addr2line-0.22.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "6e4503c46a5c0c7844e948c9a4d6acd9f50cccb4de1c48eb9e291ea17470c678",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/addr2line/0.22.0/download"
+              ],
+              "strip_prefix": "addr2line-0.22.0",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.addr2line-0.22.0.bazel"
+            }
+          },
+          "rules_rust_prost__adler-1.0.2": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/adler/1.0.2/download"
+              ],
+              "strip_prefix": "adler-1.0.2",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.adler-1.0.2.bazel"
+            }
+          },
+          "rules_rust_prost__aho-corasick-1.1.3": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/aho-corasick/1.1.3/download"
+              ],
+              "strip_prefix": "aho-corasick-1.1.3",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.aho-corasick-1.1.3.bazel"
+            }
+          },
+          "rules_rust_prost__anyhow-1.0.86": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "b3d1d046238990b9cf5bcde22a3fb3584ee5cf65fb2765f454ed428c7a0063da",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/anyhow/1.0.86/download"
+              ],
+              "strip_prefix": "anyhow-1.0.86",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.anyhow-1.0.86.bazel"
+            }
+          },
+          "rules_rust_prost__async-stream-0.3.5": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "cd56dd203fef61ac097dd65721a419ddccb106b2d2b70ba60a6b529f03961a51",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/async-stream/0.3.5/download"
+              ],
+              "strip_prefix": "async-stream-0.3.5",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.async-stream-0.3.5.bazel"
+            }
+          },
+          "rules_rust_prost__async-stream-impl-0.3.5": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/async-stream-impl/0.3.5/download"
+              ],
+              "strip_prefix": "async-stream-impl-0.3.5",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.async-stream-impl-0.3.5.bazel"
+            }
+          },
+          "rules_rust_prost__async-trait-0.1.81": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "6e0c28dcc82d7c8ead5cb13beb15405b57b8546e93215673ff8ca0349a028107",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/async-trait/0.1.81/download"
+              ],
+              "strip_prefix": "async-trait-0.1.81",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.async-trait-0.1.81.bazel"
+            }
+          },
+          "rules_rust_prost__atomic-waker-1.1.2": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/atomic-waker/1.1.2/download"
+              ],
+              "strip_prefix": "atomic-waker-1.1.2",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.atomic-waker-1.1.2.bazel"
+            }
+          },
+          "rules_rust_prost__autocfg-1.3.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/autocfg/1.3.0/download"
+              ],
+              "strip_prefix": "autocfg-1.3.0",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.autocfg-1.3.0.bazel"
+            }
+          },
+          "rules_rust_prost__axum-0.7.5": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "3a6c9af12842a67734c9a2e355436e5d03b22383ed60cf13cd0c18fbfe3dcbcf",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/axum/0.7.5/download"
+              ],
+              "strip_prefix": "axum-0.7.5",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.axum-0.7.5.bazel"
+            }
+          },
+          "rules_rust_prost__axum-core-0.4.3": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "a15c63fd72d41492dc4f497196f5da1fb04fb7529e631d73630d1b491e47a2e3",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/axum-core/0.4.3/download"
+              ],
+              "strip_prefix": "axum-core-0.4.3",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.axum-core-0.4.3.bazel"
+            }
+          },
+          "rules_rust_prost__backtrace-0.3.73": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "5cc23269a4f8976d0a4d2e7109211a419fe30e8d88d677cd60b6bc79c5732e0a",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/backtrace/0.3.73/download"
+              ],
+              "strip_prefix": "backtrace-0.3.73",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.backtrace-0.3.73.bazel"
+            }
+          },
+          "rules_rust_prost__base64-0.22.1": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/base64/0.22.1/download"
+              ],
+              "strip_prefix": "base64-0.22.1",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.base64-0.22.1.bazel"
+            }
+          },
+          "rules_rust_prost__bitflags-2.6.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/bitflags/2.6.0/download"
+              ],
+              "strip_prefix": "bitflags-2.6.0",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.bitflags-2.6.0.bazel"
+            }
+          },
+          "rules_rust_prost__byteorder-1.5.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/byteorder/1.5.0/download"
+              ],
+              "strip_prefix": "byteorder-1.5.0",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.byteorder-1.5.0.bazel"
+            }
+          },
+          "rules_rust_prost__bytes-1.7.1": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "8318a53db07bb3f8dca91a600466bdb3f2eaadeedfdbcf02e1accbad9271ba50",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/bytes/1.7.1/download"
+              ],
+              "strip_prefix": "bytes-1.7.1",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.bytes-1.7.1.bazel"
+            }
+          },
+          "rules_rust_prost__cc-1.1.14": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "50d2eb3cd3d1bf4529e31c215ee6f93ec5a3d536d9f578f93d9d33ee19562932",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/cc/1.1.14/download"
+              ],
+              "strip_prefix": "cc-1.1.14",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.cc-1.1.14.bazel"
+            }
+          },
+          "rules_rust_prost__cfg-if-1.0.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/cfg-if/1.0.0/download"
+              ],
+              "strip_prefix": "cfg-if-1.0.0",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.cfg-if-1.0.0.bazel"
+            }
+          },
+          "rules_rust_prost__either-1.13.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/either/1.13.0/download"
+              ],
+              "strip_prefix": "either-1.13.0",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.either-1.13.0.bazel"
+            }
+          },
+          "rules_rust_prost__equivalent-1.0.1": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/equivalent/1.0.1/download"
+              ],
+              "strip_prefix": "equivalent-1.0.1",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.equivalent-1.0.1.bazel"
+            }
+          },
+          "rules_rust_prost__errno-0.3.9": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "534c5cf6194dfab3db3242765c03bbe257cf92f22b38f6bc0c58d59108a820ba",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/errno/0.3.9/download"
+              ],
+              "strip_prefix": "errno-0.3.9",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.errno-0.3.9.bazel"
+            }
+          },
+          "rules_rust_prost__fastrand-2.1.1": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "e8c02a5121d4ea3eb16a80748c74f5549a5665e4c21333c6098f283870fbdea6",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/fastrand/2.1.1/download"
+              ],
+              "strip_prefix": "fastrand-2.1.1",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.fastrand-2.1.1.bazel"
+            }
+          },
+          "rules_rust_prost__fixedbitset-0.4.2": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/fixedbitset/0.4.2/download"
+              ],
+              "strip_prefix": "fixedbitset-0.4.2",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.fixedbitset-0.4.2.bazel"
+            }
+          },
+          "rules_rust_prost__fnv-1.0.7": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/fnv/1.0.7/download"
+              ],
+              "strip_prefix": "fnv-1.0.7",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.fnv-1.0.7.bazel"
+            }
+          },
+          "rules_rust_prost__futures-channel-0.3.30": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "eac8f7d7865dcb88bd4373ab671c8cf4508703796caa2b1985a9ca867b3fcb78",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/futures-channel/0.3.30/download"
+              ],
+              "strip_prefix": "futures-channel-0.3.30",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.futures-channel-0.3.30.bazel"
+            }
+          },
+          "rules_rust_prost__futures-core-0.3.30": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "dfc6580bb841c5a68e9ef15c77ccc837b40a7504914d52e47b8b0e9bbda25a1d",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/futures-core/0.3.30/download"
+              ],
+              "strip_prefix": "futures-core-0.3.30",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.futures-core-0.3.30.bazel"
+            }
+          },
+          "rules_rust_prost__futures-sink-0.3.30": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "9fb8e00e87438d937621c1c6269e53f536c14d3fbd6a042bb24879e57d474fb5",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/futures-sink/0.3.30/download"
+              ],
+              "strip_prefix": "futures-sink-0.3.30",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.futures-sink-0.3.30.bazel"
+            }
+          },
+          "rules_rust_prost__futures-task-0.3.30": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "38d84fa142264698cdce1a9f9172cf383a0c82de1bddcf3092901442c4097004",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/futures-task/0.3.30/download"
+              ],
+              "strip_prefix": "futures-task-0.3.30",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.futures-task-0.3.30.bazel"
+            }
+          },
+          "rules_rust_prost__futures-util-0.3.30": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "3d6401deb83407ab3da39eba7e33987a73c3df0c82b4bb5813ee871c19c41d48",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/futures-util/0.3.30/download"
+              ],
+              "strip_prefix": "futures-util-0.3.30",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.futures-util-0.3.30.bazel"
+            }
+          },
+          "rules_rust_prost__getrandom-0.2.15": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/getrandom/0.2.15/download"
+              ],
+              "strip_prefix": "getrandom-0.2.15",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.getrandom-0.2.15.bazel"
+            }
+          },
+          "rules_rust_prost__gimli-0.29.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "40ecd4077b5ae9fd2e9e169b102c6c330d0605168eb0e8bf79952b256dbefffd",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/gimli/0.29.0/download"
+              ],
+              "strip_prefix": "gimli-0.29.0",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.gimli-0.29.0.bazel"
+            }
+          },
+          "rules_rust_prost__h2-0.4.6": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "524e8ac6999421f49a846c2d4411f337e53497d8ec55d67753beffa43c5d9205",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/h2/0.4.6/download"
+              ],
+              "strip_prefix": "h2-0.4.6",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.h2-0.4.6.bazel"
+            }
+          },
+          "rules_rust_prost__hashbrown-0.12.3": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/hashbrown/0.12.3/download"
+              ],
+              "strip_prefix": "hashbrown-0.12.3",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.hashbrown-0.12.3.bazel"
+            }
+          },
+          "rules_rust_prost__hashbrown-0.14.5": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/hashbrown/0.14.5/download"
+              ],
+              "strip_prefix": "hashbrown-0.14.5",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.hashbrown-0.14.5.bazel"
+            }
+          },
+          "rules_rust_prost__heck-0.5.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/heck/0.5.0/download"
+              ],
+              "strip_prefix": "heck-0.5.0",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.heck-0.5.0.bazel"
+            }
+          },
+          "rules_rust_prost__hermit-abi-0.3.9": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/hermit-abi/0.3.9/download"
+              ],
+              "strip_prefix": "hermit-abi-0.3.9",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.hermit-abi-0.3.9.bazel"
+            }
+          },
+          "rules_rust_prost__http-1.1.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "21b9ddb458710bc376481b842f5da65cdf31522de232c1ca8146abce2a358258",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/http/1.1.0/download"
+              ],
+              "strip_prefix": "http-1.1.0",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.http-1.1.0.bazel"
+            }
+          },
+          "rules_rust_prost__http-body-1.0.1": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/http-body/1.0.1/download"
+              ],
+              "strip_prefix": "http-body-1.0.1",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.http-body-1.0.1.bazel"
+            }
+          },
+          "rules_rust_prost__http-body-util-0.1.2": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "793429d76616a256bcb62c2a2ec2bed781c8307e797e2598c50010f2bee2544f",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/http-body-util/0.1.2/download"
+              ],
+              "strip_prefix": "http-body-util-0.1.2",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.http-body-util-0.1.2.bazel"
+            }
+          },
+          "rules_rust_prost__httparse-1.9.4": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "0fcc0b4a115bf80b728eb8ea024ad5bd707b615bfed49e0665b6e0f86fd082d9",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/httparse/1.9.4/download"
+              ],
+              "strip_prefix": "httparse-1.9.4",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.httparse-1.9.4.bazel"
+            }
+          },
+          "rules_rust_prost__httpdate-1.0.3": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/httpdate/1.0.3/download"
+              ],
+              "strip_prefix": "httpdate-1.0.3",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.httpdate-1.0.3.bazel"
+            }
+          },
+          "rules_rust_prost__hyper-1.4.1": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "50dfd22e0e76d0f662d429a5f80fcaf3855009297eab6a0a9f8543834744ba05",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/hyper/1.4.1/download"
+              ],
+              "strip_prefix": "hyper-1.4.1",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.hyper-1.4.1.bazel"
+            }
+          },
+          "rules_rust_prost__hyper-timeout-0.5.1": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "3203a961e5c83b6f5498933e78b6b263e208c197b63e9c6c53cc82ffd3f63793",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/hyper-timeout/0.5.1/download"
+              ],
+              "strip_prefix": "hyper-timeout-0.5.1",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.hyper-timeout-0.5.1.bazel"
+            }
+          },
+          "rules_rust_prost__hyper-util-0.1.7": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "cde7055719c54e36e95e8719f95883f22072a48ede39db7fc17a4e1d5281e9b9",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/hyper-util/0.1.7/download"
+              ],
+              "strip_prefix": "hyper-util-0.1.7",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.hyper-util-0.1.7.bazel"
+            }
+          },
+          "rules_rust_prost__indexmap-1.9.3": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/indexmap/1.9.3/download"
+              ],
+              "strip_prefix": "indexmap-1.9.3",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.indexmap-1.9.3.bazel"
+            }
+          },
+          "rules_rust_prost__indexmap-2.4.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "93ead53efc7ea8ed3cfb0c79fc8023fbb782a5432b52830b6518941cebe6505c",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/indexmap/2.4.0/download"
+              ],
+              "strip_prefix": "indexmap-2.4.0",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.indexmap-2.4.0.bazel"
+            }
+          },
+          "rules_rust_prost__itertools-0.13.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/itertools/0.13.0/download"
+              ],
+              "strip_prefix": "itertools-0.13.0",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.itertools-0.13.0.bazel"
+            }
+          },
+          "rules_rust_prost__itoa-1.0.11": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/itoa/1.0.11/download"
+              ],
+              "strip_prefix": "itoa-1.0.11",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.itoa-1.0.11.bazel"
+            }
+          },
+          "rules_rust_prost__libc-0.2.158": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "d8adc4bb1803a324070e64a98ae98f38934d91957a99cfb3a43dcbc01bc56439",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/libc/0.2.158/download"
+              ],
+              "strip_prefix": "libc-0.2.158",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.libc-0.2.158.bazel"
+            }
+          },
+          "rules_rust_prost__linux-raw-sys-0.4.14": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/linux-raw-sys/0.4.14/download"
+              ],
+              "strip_prefix": "linux-raw-sys-0.4.14",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.linux-raw-sys-0.4.14.bazel"
+            }
+          },
+          "rules_rust_prost__lock_api-0.4.12": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/lock_api/0.4.12/download"
+              ],
+              "strip_prefix": "lock_api-0.4.12",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.lock_api-0.4.12.bazel"
+            }
+          },
+          "rules_rust_prost__log-0.4.22": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/log/0.4.22/download"
+              ],
+              "strip_prefix": "log-0.4.22",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.log-0.4.22.bazel"
+            }
+          },
+          "rules_rust_prost__matchit-0.7.3": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/matchit/0.7.3/download"
+              ],
+              "strip_prefix": "matchit-0.7.3",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.matchit-0.7.3.bazel"
+            }
+          },
+          "rules_rust_prost__memchr-2.7.4": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/memchr/2.7.4/download"
+              ],
+              "strip_prefix": "memchr-2.7.4",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.memchr-2.7.4.bazel"
+            }
+          },
+          "rules_rust_prost__mime-0.3.17": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/mime/0.3.17/download"
+              ],
+              "strip_prefix": "mime-0.3.17",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.mime-0.3.17.bazel"
+            }
+          },
+          "rules_rust_prost__miniz_oxide-0.7.4": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "b8a240ddb74feaf34a79a7add65a741f3167852fba007066dcac1ca548d89c08",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/miniz_oxide/0.7.4/download"
+              ],
+              "strip_prefix": "miniz_oxide-0.7.4",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.miniz_oxide-0.7.4.bazel"
+            }
+          },
+          "rules_rust_prost__mio-1.0.2": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "80e04d1dcff3aae0704555fe5fee3bcfaf3d1fdf8a7e521d5b9d2b42acb52cec",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/mio/1.0.2/download"
+              ],
+              "strip_prefix": "mio-1.0.2",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.mio-1.0.2.bazel"
+            }
+          },
+          "rules_rust_prost__multimap-0.10.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "defc4c55412d89136f966bbb339008b474350e5e6e78d2714439c386b3137a03",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/multimap/0.10.0/download"
+              ],
+              "strip_prefix": "multimap-0.10.0",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.multimap-0.10.0.bazel"
+            }
+          },
+          "rules_rust_prost__object-0.36.3": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "27b64972346851a39438c60b341ebc01bba47464ae329e55cf343eb93964efd9",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/object/0.36.3/download"
+              ],
+              "strip_prefix": "object-0.36.3",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.object-0.36.3.bazel"
+            }
+          },
+          "rules_rust_prost__once_cell-1.19.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/once_cell/1.19.0/download"
+              ],
+              "strip_prefix": "once_cell-1.19.0",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.once_cell-1.19.0.bazel"
+            }
+          },
+          "rules_rust_prost__parking_lot-0.12.3": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/parking_lot/0.12.3/download"
+              ],
+              "strip_prefix": "parking_lot-0.12.3",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.parking_lot-0.12.3.bazel"
+            }
+          },
+          "rules_rust_prost__parking_lot_core-0.9.10": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/parking_lot_core/0.9.10/download"
+              ],
+              "strip_prefix": "parking_lot_core-0.9.10",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.parking_lot_core-0.9.10.bazel"
+            }
+          },
+          "rules_rust_prost__percent-encoding-2.3.1": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/percent-encoding/2.3.1/download"
+              ],
+              "strip_prefix": "percent-encoding-2.3.1",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.percent-encoding-2.3.1.bazel"
+            }
+          },
+          "rules_rust_prost__petgraph-0.6.5": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/petgraph/0.6.5/download"
+              ],
+              "strip_prefix": "petgraph-0.6.5",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.petgraph-0.6.5.bazel"
+            }
+          },
+          "rules_rust_prost__pin-project-1.1.5": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "b6bf43b791c5b9e34c3d182969b4abb522f9343702850a2e57f460d00d09b4b3",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/pin-project/1.1.5/download"
+              ],
+              "strip_prefix": "pin-project-1.1.5",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.pin-project-1.1.5.bazel"
+            }
+          },
+          "rules_rust_prost__pin-project-internal-1.1.5": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/pin-project-internal/1.1.5/download"
+              ],
+              "strip_prefix": "pin-project-internal-1.1.5",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.pin-project-internal-1.1.5.bazel"
+            }
+          },
+          "rules_rust_prost__pin-project-lite-0.2.14": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "bda66fc9667c18cb2758a2ac84d1167245054bcf85d5d1aaa6923f45801bdd02",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/pin-project-lite/0.2.14/download"
+              ],
+              "strip_prefix": "pin-project-lite-0.2.14",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.pin-project-lite-0.2.14.bazel"
+            }
+          },
+          "rules_rust_prost__pin-utils-0.1.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/pin-utils/0.1.0/download"
+              ],
+              "strip_prefix": "pin-utils-0.1.0",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.pin-utils-0.1.0.bazel"
+            }
+          },
+          "rules_rust_prost__ppv-lite86-0.2.20": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/ppv-lite86/0.2.20/download"
+              ],
+              "strip_prefix": "ppv-lite86-0.2.20",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.ppv-lite86-0.2.20.bazel"
+            }
+          },
+          "rules_rust_prost__prettyplease-0.2.22": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "479cf940fbbb3426c32c5d5176f62ad57549a0bb84773423ba8be9d089f5faba",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/prettyplease/0.2.22/download"
+              ],
+              "strip_prefix": "prettyplease-0.2.22",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.prettyplease-0.2.22.bazel"
+            }
+          },
+          "rules_rust_prost__proc-macro2-1.0.86": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/proc-macro2/1.0.86/download"
+              ],
+              "strip_prefix": "proc-macro2-1.0.86",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.proc-macro2-1.0.86.bazel"
+            }
+          },
+          "rules_rust_prost__prost-0.13.1": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "e13db3d3fde688c61e2446b4d843bc27a7e8af269a69440c0308021dc92333cc",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/prost/0.13.1/download"
+              ],
+              "strip_prefix": "prost-0.13.1",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.prost-0.13.1.bazel"
+            }
+          },
+          "rules_rust_prost__prost-build-0.13.1": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "5bb182580f71dd070f88d01ce3de9f4da5021db7115d2e1c3605a754153b77c1",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/prost-build/0.13.1/download"
+              ],
+              "strip_prefix": "prost-build-0.13.1",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.prost-build-0.13.1.bazel"
+            }
+          },
+          "rules_rust_prost__prost-derive-0.13.1": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "18bec9b0adc4eba778b33684b7ba3e7137789434769ee3ce3930463ef904cfca",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/prost-derive/0.13.1/download"
+              ],
+              "strip_prefix": "prost-derive-0.13.1",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.prost-derive-0.13.1.bazel"
+            }
+          },
+          "rules_rust_prost__prost-types-0.13.1": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "cee5168b05f49d4b0ca581206eb14a7b22fafd963efe729ac48eb03266e25cc2",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/prost-types/0.13.1/download"
+              ],
+              "strip_prefix": "prost-types-0.13.1",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.prost-types-0.13.1.bazel"
+            }
+          },
+          "rules_rust_prost__protoc-gen-prost-0.4.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "77eb17a7657a703f30cb9b7ba4d981e4037b8af2d819ab0077514b0bef537406",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/protoc-gen-prost/0.4.0/download"
+              ],
+              "strip_prefix": "protoc-gen-prost-0.4.0",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.protoc-gen-prost-0.4.0.bazel"
+            }
+          },
+          "rules_rust_prost__protoc-gen-tonic-0.4.1": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "6ab6a0d73a0914752ed8fd7cc51afe169e28da87be3efef292de5676cc527634",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/protoc-gen-tonic/0.4.1/download"
+              ],
+              "strip_prefix": "protoc-gen-tonic-0.4.1",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.protoc-gen-tonic-0.4.1.bazel"
+            }
+          },
+          "rules_rust_prost__quote-1.0.37": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/quote/1.0.37/download"
+              ],
+              "strip_prefix": "quote-1.0.37",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.quote-1.0.37.bazel"
+            }
+          },
+          "rules_rust_prost__rand-0.8.5": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/rand/0.8.5/download"
+              ],
+              "strip_prefix": "rand-0.8.5",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.rand-0.8.5.bazel"
+            }
+          },
+          "rules_rust_prost__rand_chacha-0.3.1": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/rand_chacha/0.3.1/download"
+              ],
+              "strip_prefix": "rand_chacha-0.3.1",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.rand_chacha-0.3.1.bazel"
+            }
+          },
+          "rules_rust_prost__rand_core-0.6.4": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/rand_core/0.6.4/download"
+              ],
+              "strip_prefix": "rand_core-0.6.4",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.rand_core-0.6.4.bazel"
+            }
+          },
+          "rules_rust_prost__redox_syscall-0.5.3": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "2a908a6e00f1fdd0dfd9c0eb08ce85126f6d8bbda50017e74bc4a4b7d4a926a4",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/redox_syscall/0.5.3/download"
+              ],
+              "strip_prefix": "redox_syscall-0.5.3",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.redox_syscall-0.5.3.bazel"
+            }
+          },
+          "rules_rust_prost__regex-1.10.6": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "4219d74c6b67a3654a9fbebc4b419e22126d13d2f3c4a07ee0cb61ff79a79619",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/regex/1.10.6/download"
+              ],
+              "strip_prefix": "regex-1.10.6",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.regex-1.10.6.bazel"
+            }
+          },
+          "rules_rust_prost__regex-automata-0.4.7": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "38caf58cc5ef2fed281f89292ef23f6365465ed9a41b7a7754eb4e26496c92df",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/regex-automata/0.4.7/download"
+              ],
+              "strip_prefix": "regex-automata-0.4.7",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.regex-automata-0.4.7.bazel"
+            }
+          },
+          "rules_rust_prost__regex-syntax-0.8.4": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/regex-syntax/0.8.4/download"
+              ],
+              "strip_prefix": "regex-syntax-0.8.4",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.regex-syntax-0.8.4.bazel"
+            }
+          },
+          "rules_rust_prost__rustc-demangle-0.1.24": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/rustc-demangle/0.1.24/download"
+              ],
+              "strip_prefix": "rustc-demangle-0.1.24",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.rustc-demangle-0.1.24.bazel"
+            }
+          },
+          "rules_rust_prost__rustix-0.38.34": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "70dc5ec042f7a43c4a73241207cecc9873a06d45debb38b329f8541d85c2730f",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/rustix/0.38.34/download"
+              ],
+              "strip_prefix": "rustix-0.38.34",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.rustix-0.38.34.bazel"
+            }
+          },
+          "rules_rust_prost__rustversion-1.0.17": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "955d28af4278de8121b7ebeb796b6a45735dc01436d898801014aced2773a3d6",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/rustversion/1.0.17/download"
+              ],
+              "strip_prefix": "rustversion-1.0.17",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.rustversion-1.0.17.bazel"
+            }
+          },
+          "rules_rust_prost__scopeguard-1.2.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/scopeguard/1.2.0/download"
+              ],
+              "strip_prefix": "scopeguard-1.2.0",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.scopeguard-1.2.0.bazel"
+            }
+          },
+          "rules_rust_prost__serde-1.0.209": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "99fce0ffe7310761ca6bf9faf5115afbc19688edd00171d81b1bb1b116c63e09",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/serde/1.0.209/download"
+              ],
+              "strip_prefix": "serde-1.0.209",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.serde-1.0.209.bazel"
+            }
+          },
+          "rules_rust_prost__serde_derive-1.0.209": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "a5831b979fd7b5439637af1752d535ff49f4860c0f341d1baeb6faf0f4242170",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/serde_derive/1.0.209/download"
+              ],
+              "strip_prefix": "serde_derive-1.0.209",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.serde_derive-1.0.209.bazel"
+            }
+          },
+          "rules_rust_prost__shlex-1.3.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/shlex/1.3.0/download"
+              ],
+              "strip_prefix": "shlex-1.3.0",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.shlex-1.3.0.bazel"
+            }
+          },
+          "rules_rust_prost__signal-hook-registry-1.4.2": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "a9e9e0b4211b72e7b8b6e85c807d36c212bdb33ea8587f7569562a84df5465b1",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/signal-hook-registry/1.4.2/download"
+              ],
+              "strip_prefix": "signal-hook-registry-1.4.2",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.signal-hook-registry-1.4.2.bazel"
+            }
+          },
+          "rules_rust_prost__slab-0.4.9": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/slab/0.4.9/download"
+              ],
+              "strip_prefix": "slab-0.4.9",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.slab-0.4.9.bazel"
+            }
+          },
+          "rules_rust_prost__smallvec-1.13.2": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/smallvec/1.13.2/download"
+              ],
+              "strip_prefix": "smallvec-1.13.2",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.smallvec-1.13.2.bazel"
+            }
+          },
+          "rules_rust_prost__socket2-0.5.7": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "ce305eb0b4296696835b71df73eb912e0f1ffd2556a501fcede6e0c50349191c",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/socket2/0.5.7/download"
+              ],
+              "strip_prefix": "socket2-0.5.7",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.socket2-0.5.7.bazel"
+            }
+          },
+          "rules_rust_prost__syn-2.0.76": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "578e081a14e0cefc3279b0472138c513f37b41a08d5a3cca9b6e4e8ceb6cd525",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/syn/2.0.76/download"
+              ],
+              "strip_prefix": "syn-2.0.76",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.syn-2.0.76.bazel"
+            }
+          },
+          "rules_rust_prost__sync_wrapper-0.1.2": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/sync_wrapper/0.1.2/download"
+              ],
+              "strip_prefix": "sync_wrapper-0.1.2",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.sync_wrapper-0.1.2.bazel"
+            }
+          },
+          "rules_rust_prost__sync_wrapper-1.0.1": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "a7065abeca94b6a8a577f9bd45aa0867a2238b74e8eb67cf10d492bc39351394",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/sync_wrapper/1.0.1/download"
+              ],
+              "strip_prefix": "sync_wrapper-1.0.1",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.sync_wrapper-1.0.1.bazel"
+            }
+          },
+          "rules_rust_prost__tempfile-3.12.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "04cbcdd0c794ebb0d4cf35e88edd2f7d2c4c3e9a5a6dab322839b321c6a87a64",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/tempfile/3.12.0/download"
+              ],
+              "strip_prefix": "tempfile-3.12.0",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.tempfile-3.12.0.bazel"
+            }
+          },
+          "rules_rust_prost__tokio-1.39.3": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "9babc99b9923bfa4804bd74722ff02c0381021eafa4db9949217e3be8e84fff5",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/tokio/1.39.3/download"
+              ],
+              "strip_prefix": "tokio-1.39.3",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.tokio-1.39.3.bazel"
+            }
+          },
+          "rules_rust_prost__tokio-macros-2.4.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/tokio-macros/2.4.0/download"
+              ],
+              "strip_prefix": "tokio-macros-2.4.0",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.tokio-macros-2.4.0.bazel"
+            }
+          },
+          "rules_rust_prost__tokio-stream-0.1.15": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "267ac89e0bec6e691e5813911606935d77c476ff49024f98abcea3e7b15e37af",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/tokio-stream/0.1.15/download"
+              ],
+              "strip_prefix": "tokio-stream-0.1.15",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.tokio-stream-0.1.15.bazel"
+            }
+          },
+          "rules_rust_prost__tokio-util-0.7.11": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "9cf6b47b3771c49ac75ad09a6162f53ad4b8088b76ac60e8ec1455b31a189fe1",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/tokio-util/0.7.11/download"
+              ],
+              "strip_prefix": "tokio-util-0.7.11",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.tokio-util-0.7.11.bazel"
+            }
+          },
+          "rules_rust_prost__tonic-0.12.1": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "38659f4a91aba8598d27821589f5db7dddd94601e7a01b1e485a50e5484c7401",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/tonic/0.12.1/download"
+              ],
+              "strip_prefix": "tonic-0.12.1",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.tonic-0.12.1.bazel"
+            }
+          },
+          "rules_rust_prost__tonic-build-0.12.1": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "568392c5a2bd0020723e3f387891176aabafe36fd9fcd074ad309dfa0c8eb964",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/tonic-build/0.12.1/download"
+              ],
+              "strip_prefix": "tonic-build-0.12.1",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.tonic-build-0.12.1.bazel"
+            }
+          },
+          "rules_rust_prost__tower-0.4.13": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/tower/0.4.13/download"
+              ],
+              "strip_prefix": "tower-0.4.13",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.tower-0.4.13.bazel"
+            }
+          },
+          "rules_rust_prost__tower-layer-0.3.3": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/tower-layer/0.3.3/download"
+              ],
+              "strip_prefix": "tower-layer-0.3.3",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.tower-layer-0.3.3.bazel"
+            }
+          },
+          "rules_rust_prost__tower-service-0.3.3": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/tower-service/0.3.3/download"
+              ],
+              "strip_prefix": "tower-service-0.3.3",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.tower-service-0.3.3.bazel"
+            }
+          },
+          "rules_rust_prost__tracing-0.1.40": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/tracing/0.1.40/download"
+              ],
+              "strip_prefix": "tracing-0.1.40",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.tracing-0.1.40.bazel"
+            }
+          },
+          "rules_rust_prost__tracing-attributes-0.1.27": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/tracing-attributes/0.1.27/download"
+              ],
+              "strip_prefix": "tracing-attributes-0.1.27",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.tracing-attributes-0.1.27.bazel"
+            }
+          },
+          "rules_rust_prost__tracing-core-0.1.32": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/tracing-core/0.1.32/download"
+              ],
+              "strip_prefix": "tracing-core-0.1.32",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.tracing-core-0.1.32.bazel"
+            }
+          },
+          "rules_rust_prost__try-lock-0.2.5": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/try-lock/0.2.5/download"
+              ],
+              "strip_prefix": "try-lock-0.2.5",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.try-lock-0.2.5.bazel"
+            }
+          },
+          "rules_rust_prost__unicode-ident-1.0.12": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/unicode-ident/1.0.12/download"
+              ],
+              "strip_prefix": "unicode-ident-1.0.12",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.unicode-ident-1.0.12.bazel"
+            }
+          },
+          "rules_rust_prost__want-0.3.1": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/want/0.3.1/download"
+              ],
+              "strip_prefix": "want-0.3.1",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.want-0.3.1.bazel"
+            }
+          },
+          "rules_rust_prost__wasi-0.11.0-wasi-snapshot-preview1": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/wasi/0.11.0+wasi-snapshot-preview1/download"
+              ],
+              "strip_prefix": "wasi-0.11.0+wasi-snapshot-preview1",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.wasi-0.11.0+wasi-snapshot-preview1.bazel"
+            }
+          },
+          "rules_rust_prost__windows-sys-0.52.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/windows-sys/0.52.0/download"
+              ],
+              "strip_prefix": "windows-sys-0.52.0",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.windows-sys-0.52.0.bazel"
+            }
+          },
+          "rules_rust_prost__windows-sys-0.59.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/windows-sys/0.59.0/download"
+              ],
+              "strip_prefix": "windows-sys-0.59.0",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.windows-sys-0.59.0.bazel"
+            }
+          },
+          "rules_rust_prost__windows-targets-0.52.6": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/windows-targets/0.52.6/download"
+              ],
+              "strip_prefix": "windows-targets-0.52.6",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.windows-targets-0.52.6.bazel"
+            }
+          },
+          "rules_rust_prost__windows_aarch64_gnullvm-0.52.6": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/windows_aarch64_gnullvm/0.52.6/download"
+              ],
+              "strip_prefix": "windows_aarch64_gnullvm-0.52.6",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.windows_aarch64_gnullvm-0.52.6.bazel"
+            }
+          },
+          "rules_rust_prost__windows_aarch64_msvc-0.52.6": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/windows_aarch64_msvc/0.52.6/download"
+              ],
+              "strip_prefix": "windows_aarch64_msvc-0.52.6",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.windows_aarch64_msvc-0.52.6.bazel"
+            }
+          },
+          "rules_rust_prost__windows_i686_gnu-0.52.6": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/windows_i686_gnu/0.52.6/download"
+              ],
+              "strip_prefix": "windows_i686_gnu-0.52.6",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.windows_i686_gnu-0.52.6.bazel"
+            }
+          },
+          "rules_rust_prost__windows_i686_gnullvm-0.52.6": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/windows_i686_gnullvm/0.52.6/download"
+              ],
+              "strip_prefix": "windows_i686_gnullvm-0.52.6",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.windows_i686_gnullvm-0.52.6.bazel"
+            }
+          },
+          "rules_rust_prost__windows_i686_msvc-0.52.6": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/windows_i686_msvc/0.52.6/download"
+              ],
+              "strip_prefix": "windows_i686_msvc-0.52.6",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.windows_i686_msvc-0.52.6.bazel"
+            }
+          },
+          "rules_rust_prost__windows_x86_64_gnu-0.52.6": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/windows_x86_64_gnu/0.52.6/download"
+              ],
+              "strip_prefix": "windows_x86_64_gnu-0.52.6",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.windows_x86_64_gnu-0.52.6.bazel"
+            }
+          },
+          "rules_rust_prost__windows_x86_64_gnullvm-0.52.6": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/windows_x86_64_gnullvm/0.52.6/download"
+              ],
+              "strip_prefix": "windows_x86_64_gnullvm-0.52.6",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.windows_x86_64_gnullvm-0.52.6.bazel"
+            }
+          },
+          "rules_rust_prost__windows_x86_64_msvc-0.52.6": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/windows_x86_64_msvc/0.52.6/download"
+              ],
+              "strip_prefix": "windows_x86_64_msvc-0.52.6",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.windows_x86_64_msvc-0.52.6.bazel"
+            }
+          },
+          "rules_rust_prost__zerocopy-0.7.35": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/zerocopy/0.7.35/download"
+              ],
+              "strip_prefix": "zerocopy-0.7.35",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.zerocopy-0.7.35.bazel"
+            }
+          },
+          "rules_rust_prost__zerocopy-derive-0.7.35": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/zerocopy-derive/0.7.35/download"
+              ],
+              "strip_prefix": "zerocopy-derive-0.7.35",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.zerocopy-derive-0.7.35.bazel"
+            }
+          },
+          "rules_rust_prost__heck": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "integrity": "sha256-IwTgCYP4f/s4tVtES147YKiEtdMMD8p9gv4zRJu+Veo=",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/heck/heck-0.5.0.crate"
+              ],
+              "strip_prefix": "heck-0.5.0",
+              "build_file": "@@rules_rust+//proto/prost/private/3rdparty/crates:BUILD.heck-0.5.0.bazel"
+            }
+          },
+          "rules_rust_proto__autocfg-1.1.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/autocfg/1.1.0/download"
+              ],
+              "strip_prefix": "autocfg-1.1.0",
+              "build_file": "@@rules_rust+//proto/protobuf/3rdparty/crates:BUILD.autocfg-1.1.0.bazel"
+            }
+          },
+          "rules_rust_proto__base64-0.9.3": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "489d6c0ed21b11d038c31b6ceccca973e65d73ba3bd8ecb9a2babf5546164643",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/base64/0.9.3/download"
+              ],
+              "strip_prefix": "base64-0.9.3",
+              "build_file": "@@rules_rust+//proto/protobuf/3rdparty/crates:BUILD.base64-0.9.3.bazel"
+            }
+          },
+          "rules_rust_proto__bitflags-1.3.2": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/bitflags/1.3.2/download"
+              ],
+              "strip_prefix": "bitflags-1.3.2",
+              "build_file": "@@rules_rust+//proto/protobuf/3rdparty/crates:BUILD.bitflags-1.3.2.bazel"
+            }
+          },
+          "rules_rust_proto__byteorder-1.4.3": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/byteorder/1.4.3/download"
+              ],
+              "strip_prefix": "byteorder-1.4.3",
+              "build_file": "@@rules_rust+//proto/protobuf/3rdparty/crates:BUILD.byteorder-1.4.3.bazel"
+            }
+          },
+          "rules_rust_proto__bytes-0.4.12": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "206fdffcfa2df7cbe15601ef46c813fce0965eb3286db6b56c583b814b51c81c",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/bytes/0.4.12/download"
+              ],
+              "strip_prefix": "bytes-0.4.12",
+              "build_file": "@@rules_rust+//proto/protobuf/3rdparty/crates:BUILD.bytes-0.4.12.bazel"
+            }
+          },
+          "rules_rust_proto__cfg-if-0.1.10": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/cfg-if/0.1.10/download"
+              ],
+              "strip_prefix": "cfg-if-0.1.10",
+              "build_file": "@@rules_rust+//proto/protobuf/3rdparty/crates:BUILD.cfg-if-0.1.10.bazel"
+            }
+          },
+          "rules_rust_proto__cfg-if-1.0.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/cfg-if/1.0.0/download"
+              ],
+              "strip_prefix": "cfg-if-1.0.0",
+              "build_file": "@@rules_rust+//proto/protobuf/3rdparty/crates:BUILD.cfg-if-1.0.0.bazel"
+            }
+          },
+          "rules_rust_proto__cloudabi-0.0.3": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/cloudabi/0.0.3/download"
+              ],
+              "strip_prefix": "cloudabi-0.0.3",
+              "build_file": "@@rules_rust+//proto/protobuf/3rdparty/crates:BUILD.cloudabi-0.0.3.bazel"
+            }
+          },
+          "rules_rust_proto__crossbeam-deque-0.7.4": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "c20ff29ded3204c5106278a81a38f4b482636ed4fa1e6cfbeef193291beb29ed",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/crossbeam-deque/0.7.4/download"
+              ],
+              "strip_prefix": "crossbeam-deque-0.7.4",
+              "build_file": "@@rules_rust+//proto/protobuf/3rdparty/crates:BUILD.crossbeam-deque-0.7.4.bazel"
+            }
+          },
+          "rules_rust_proto__crossbeam-epoch-0.8.2": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "058ed274caafc1f60c4997b5fc07bf7dc7cca454af7c6e81edffe5f33f70dace",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/crossbeam-epoch/0.8.2/download"
+              ],
+              "strip_prefix": "crossbeam-epoch-0.8.2",
+              "build_file": "@@rules_rust+//proto/protobuf/3rdparty/crates:BUILD.crossbeam-epoch-0.8.2.bazel"
+            }
+          },
+          "rules_rust_proto__crossbeam-queue-0.2.3": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "774ba60a54c213d409d5353bda12d49cd68d14e45036a285234c8d6f91f92570",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/crossbeam-queue/0.2.3/download"
+              ],
+              "strip_prefix": "crossbeam-queue-0.2.3",
+              "build_file": "@@rules_rust+//proto/protobuf/3rdparty/crates:BUILD.crossbeam-queue-0.2.3.bazel"
+            }
+          },
+          "rules_rust_proto__crossbeam-utils-0.7.2": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "c3c7c73a2d1e9fc0886a08b93e98eb643461230d5f1925e4036204d5f2e261a8",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/crossbeam-utils/0.7.2/download"
+              ],
+              "strip_prefix": "crossbeam-utils-0.7.2",
+              "build_file": "@@rules_rust+//proto/protobuf/3rdparty/crates:BUILD.crossbeam-utils-0.7.2.bazel"
+            }
+          },
+          "rules_rust_proto__fnv-1.0.7": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/fnv/1.0.7/download"
+              ],
+              "strip_prefix": "fnv-1.0.7",
+              "build_file": "@@rules_rust+//proto/protobuf/3rdparty/crates:BUILD.fnv-1.0.7.bazel"
+            }
+          },
+          "rules_rust_proto__fuchsia-zircon-0.3.3": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/fuchsia-zircon/0.3.3/download"
+              ],
+              "strip_prefix": "fuchsia-zircon-0.3.3",
+              "build_file": "@@rules_rust+//proto/protobuf/3rdparty/crates:BUILD.fuchsia-zircon-0.3.3.bazel"
+            }
+          },
+          "rules_rust_proto__fuchsia-zircon-sys-0.3.3": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/fuchsia-zircon-sys/0.3.3/download"
+              ],
+              "strip_prefix": "fuchsia-zircon-sys-0.3.3",
+              "build_file": "@@rules_rust+//proto/protobuf/3rdparty/crates:BUILD.fuchsia-zircon-sys-0.3.3.bazel"
+            }
+          },
+          "rules_rust_proto__futures-0.1.31": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "3a471a38ef8ed83cd6e40aa59c1ffe17db6855c18e3604d9c4ed8c08ebc28678",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/futures/0.1.31/download"
+              ],
+              "strip_prefix": "futures-0.1.31",
+              "build_file": "@@rules_rust+//proto/protobuf/3rdparty/crates:BUILD.futures-0.1.31.bazel"
+            }
+          },
+          "rules_rust_proto__futures-cpupool-0.1.8": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "ab90cde24b3319636588d0c35fe03b1333857621051837ed769faefb4c2162e4",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/futures-cpupool/0.1.8/download"
+              ],
+              "strip_prefix": "futures-cpupool-0.1.8",
+              "build_file": "@@rules_rust+//proto/protobuf/3rdparty/crates:BUILD.futures-cpupool-0.1.8.bazel"
+            }
+          },
+          "rules_rust_proto__grpc-0.6.2": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "2aaf1d741fe6f3413f1f9f71b99f5e4e26776d563475a8a53ce53a73a8534c1d",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/grpc/0.6.2/download"
+              ],
+              "strip_prefix": "grpc-0.6.2",
+              "build_file": "@@rules_rust+//proto/protobuf/3rdparty/crates:BUILD.grpc-0.6.2.bazel"
+            }
+          },
+          "rules_rust_proto__grpc-compiler-0.6.2": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "907274ce8ee7b40a0d0b0db09022ea22846a47cfb1fc8ad2c983c70001b4ffb1",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/grpc-compiler/0.6.2/download"
+              ],
+              "strip_prefix": "grpc-compiler-0.6.2",
+              "build_file": "@@rules_rust+//proto/protobuf/3rdparty/crates:BUILD.grpc-compiler-0.6.2.bazel"
+            }
+          },
+          "rules_rust_proto__hermit-abi-0.2.6": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "ee512640fe35acbfb4bb779db6f0d80704c2cacfa2e39b601ef3e3f47d1ae4c7",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/hermit-abi/0.2.6/download"
+              ],
+              "strip_prefix": "hermit-abi-0.2.6",
+              "build_file": "@@rules_rust+//proto/protobuf/3rdparty/crates:BUILD.hermit-abi-0.2.6.bazel"
+            }
+          },
+          "rules_rust_proto__httpbis-0.7.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "7689cfa896b2a71da4f16206af167542b75d242b6906313e53857972a92d5614",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/httpbis/0.7.0/download"
+              ],
+              "strip_prefix": "httpbis-0.7.0",
+              "build_file": "@@rules_rust+//proto/protobuf/3rdparty/crates:BUILD.httpbis-0.7.0.bazel"
+            }
+          },
+          "rules_rust_proto__iovec-0.1.4": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "b2b3ea6ff95e175473f8ffe6a7eb7c00d054240321b84c57051175fe3c1e075e",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/iovec/0.1.4/download"
+              ],
+              "strip_prefix": "iovec-0.1.4",
+              "build_file": "@@rules_rust+//proto/protobuf/3rdparty/crates:BUILD.iovec-0.1.4.bazel"
+            }
+          },
+          "rules_rust_proto__kernel32-sys-0.2.2": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/kernel32-sys/0.2.2/download"
+              ],
+              "strip_prefix": "kernel32-sys-0.2.2",
+              "build_file": "@@rules_rust+//proto/protobuf/3rdparty/crates:BUILD.kernel32-sys-0.2.2.bazel"
+            }
+          },
+          "rules_rust_proto__lazy_static-1.4.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/lazy_static/1.4.0/download"
+              ],
+              "strip_prefix": "lazy_static-1.4.0",
+              "build_file": "@@rules_rust+//proto/protobuf/3rdparty/crates:BUILD.lazy_static-1.4.0.bazel"
+            }
+          },
+          "rules_rust_proto__libc-0.2.139": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/libc/0.2.139/download"
+              ],
+              "strip_prefix": "libc-0.2.139",
+              "build_file": "@@rules_rust+//proto/protobuf/3rdparty/crates:BUILD.libc-0.2.139.bazel"
+            }
+          },
+          "rules_rust_proto__lock_api-0.3.4": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "c4da24a77a3d8a6d4862d95f72e6fdb9c09a643ecdb402d754004a557f2bec75",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/lock_api/0.3.4/download"
+              ],
+              "strip_prefix": "lock_api-0.3.4",
+              "build_file": "@@rules_rust+//proto/protobuf/3rdparty/crates:BUILD.lock_api-0.3.4.bazel"
+            }
+          },
+          "rules_rust_proto__log-0.3.9": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "e19e8d5c34a3e0e2223db8e060f9e8264aeeb5c5fc64a4ee9965c062211c024b",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/log/0.3.9/download"
+              ],
+              "strip_prefix": "log-0.3.9",
+              "build_file": "@@rules_rust+//proto/protobuf/3rdparty/crates:BUILD.log-0.3.9.bazel"
+            }
+          },
+          "rules_rust_proto__log-0.4.17": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/log/0.4.17/download"
+              ],
+              "strip_prefix": "log-0.4.17",
+              "build_file": "@@rules_rust+//proto/protobuf/3rdparty/crates:BUILD.log-0.4.17.bazel"
+            }
+          },
+          "rules_rust_proto__maybe-uninit-2.0.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "60302e4db3a61da70c0cb7991976248362f30319e88850c487b9b95bbf059e00",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/maybe-uninit/2.0.0/download"
+              ],
+              "strip_prefix": "maybe-uninit-2.0.0",
+              "build_file": "@@rules_rust+//proto/protobuf/3rdparty/crates:BUILD.maybe-uninit-2.0.0.bazel"
+            }
+          },
+          "rules_rust_proto__memoffset-0.5.6": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "043175f069eda7b85febe4a74abbaeff828d9f8b448515d3151a14a3542811aa",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/memoffset/0.5.6/download"
+              ],
+              "strip_prefix": "memoffset-0.5.6",
+              "build_file": "@@rules_rust+//proto/protobuf/3rdparty/crates:BUILD.memoffset-0.5.6.bazel"
+            }
+          },
+          "rules_rust_proto__mio-0.6.23": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "4afd66f5b91bf2a3bc13fad0e21caedac168ca4c707504e75585648ae80e4cc4",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/mio/0.6.23/download"
+              ],
+              "strip_prefix": "mio-0.6.23",
+              "build_file": "@@rules_rust+//proto/protobuf/3rdparty/crates:BUILD.mio-0.6.23.bazel"
+            }
+          },
+          "rules_rust_proto__mio-uds-0.6.8": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "afcb699eb26d4332647cc848492bbc15eafb26f08d0304550d5aa1f612e066f0",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/mio-uds/0.6.8/download"
+              ],
+              "strip_prefix": "mio-uds-0.6.8",
+              "build_file": "@@rules_rust+//proto/protobuf/3rdparty/crates:BUILD.mio-uds-0.6.8.bazel"
+            }
+          },
+          "rules_rust_proto__miow-0.2.2": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "ebd808424166322d4a38da87083bfddd3ac4c131334ed55856112eb06d46944d",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/miow/0.2.2/download"
+              ],
+              "strip_prefix": "miow-0.2.2",
+              "build_file": "@@rules_rust+//proto/protobuf/3rdparty/crates:BUILD.miow-0.2.2.bazel"
+            }
+          },
+          "rules_rust_proto__net2-0.2.38": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "74d0df99cfcd2530b2e694f6e17e7f37b8e26bb23983ac530c0c97408837c631",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/net2/0.2.38/download"
+              ],
+              "strip_prefix": "net2-0.2.38",
+              "build_file": "@@rules_rust+//proto/protobuf/3rdparty/crates:BUILD.net2-0.2.38.bazel"
+            }
+          },
+          "rules_rust_proto__num_cpus-1.15.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "0fac9e2da13b5eb447a6ce3d392f23a29d8694bff781bf03a16cd9ac8697593b",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/num_cpus/1.15.0/download"
+              ],
+              "strip_prefix": "num_cpus-1.15.0",
+              "build_file": "@@rules_rust+//proto/protobuf/3rdparty/crates:BUILD.num_cpus-1.15.0.bazel"
+            }
+          },
+          "rules_rust_proto__parking_lot-0.9.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "f842b1982eb6c2fe34036a4fbfb06dd185a3f5c8edfaacdf7d1ea10b07de6252",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/parking_lot/0.9.0/download"
+              ],
+              "strip_prefix": "parking_lot-0.9.0",
+              "build_file": "@@rules_rust+//proto/protobuf/3rdparty/crates:BUILD.parking_lot-0.9.0.bazel"
+            }
+          },
+          "rules_rust_proto__parking_lot_core-0.6.3": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "bda66b810a62be75176a80873726630147a5ca780cd33921e0b5709033e66b0a",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/parking_lot_core/0.6.3/download"
+              ],
+              "strip_prefix": "parking_lot_core-0.6.3",
+              "build_file": "@@rules_rust+//proto/protobuf/3rdparty/crates:BUILD.parking_lot_core-0.6.3.bazel"
+            }
+          },
+          "rules_rust_proto__protobuf-2.8.2": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "patch_args": [
+                "-p1"
+              ],
+              "patches": [
+                "@@rules_rust+//proto/protobuf/3rdparty/patches:protobuf-2.8.2.patch"
+              ],
+              "sha256": "70731852eec72c56d11226c8a5f96ad5058a3dab73647ca5f7ee351e464f2571",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/protobuf/2.8.2/download"
+              ],
+              "strip_prefix": "protobuf-2.8.2",
+              "build_file": "@@rules_rust+//proto/protobuf/3rdparty/crates:BUILD.protobuf-2.8.2.bazel"
+            }
+          },
+          "rules_rust_proto__protobuf-codegen-2.8.2": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "3d74b9cbbf2ac9a7169c85a3714ec16c51ee9ec7cfd511549527e9a7df720795",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/protobuf-codegen/2.8.2/download"
+              ],
+              "strip_prefix": "protobuf-codegen-2.8.2",
+              "build_file": "@@rules_rust+//proto/protobuf/3rdparty/crates:BUILD.protobuf-codegen-2.8.2.bazel"
+            }
+          },
+          "rules_rust_proto__redox_syscall-0.1.57": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "41cc0f7e4d5d4544e8861606a285bb08d3e70712ccc7d2b84d7c0ccfaf4b05ce",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/redox_syscall/0.1.57/download"
+              ],
+              "strip_prefix": "redox_syscall-0.1.57",
+              "build_file": "@@rules_rust+//proto/protobuf/3rdparty/crates:BUILD.redox_syscall-0.1.57.bazel"
+            }
+          },
+          "rules_rust_proto__rustc_version-0.2.3": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/rustc_version/0.2.3/download"
+              ],
+              "strip_prefix": "rustc_version-0.2.3",
+              "build_file": "@@rules_rust+//proto/protobuf/3rdparty/crates:BUILD.rustc_version-0.2.3.bazel"
+            }
+          },
+          "rules_rust_proto__safemem-0.3.3": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "ef703b7cb59335eae2eb93ceb664c0eb7ea6bf567079d843e09420219668e072",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/safemem/0.3.3/download"
+              ],
+              "strip_prefix": "safemem-0.3.3",
+              "build_file": "@@rules_rust+//proto/protobuf/3rdparty/crates:BUILD.safemem-0.3.3.bazel"
+            }
+          },
+          "rules_rust_proto__scoped-tls-0.1.2": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "332ffa32bf586782a3efaeb58f127980944bbc8c4d6913a86107ac2a5ab24b28",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/scoped-tls/0.1.2/download"
+              ],
+              "strip_prefix": "scoped-tls-0.1.2",
+              "build_file": "@@rules_rust+//proto/protobuf/3rdparty/crates:BUILD.scoped-tls-0.1.2.bazel"
+            }
+          },
+          "rules_rust_proto__scopeguard-1.1.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/scopeguard/1.1.0/download"
+              ],
+              "strip_prefix": "scopeguard-1.1.0",
+              "build_file": "@@rules_rust+//proto/protobuf/3rdparty/crates:BUILD.scopeguard-1.1.0.bazel"
+            }
+          },
+          "rules_rust_proto__semver-0.9.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/semver/0.9.0/download"
+              ],
+              "strip_prefix": "semver-0.9.0",
+              "build_file": "@@rules_rust+//proto/protobuf/3rdparty/crates:BUILD.semver-0.9.0.bazel"
+            }
+          },
+          "rules_rust_proto__semver-parser-0.7.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/semver-parser/0.7.0/download"
+              ],
+              "strip_prefix": "semver-parser-0.7.0",
+              "build_file": "@@rules_rust+//proto/protobuf/3rdparty/crates:BUILD.semver-parser-0.7.0.bazel"
+            }
+          },
+          "rules_rust_proto__slab-0.3.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "17b4fcaed89ab08ef143da37bc52adbcc04d4a69014f4c1208d6b51f0c47bc23",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/slab/0.3.0/download"
+              ],
+              "strip_prefix": "slab-0.3.0",
+              "build_file": "@@rules_rust+//proto/protobuf/3rdparty/crates:BUILD.slab-0.3.0.bazel"
+            }
+          },
+          "rules_rust_proto__slab-0.4.7": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "4614a76b2a8be0058caa9dbbaf66d988527d86d003c11a94fbd335d7661edcef",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/slab/0.4.7/download"
+              ],
+              "strip_prefix": "slab-0.4.7",
+              "build_file": "@@rules_rust+//proto/protobuf/3rdparty/crates:BUILD.slab-0.4.7.bazel"
+            }
+          },
+          "rules_rust_proto__smallvec-0.6.14": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "b97fcaeba89edba30f044a10c6a3cc39df9c3f17d7cd829dd1446cab35f890e0",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/smallvec/0.6.14/download"
+              ],
+              "strip_prefix": "smallvec-0.6.14",
+              "build_file": "@@rules_rust+//proto/protobuf/3rdparty/crates:BUILD.smallvec-0.6.14.bazel"
+            }
+          },
+          "rules_rust_proto__tls-api-0.1.22": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "049c03787a0595182357fbd487577947f4351b78ce20c3668f6d49f17feb13d1",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/tls-api/0.1.22/download"
+              ],
+              "strip_prefix": "tls-api-0.1.22",
+              "build_file": "@@rules_rust+//proto/protobuf/3rdparty/crates:BUILD.tls-api-0.1.22.bazel"
+            }
+          },
+          "rules_rust_proto__tls-api-stub-0.1.22": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "c9a0cc8c149724db9de7d73a0e1bc80b1a74f5394f08c6f301e11f9c35fa061e",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/tls-api-stub/0.1.22/download"
+              ],
+              "strip_prefix": "tls-api-stub-0.1.22",
+              "build_file": "@@rules_rust+//proto/protobuf/3rdparty/crates:BUILD.tls-api-stub-0.1.22.bazel"
+            }
+          },
+          "rules_rust_proto__tokio-0.1.22": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "5a09c0b5bb588872ab2f09afa13ee6e9dac11e10a0ec9e8e3ba39a5a5d530af6",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/tokio/0.1.22/download"
+              ],
+              "strip_prefix": "tokio-0.1.22",
+              "build_file": "@@rules_rust+//proto/protobuf/3rdparty/crates:BUILD.tokio-0.1.22.bazel"
+            }
+          },
+          "rules_rust_proto__tokio-codec-0.1.2": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "25b2998660ba0e70d18684de5d06b70b70a3a747469af9dea7618cc59e75976b",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/tokio-codec/0.1.2/download"
+              ],
+              "strip_prefix": "tokio-codec-0.1.2",
+              "build_file": "@@rules_rust+//proto/protobuf/3rdparty/crates:BUILD.tokio-codec-0.1.2.bazel"
+            }
+          },
+          "rules_rust_proto__tokio-core-0.1.18": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "87b1395334443abca552f63d4f61d0486f12377c2ba8b368e523f89e828cffd4",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/tokio-core/0.1.18/download"
+              ],
+              "strip_prefix": "tokio-core-0.1.18",
+              "build_file": "@@rules_rust+//proto/protobuf/3rdparty/crates:BUILD.tokio-core-0.1.18.bazel"
+            }
+          },
+          "rules_rust_proto__tokio-current-thread-0.1.7": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "b1de0e32a83f131e002238d7ccde18211c0a5397f60cbfffcb112868c2e0e20e",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/tokio-current-thread/0.1.7/download"
+              ],
+              "strip_prefix": "tokio-current-thread-0.1.7",
+              "build_file": "@@rules_rust+//proto/protobuf/3rdparty/crates:BUILD.tokio-current-thread-0.1.7.bazel"
+            }
+          },
+          "rules_rust_proto__tokio-executor-0.1.10": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "fb2d1b8f4548dbf5e1f7818512e9c406860678f29c300cdf0ebac72d1a3a1671",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/tokio-executor/0.1.10/download"
+              ],
+              "strip_prefix": "tokio-executor-0.1.10",
+              "build_file": "@@rules_rust+//proto/protobuf/3rdparty/crates:BUILD.tokio-executor-0.1.10.bazel"
+            }
+          },
+          "rules_rust_proto__tokio-fs-0.1.7": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "297a1206e0ca6302a0eed35b700d292b275256f596e2f3fea7729d5e629b6ff4",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/tokio-fs/0.1.7/download"
+              ],
+              "strip_prefix": "tokio-fs-0.1.7",
+              "build_file": "@@rules_rust+//proto/protobuf/3rdparty/crates:BUILD.tokio-fs-0.1.7.bazel"
+            }
+          },
+          "rules_rust_proto__tokio-io-0.1.13": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "57fc868aae093479e3131e3d165c93b1c7474109d13c90ec0dda2a1bbfff0674",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/tokio-io/0.1.13/download"
+              ],
+              "strip_prefix": "tokio-io-0.1.13",
+              "build_file": "@@rules_rust+//proto/protobuf/3rdparty/crates:BUILD.tokio-io-0.1.13.bazel"
+            }
+          },
+          "rules_rust_proto__tokio-reactor-0.1.12": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "09bc590ec4ba8ba87652da2068d150dcada2cfa2e07faae270a5e0409aa51351",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/tokio-reactor/0.1.12/download"
+              ],
+              "strip_prefix": "tokio-reactor-0.1.12",
+              "build_file": "@@rules_rust+//proto/protobuf/3rdparty/crates:BUILD.tokio-reactor-0.1.12.bazel"
+            }
+          },
+          "rules_rust_proto__tokio-sync-0.1.8": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "edfe50152bc8164fcc456dab7891fa9bf8beaf01c5ee7e1dd43a397c3cf87dee",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/tokio-sync/0.1.8/download"
+              ],
+              "strip_prefix": "tokio-sync-0.1.8",
+              "build_file": "@@rules_rust+//proto/protobuf/3rdparty/crates:BUILD.tokio-sync-0.1.8.bazel"
+            }
+          },
+          "rules_rust_proto__tokio-tcp-0.1.4": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "98df18ed66e3b72e742f185882a9e201892407957e45fbff8da17ae7a7c51f72",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/tokio-tcp/0.1.4/download"
+              ],
+              "strip_prefix": "tokio-tcp-0.1.4",
+              "build_file": "@@rules_rust+//proto/protobuf/3rdparty/crates:BUILD.tokio-tcp-0.1.4.bazel"
+            }
+          },
+          "rules_rust_proto__tokio-threadpool-0.1.18": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "df720b6581784c118f0eb4310796b12b1d242a7eb95f716a8367855325c25f89",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/tokio-threadpool/0.1.18/download"
+              ],
+              "strip_prefix": "tokio-threadpool-0.1.18",
+              "build_file": "@@rules_rust+//proto/protobuf/3rdparty/crates:BUILD.tokio-threadpool-0.1.18.bazel"
+            }
+          },
+          "rules_rust_proto__tokio-timer-0.1.2": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "6131e780037787ff1b3f8aad9da83bca02438b72277850dd6ad0d455e0e20efc",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/tokio-timer/0.1.2/download"
+              ],
+              "strip_prefix": "tokio-timer-0.1.2",
+              "build_file": "@@rules_rust+//proto/protobuf/3rdparty/crates:BUILD.tokio-timer-0.1.2.bazel"
+            }
+          },
+          "rules_rust_proto__tokio-timer-0.2.13": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "93044f2d313c95ff1cb7809ce9a7a05735b012288a888b62d4434fd58c94f296",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/tokio-timer/0.2.13/download"
+              ],
+              "strip_prefix": "tokio-timer-0.2.13",
+              "build_file": "@@rules_rust+//proto/protobuf/3rdparty/crates:BUILD.tokio-timer-0.2.13.bazel"
+            }
+          },
+          "rules_rust_proto__tokio-tls-api-0.1.22": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "68d0e040d5b1f4cfca70ec4f371229886a5de5bb554d272a4a8da73004a7b2c9",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/tokio-tls-api/0.1.22/download"
+              ],
+              "strip_prefix": "tokio-tls-api-0.1.22",
+              "build_file": "@@rules_rust+//proto/protobuf/3rdparty/crates:BUILD.tokio-tls-api-0.1.22.bazel"
+            }
+          },
+          "rules_rust_proto__tokio-udp-0.1.6": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "e2a0b10e610b39c38b031a2fcab08e4b82f16ece36504988dcbd81dbba650d82",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/tokio-udp/0.1.6/download"
+              ],
+              "strip_prefix": "tokio-udp-0.1.6",
+              "build_file": "@@rules_rust+//proto/protobuf/3rdparty/crates:BUILD.tokio-udp-0.1.6.bazel"
+            }
+          },
+          "rules_rust_proto__tokio-uds-0.1.7": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "65ae5d255ce739e8537221ed2942e0445f4b3b813daebac1c0050ddaaa3587f9",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/tokio-uds/0.1.7/download"
+              ],
+              "strip_prefix": "tokio-uds-0.1.7",
+              "build_file": "@@rules_rust+//proto/protobuf/3rdparty/crates:BUILD.tokio-uds-0.1.7.bazel"
+            }
+          },
+          "rules_rust_proto__tokio-uds-0.2.7": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "ab57a4ac4111c8c9dbcf70779f6fc8bc35ae4b2454809febac840ad19bd7e4e0",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/tokio-uds/0.2.7/download"
+              ],
+              "strip_prefix": "tokio-uds-0.2.7",
+              "build_file": "@@rules_rust+//proto/protobuf/3rdparty/crates:BUILD.tokio-uds-0.2.7.bazel"
+            }
+          },
+          "rules_rust_proto__unix_socket-0.5.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "6aa2700417c405c38f5e6902d699345241c28c0b7ade4abaad71e35a87eb1564",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/unix_socket/0.5.0/download"
+              ],
+              "strip_prefix": "unix_socket-0.5.0",
+              "build_file": "@@rules_rust+//proto/protobuf/3rdparty/crates:BUILD.unix_socket-0.5.0.bazel"
+            }
+          },
+          "rules_rust_proto__void-1.0.2": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/void/1.0.2/download"
+              ],
+              "strip_prefix": "void-1.0.2",
+              "build_file": "@@rules_rust+//proto/protobuf/3rdparty/crates:BUILD.void-1.0.2.bazel"
+            }
+          },
+          "rules_rust_proto__winapi-0.2.8": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/winapi/0.2.8/download"
+              ],
+              "strip_prefix": "winapi-0.2.8",
+              "build_file": "@@rules_rust+//proto/protobuf/3rdparty/crates:BUILD.winapi-0.2.8.bazel"
+            }
+          },
+          "rules_rust_proto__winapi-0.3.9": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/winapi/0.3.9/download"
+              ],
+              "strip_prefix": "winapi-0.3.9",
+              "build_file": "@@rules_rust+//proto/protobuf/3rdparty/crates:BUILD.winapi-0.3.9.bazel"
+            }
+          },
+          "rules_rust_proto__winapi-build-0.1.1": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/winapi-build/0.1.1/download"
+              ],
+              "strip_prefix": "winapi-build-0.1.1",
+              "build_file": "@@rules_rust+//proto/protobuf/3rdparty/crates:BUILD.winapi-build-0.1.1.bazel"
+            }
+          },
+          "rules_rust_proto__winapi-i686-pc-windows-gnu-0.4.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/winapi-i686-pc-windows-gnu/0.4.0/download"
+              ],
+              "strip_prefix": "winapi-i686-pc-windows-gnu-0.4.0",
+              "build_file": "@@rules_rust+//proto/protobuf/3rdparty/crates:BUILD.winapi-i686-pc-windows-gnu-0.4.0.bazel"
+            }
+          },
+          "rules_rust_proto__winapi-x86_64-pc-windows-gnu-0.4.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/winapi-x86_64-pc-windows-gnu/0.4.0/download"
+              ],
+              "strip_prefix": "winapi-x86_64-pc-windows-gnu-0.4.0",
+              "build_file": "@@rules_rust+//proto/protobuf/3rdparty/crates:BUILD.winapi-x86_64-pc-windows-gnu-0.4.0.bazel"
+            }
+          },
+          "rules_rust_proto__ws2_32-sys-0.2.1": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "d59cefebd0c892fa2dd6de581e937301d8552cb44489cdff035c6187cb63fa5e",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/ws2_32-sys/0.2.1/download"
+              ],
+              "strip_prefix": "ws2_32-sys-0.2.1",
+              "build_file": "@@rules_rust+//proto/protobuf/3rdparty/crates:BUILD.ws2_32-sys-0.2.1.bazel"
+            }
+          },
+          "llvm-raw": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "urls": [
+                "https://github.com/llvm/llvm-project/releases/download/llvmorg-14.0.6/llvm-project-14.0.6.src.tar.xz"
+              ],
+              "strip_prefix": "llvm-project-14.0.6.src",
+              "sha256": "8b3cfd7bc695bd6cea0f37f53f0981f34f87496e79e2529874fd03a2f9dd3a8a",
+              "build_file_content": "# empty",
+              "patch_args": [
+                "-p1"
+              ],
+              "patches": [
+                "@@rules_rust+//bindgen/3rdparty/patches:llvm-project.cxx17.patch",
+                "@@rules_rust+//bindgen/3rdparty/patches:llvm-project.incompatible_disallow_empty_glob.patch"
+              ]
+            }
+          },
+          "rules_rust_bindgen__bindgen-cli-0.70.1": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "integrity": "sha256-Mz+eRtWNh1r7irkjwi27fmF4j1WtKPK12Yv5ENkL1ao=",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/bindgen-cli/bindgen-cli-0.70.1.crate"
+              ],
+              "strip_prefix": "bindgen-cli-0.70.1",
+              "build_file": "@@rules_rust+//bindgen/3rdparty:BUILD.bindgen-cli.bazel"
+            }
+          },
+          "rules_rust_bindgen__aho-corasick-1.1.3": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/aho-corasick/1.1.3/download"
+              ],
+              "strip_prefix": "aho-corasick-1.1.3",
+              "build_file": "@@rules_rust+//bindgen/3rdparty/crates:BUILD.aho-corasick-1.1.3.bazel"
+            }
+          },
+          "rules_rust_bindgen__annotate-snippets-0.9.2": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "ccaf7e9dfbb6ab22c82e473cd1a8a7bd313c19a5b7e40970f3d89ef5a5c9e81e",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/annotate-snippets/0.9.2/download"
+              ],
+              "strip_prefix": "annotate-snippets-0.9.2",
+              "build_file": "@@rules_rust+//bindgen/3rdparty/crates:BUILD.annotate-snippets-0.9.2.bazel"
+            }
+          },
+          "rules_rust_bindgen__anstream-0.6.15": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "64e15c1ab1f89faffbf04a634d5e1962e9074f2741eef6d97f3c4e322426d526",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/anstream/0.6.15/download"
+              ],
+              "strip_prefix": "anstream-0.6.15",
+              "build_file": "@@rules_rust+//bindgen/3rdparty/crates:BUILD.anstream-0.6.15.bazel"
+            }
+          },
+          "rules_rust_bindgen__anstyle-1.0.8": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "1bec1de6f59aedf83baf9ff929c98f2ad654b97c9510f4e70cf6f661d49fd5b1",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/anstyle/1.0.8/download"
+              ],
+              "strip_prefix": "anstyle-1.0.8",
+              "build_file": "@@rules_rust+//bindgen/3rdparty/crates:BUILD.anstyle-1.0.8.bazel"
+            }
+          },
+          "rules_rust_bindgen__anstyle-parse-0.2.5": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "eb47de1e80c2b463c735db5b217a0ddc39d612e7ac9e2e96a5aed1f57616c1cb",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/anstyle-parse/0.2.5/download"
+              ],
+              "strip_prefix": "anstyle-parse-0.2.5",
+              "build_file": "@@rules_rust+//bindgen/3rdparty/crates:BUILD.anstyle-parse-0.2.5.bazel"
+            }
+          },
+          "rules_rust_bindgen__anstyle-query-1.1.1": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "6d36fc52c7f6c869915e99412912f22093507da8d9e942ceaf66fe4b7c14422a",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/anstyle-query/1.1.1/download"
+              ],
+              "strip_prefix": "anstyle-query-1.1.1",
+              "build_file": "@@rules_rust+//bindgen/3rdparty/crates:BUILD.anstyle-query-1.1.1.bazel"
+            }
+          },
+          "rules_rust_bindgen__anstyle-wincon-3.0.4": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "5bf74e1b6e971609db8ca7a9ce79fd5768ab6ae46441c572e46cf596f59e57f8",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/anstyle-wincon/3.0.4/download"
+              ],
+              "strip_prefix": "anstyle-wincon-3.0.4",
+              "build_file": "@@rules_rust+//bindgen/3rdparty/crates:BUILD.anstyle-wincon-3.0.4.bazel"
+            }
+          },
+          "rules_rust_bindgen__bindgen-0.70.1": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "f49d8fed880d473ea71efb9bf597651e77201bdd4893efe54c9e5d65ae04ce6f",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/bindgen/0.70.1/download"
+              ],
+              "strip_prefix": "bindgen-0.70.1",
+              "build_file": "@@rules_rust+//bindgen/3rdparty/crates:BUILD.bindgen-0.70.1.bazel"
+            }
+          },
+          "rules_rust_bindgen__bitflags-2.6.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/bitflags/2.6.0/download"
+              ],
+              "strip_prefix": "bitflags-2.6.0",
+              "build_file": "@@rules_rust+//bindgen/3rdparty/crates:BUILD.bitflags-2.6.0.bazel"
+            }
+          },
+          "rules_rust_bindgen__cexpr-0.6.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/cexpr/0.6.0/download"
+              ],
+              "strip_prefix": "cexpr-0.6.0",
+              "build_file": "@@rules_rust+//bindgen/3rdparty/crates:BUILD.cexpr-0.6.0.bazel"
+            }
+          },
+          "rules_rust_bindgen__cfg-if-1.0.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/cfg-if/1.0.0/download"
+              ],
+              "strip_prefix": "cfg-if-1.0.0",
+              "build_file": "@@rules_rust+//bindgen/3rdparty/crates:BUILD.cfg-if-1.0.0.bazel"
+            }
+          },
+          "rules_rust_bindgen__clang-sys-1.8.1": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/clang-sys/1.8.1/download"
+              ],
+              "strip_prefix": "clang-sys-1.8.1",
+              "build_file": "@@rules_rust+//bindgen/3rdparty/crates:BUILD.clang-sys-1.8.1.bazel"
+            }
+          },
+          "rules_rust_bindgen__clap-4.5.17": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "3e5a21b8495e732f1b3c364c9949b201ca7bae518c502c80256c96ad79eaf6ac",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/clap/4.5.17/download"
+              ],
+              "strip_prefix": "clap-4.5.17",
+              "build_file": "@@rules_rust+//bindgen/3rdparty/crates:BUILD.clap-4.5.17.bazel"
+            }
+          },
+          "rules_rust_bindgen__clap_builder-4.5.17": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "8cf2dd12af7a047ad9d6da2b6b249759a22a7abc0f474c1dae1777afa4b21a73",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/clap_builder/4.5.17/download"
+              ],
+              "strip_prefix": "clap_builder-4.5.17",
+              "build_file": "@@rules_rust+//bindgen/3rdparty/crates:BUILD.clap_builder-4.5.17.bazel"
+            }
+          },
+          "rules_rust_bindgen__clap_complete-4.5.26": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "205d5ef6d485fa47606b98b0ddc4ead26eb850aaa86abfb562a94fb3280ecba0",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/clap_complete/4.5.26/download"
+              ],
+              "strip_prefix": "clap_complete-4.5.26",
+              "build_file": "@@rules_rust+//bindgen/3rdparty/crates:BUILD.clap_complete-4.5.26.bazel"
+            }
+          },
+          "rules_rust_bindgen__clap_derive-4.5.13": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "501d359d5f3dcaf6ecdeee48833ae73ec6e42723a1e52419c79abf9507eec0a0",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/clap_derive/4.5.13/download"
+              ],
+              "strip_prefix": "clap_derive-4.5.13",
+              "build_file": "@@rules_rust+//bindgen/3rdparty/crates:BUILD.clap_derive-4.5.13.bazel"
+            }
+          },
+          "rules_rust_bindgen__clap_lex-0.7.2": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "1462739cb27611015575c0c11df5df7601141071f07518d56fcc1be504cbec97",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/clap_lex/0.7.2/download"
+              ],
+              "strip_prefix": "clap_lex-0.7.2",
+              "build_file": "@@rules_rust+//bindgen/3rdparty/crates:BUILD.clap_lex-0.7.2.bazel"
+            }
+          },
+          "rules_rust_bindgen__colorchoice-1.0.2": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "d3fd119d74b830634cea2a0f58bbd0d54540518a14397557951e79340abc28c0",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/colorchoice/1.0.2/download"
+              ],
+              "strip_prefix": "colorchoice-1.0.2",
+              "build_file": "@@rules_rust+//bindgen/3rdparty/crates:BUILD.colorchoice-1.0.2.bazel"
+            }
+          },
+          "rules_rust_bindgen__either-1.13.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/either/1.13.0/download"
+              ],
+              "strip_prefix": "either-1.13.0",
+              "build_file": "@@rules_rust+//bindgen/3rdparty/crates:BUILD.either-1.13.0.bazel"
+            }
+          },
+          "rules_rust_bindgen__env_logger-0.10.2": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "4cd405aab171cb85d6735e5c8d9db038c17d3ca007a4d2c25f337935c3d90580",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/env_logger/0.10.2/download"
+              ],
+              "strip_prefix": "env_logger-0.10.2",
+              "build_file": "@@rules_rust+//bindgen/3rdparty/crates:BUILD.env_logger-0.10.2.bazel"
+            }
+          },
+          "rules_rust_bindgen__glob-0.3.1": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/glob/0.3.1/download"
+              ],
+              "strip_prefix": "glob-0.3.1",
+              "build_file": "@@rules_rust+//bindgen/3rdparty/crates:BUILD.glob-0.3.1.bazel"
+            }
+          },
+          "rules_rust_bindgen__heck-0.5.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/heck/0.5.0/download"
+              ],
+              "strip_prefix": "heck-0.5.0",
+              "build_file": "@@rules_rust+//bindgen/3rdparty/crates:BUILD.heck-0.5.0.bazel"
+            }
+          },
+          "rules_rust_bindgen__hermit-abi-0.4.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "fbf6a919d6cf397374f7dfeeea91d974c7c0a7221d0d0f4f20d859d329e53fcc",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/hermit-abi/0.4.0/download"
+              ],
+              "strip_prefix": "hermit-abi-0.4.0",
+              "build_file": "@@rules_rust+//bindgen/3rdparty/crates:BUILD.hermit-abi-0.4.0.bazel"
+            }
+          },
+          "rules_rust_bindgen__humantime-2.1.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/humantime/2.1.0/download"
+              ],
+              "strip_prefix": "humantime-2.1.0",
+              "build_file": "@@rules_rust+//bindgen/3rdparty/crates:BUILD.humantime-2.1.0.bazel"
+            }
+          },
+          "rules_rust_bindgen__is-terminal-0.4.13": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "261f68e344040fbd0edea105bef17c66edf46f984ddb1115b775ce31be948f4b",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/is-terminal/0.4.13/download"
+              ],
+              "strip_prefix": "is-terminal-0.4.13",
+              "build_file": "@@rules_rust+//bindgen/3rdparty/crates:BUILD.is-terminal-0.4.13.bazel"
+            }
+          },
+          "rules_rust_bindgen__is_terminal_polyfill-1.70.1": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/is_terminal_polyfill/1.70.1/download"
+              ],
+              "strip_prefix": "is_terminal_polyfill-1.70.1",
+              "build_file": "@@rules_rust+//bindgen/3rdparty/crates:BUILD.is_terminal_polyfill-1.70.1.bazel"
+            }
+          },
+          "rules_rust_bindgen__itertools-0.13.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/itertools/0.13.0/download"
+              ],
+              "strip_prefix": "itertools-0.13.0",
+              "build_file": "@@rules_rust+//bindgen/3rdparty/crates:BUILD.itertools-0.13.0.bazel"
+            }
+          },
+          "rules_rust_bindgen__libc-0.2.158": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "d8adc4bb1803a324070e64a98ae98f38934d91957a99cfb3a43dcbc01bc56439",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/libc/0.2.158/download"
+              ],
+              "strip_prefix": "libc-0.2.158",
+              "build_file": "@@rules_rust+//bindgen/3rdparty/crates:BUILD.libc-0.2.158.bazel"
+            }
+          },
+          "rules_rust_bindgen__libloading-0.8.5": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "4979f22fdb869068da03c9f7528f8297c6fd2606bc3a4affe42e6a823fdb8da4",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/libloading/0.8.5/download"
+              ],
+              "strip_prefix": "libloading-0.8.5",
+              "build_file": "@@rules_rust+//bindgen/3rdparty/crates:BUILD.libloading-0.8.5.bazel"
+            }
+          },
+          "rules_rust_bindgen__log-0.4.22": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/log/0.4.22/download"
+              ],
+              "strip_prefix": "log-0.4.22",
+              "build_file": "@@rules_rust+//bindgen/3rdparty/crates:BUILD.log-0.4.22.bazel"
+            }
+          },
+          "rules_rust_bindgen__memchr-2.7.4": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/memchr/2.7.4/download"
+              ],
+              "strip_prefix": "memchr-2.7.4",
+              "build_file": "@@rules_rust+//bindgen/3rdparty/crates:BUILD.memchr-2.7.4.bazel"
+            }
+          },
+          "rules_rust_bindgen__minimal-lexical-0.2.1": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/minimal-lexical/0.2.1/download"
+              ],
+              "strip_prefix": "minimal-lexical-0.2.1",
+              "build_file": "@@rules_rust+//bindgen/3rdparty/crates:BUILD.minimal-lexical-0.2.1.bazel"
+            }
+          },
+          "rules_rust_bindgen__nom-7.1.3": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/nom/7.1.3/download"
+              ],
+              "strip_prefix": "nom-7.1.3",
+              "build_file": "@@rules_rust+//bindgen/3rdparty/crates:BUILD.nom-7.1.3.bazel"
+            }
+          },
+          "rules_rust_bindgen__prettyplease-0.2.22": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "479cf940fbbb3426c32c5d5176f62ad57549a0bb84773423ba8be9d089f5faba",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/prettyplease/0.2.22/download"
+              ],
+              "strip_prefix": "prettyplease-0.2.22",
+              "build_file": "@@rules_rust+//bindgen/3rdparty/crates:BUILD.prettyplease-0.2.22.bazel"
+            }
+          },
+          "rules_rust_bindgen__proc-macro2-1.0.86": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/proc-macro2/1.0.86/download"
+              ],
+              "strip_prefix": "proc-macro2-1.0.86",
+              "build_file": "@@rules_rust+//bindgen/3rdparty/crates:BUILD.proc-macro2-1.0.86.bazel"
+            }
+          },
+          "rules_rust_bindgen__quote-1.0.37": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/quote/1.0.37/download"
+              ],
+              "strip_prefix": "quote-1.0.37",
+              "build_file": "@@rules_rust+//bindgen/3rdparty/crates:BUILD.quote-1.0.37.bazel"
+            }
+          },
+          "rules_rust_bindgen__regex-1.10.6": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "4219d74c6b67a3654a9fbebc4b419e22126d13d2f3c4a07ee0cb61ff79a79619",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/regex/1.10.6/download"
+              ],
+              "strip_prefix": "regex-1.10.6",
+              "build_file": "@@rules_rust+//bindgen/3rdparty/crates:BUILD.regex-1.10.6.bazel"
+            }
+          },
+          "rules_rust_bindgen__regex-automata-0.4.7": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "38caf58cc5ef2fed281f89292ef23f6365465ed9a41b7a7754eb4e26496c92df",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/regex-automata/0.4.7/download"
+              ],
+              "strip_prefix": "regex-automata-0.4.7",
+              "build_file": "@@rules_rust+//bindgen/3rdparty/crates:BUILD.regex-automata-0.4.7.bazel"
+            }
+          },
+          "rules_rust_bindgen__regex-syntax-0.8.4": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/regex-syntax/0.8.4/download"
+              ],
+              "strip_prefix": "regex-syntax-0.8.4",
+              "build_file": "@@rules_rust+//bindgen/3rdparty/crates:BUILD.regex-syntax-0.8.4.bazel"
+            }
+          },
+          "rules_rust_bindgen__rustc-hash-1.1.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/rustc-hash/1.1.0/download"
+              ],
+              "strip_prefix": "rustc-hash-1.1.0",
+              "build_file": "@@rules_rust+//bindgen/3rdparty/crates:BUILD.rustc-hash-1.1.0.bazel"
+            }
+          },
+          "rules_rust_bindgen__shlex-1.3.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/shlex/1.3.0/download"
+              ],
+              "strip_prefix": "shlex-1.3.0",
+              "build_file": "@@rules_rust+//bindgen/3rdparty/crates:BUILD.shlex-1.3.0.bazel"
+            }
+          },
+          "rules_rust_bindgen__strsim-0.11.1": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/strsim/0.11.1/download"
+              ],
+              "strip_prefix": "strsim-0.11.1",
+              "build_file": "@@rules_rust+//bindgen/3rdparty/crates:BUILD.strsim-0.11.1.bazel"
+            }
+          },
+          "rules_rust_bindgen__syn-2.0.77": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "9f35bcdf61fd8e7be6caf75f429fdca8beb3ed76584befb503b1569faee373ed",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/syn/2.0.77/download"
+              ],
+              "strip_prefix": "syn-2.0.77",
+              "build_file": "@@rules_rust+//bindgen/3rdparty/crates:BUILD.syn-2.0.77.bazel"
+            }
+          },
+          "rules_rust_bindgen__termcolor-1.4.1": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/termcolor/1.4.1/download"
+              ],
+              "strip_prefix": "termcolor-1.4.1",
+              "build_file": "@@rules_rust+//bindgen/3rdparty/crates:BUILD.termcolor-1.4.1.bazel"
+            }
+          },
+          "rules_rust_bindgen__unicode-ident-1.0.13": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "e91b56cd4cadaeb79bbf1a5645f6b4f8dc5bde8834ad5894a8db35fda9efa1fe",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/unicode-ident/1.0.13/download"
+              ],
+              "strip_prefix": "unicode-ident-1.0.13",
+              "build_file": "@@rules_rust+//bindgen/3rdparty/crates:BUILD.unicode-ident-1.0.13.bazel"
+            }
+          },
+          "rules_rust_bindgen__unicode-width-0.1.13": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "0336d538f7abc86d282a4189614dfaa90810dfc2c6f6427eaf88e16311dd225d",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/unicode-width/0.1.13/download"
+              ],
+              "strip_prefix": "unicode-width-0.1.13",
+              "build_file": "@@rules_rust+//bindgen/3rdparty/crates:BUILD.unicode-width-0.1.13.bazel"
+            }
+          },
+          "rules_rust_bindgen__utf8parse-0.2.2": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/utf8parse/0.2.2/download"
+              ],
+              "strip_prefix": "utf8parse-0.2.2",
+              "build_file": "@@rules_rust+//bindgen/3rdparty/crates:BUILD.utf8parse-0.2.2.bazel"
+            }
+          },
+          "rules_rust_bindgen__winapi-0.3.9": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/winapi/0.3.9/download"
+              ],
+              "strip_prefix": "winapi-0.3.9",
+              "build_file": "@@rules_rust+//bindgen/3rdparty/crates:BUILD.winapi-0.3.9.bazel"
+            }
+          },
+          "rules_rust_bindgen__winapi-i686-pc-windows-gnu-0.4.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/winapi-i686-pc-windows-gnu/0.4.0/download"
+              ],
+              "strip_prefix": "winapi-i686-pc-windows-gnu-0.4.0",
+              "build_file": "@@rules_rust+//bindgen/3rdparty/crates:BUILD.winapi-i686-pc-windows-gnu-0.4.0.bazel"
+            }
+          },
+          "rules_rust_bindgen__winapi-util-0.1.9": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/winapi-util/0.1.9/download"
+              ],
+              "strip_prefix": "winapi-util-0.1.9",
+              "build_file": "@@rules_rust+//bindgen/3rdparty/crates:BUILD.winapi-util-0.1.9.bazel"
+            }
+          },
+          "rules_rust_bindgen__winapi-x86_64-pc-windows-gnu-0.4.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/winapi-x86_64-pc-windows-gnu/0.4.0/download"
+              ],
+              "strip_prefix": "winapi-x86_64-pc-windows-gnu-0.4.0",
+              "build_file": "@@rules_rust+//bindgen/3rdparty/crates:BUILD.winapi-x86_64-pc-windows-gnu-0.4.0.bazel"
+            }
+          },
+          "rules_rust_bindgen__windows-sys-0.52.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/windows-sys/0.52.0/download"
+              ],
+              "strip_prefix": "windows-sys-0.52.0",
+              "build_file": "@@rules_rust+//bindgen/3rdparty/crates:BUILD.windows-sys-0.52.0.bazel"
+            }
+          },
+          "rules_rust_bindgen__windows-sys-0.59.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/windows-sys/0.59.0/download"
+              ],
+              "strip_prefix": "windows-sys-0.59.0",
+              "build_file": "@@rules_rust+//bindgen/3rdparty/crates:BUILD.windows-sys-0.59.0.bazel"
+            }
+          },
+          "rules_rust_bindgen__windows-targets-0.52.6": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/windows-targets/0.52.6/download"
+              ],
+              "strip_prefix": "windows-targets-0.52.6",
+              "build_file": "@@rules_rust+//bindgen/3rdparty/crates:BUILD.windows-targets-0.52.6.bazel"
+            }
+          },
+          "rules_rust_bindgen__windows_aarch64_gnullvm-0.52.6": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/windows_aarch64_gnullvm/0.52.6/download"
+              ],
+              "strip_prefix": "windows_aarch64_gnullvm-0.52.6",
+              "build_file": "@@rules_rust+//bindgen/3rdparty/crates:BUILD.windows_aarch64_gnullvm-0.52.6.bazel"
+            }
+          },
+          "rules_rust_bindgen__windows_aarch64_msvc-0.52.6": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/windows_aarch64_msvc/0.52.6/download"
+              ],
+              "strip_prefix": "windows_aarch64_msvc-0.52.6",
+              "build_file": "@@rules_rust+//bindgen/3rdparty/crates:BUILD.windows_aarch64_msvc-0.52.6.bazel"
+            }
+          },
+          "rules_rust_bindgen__windows_i686_gnu-0.52.6": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/windows_i686_gnu/0.52.6/download"
+              ],
+              "strip_prefix": "windows_i686_gnu-0.52.6",
+              "build_file": "@@rules_rust+//bindgen/3rdparty/crates:BUILD.windows_i686_gnu-0.52.6.bazel"
+            }
+          },
+          "rules_rust_bindgen__windows_i686_gnullvm-0.52.6": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/windows_i686_gnullvm/0.52.6/download"
+              ],
+              "strip_prefix": "windows_i686_gnullvm-0.52.6",
+              "build_file": "@@rules_rust+//bindgen/3rdparty/crates:BUILD.windows_i686_gnullvm-0.52.6.bazel"
+            }
+          },
+          "rules_rust_bindgen__windows_i686_msvc-0.52.6": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/windows_i686_msvc/0.52.6/download"
+              ],
+              "strip_prefix": "windows_i686_msvc-0.52.6",
+              "build_file": "@@rules_rust+//bindgen/3rdparty/crates:BUILD.windows_i686_msvc-0.52.6.bazel"
+            }
+          },
+          "rules_rust_bindgen__windows_x86_64_gnu-0.52.6": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/windows_x86_64_gnu/0.52.6/download"
+              ],
+              "strip_prefix": "windows_x86_64_gnu-0.52.6",
+              "build_file": "@@rules_rust+//bindgen/3rdparty/crates:BUILD.windows_x86_64_gnu-0.52.6.bazel"
+            }
+          },
+          "rules_rust_bindgen__windows_x86_64_gnullvm-0.52.6": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/windows_x86_64_gnullvm/0.52.6/download"
+              ],
+              "strip_prefix": "windows_x86_64_gnullvm-0.52.6",
+              "build_file": "@@rules_rust+//bindgen/3rdparty/crates:BUILD.windows_x86_64_gnullvm-0.52.6.bazel"
+            }
+          },
+          "rules_rust_bindgen__windows_x86_64_msvc-0.52.6": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/windows_x86_64_msvc/0.52.6/download"
+              ],
+              "strip_prefix": "windows_x86_64_msvc-0.52.6",
+              "build_file": "@@rules_rust+//bindgen/3rdparty/crates:BUILD.windows_x86_64_msvc-0.52.6.bazel"
+            }
+          },
+          "rules_rust_bindgen__yansi-term-0.1.2": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "fe5c30ade05e61656247b2e334a031dfd0cc466fadef865bdcdea8d537951bf1",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/yansi-term/0.1.2/download"
+              ],
+              "strip_prefix": "yansi-term-0.1.2",
+              "build_file": "@@rules_rust+//bindgen/3rdparty/crates:BUILD.yansi-term-0.1.2.bazel"
+            }
+          },
+          "rrra__aho-corasick-1.0.2": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "43f6cb1bf222025340178f382c426f13757b2960e89779dfcb319c32542a5a41",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/aho-corasick/1.0.2/download"
+              ],
+              "strip_prefix": "aho-corasick-1.0.2",
+              "build_file": "@@rules_rust+//tools/rust_analyzer/3rdparty/crates:BUILD.aho-corasick-1.0.2.bazel"
+            }
+          },
+          "rrra__anstream-0.3.2": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "0ca84f3628370c59db74ee214b3263d58f9aadd9b4fe7e711fd87dc452b7f163",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/anstream/0.3.2/download"
+              ],
+              "strip_prefix": "anstream-0.3.2",
+              "build_file": "@@rules_rust+//tools/rust_analyzer/3rdparty/crates:BUILD.anstream-0.3.2.bazel"
+            }
+          },
+          "rrra__anstyle-1.0.1": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "3a30da5c5f2d5e72842e00bcb57657162cdabef0931f40e2deb9b4140440cecd",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/anstyle/1.0.1/download"
+              ],
+              "strip_prefix": "anstyle-1.0.1",
+              "build_file": "@@rules_rust+//tools/rust_analyzer/3rdparty/crates:BUILD.anstyle-1.0.1.bazel"
+            }
+          },
+          "rrra__anstyle-parse-0.2.1": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "938874ff5980b03a87c5524b3ae5b59cf99b1d6bc836848df7bc5ada9643c333",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/anstyle-parse/0.2.1/download"
+              ],
+              "strip_prefix": "anstyle-parse-0.2.1",
+              "build_file": "@@rules_rust+//tools/rust_analyzer/3rdparty/crates:BUILD.anstyle-parse-0.2.1.bazel"
+            }
+          },
+          "rrra__anstyle-query-1.0.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "5ca11d4be1bab0c8bc8734a9aa7bf4ee8316d462a08c6ac5052f888fef5b494b",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/anstyle-query/1.0.0/download"
+              ],
+              "strip_prefix": "anstyle-query-1.0.0",
+              "build_file": "@@rules_rust+//tools/rust_analyzer/3rdparty/crates:BUILD.anstyle-query-1.0.0.bazel"
+            }
+          },
+          "rrra__anstyle-wincon-1.0.1": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "180abfa45703aebe0093f79badacc01b8fd4ea2e35118747e5811127f926e188",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/anstyle-wincon/1.0.1/download"
+              ],
+              "strip_prefix": "anstyle-wincon-1.0.1",
+              "build_file": "@@rules_rust+//tools/rust_analyzer/3rdparty/crates:BUILD.anstyle-wincon-1.0.1.bazel"
+            }
+          },
+          "rrra__anyhow-1.0.71": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "9c7d0618f0e0b7e8ff11427422b64564d5fb0be1940354bfe2e0529b18a9d9b8",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/anyhow/1.0.71/download"
+              ],
+              "strip_prefix": "anyhow-1.0.71",
+              "build_file": "@@rules_rust+//tools/rust_analyzer/3rdparty/crates:BUILD.anyhow-1.0.71.bazel"
+            }
+          },
+          "rrra__bitflags-1.3.2": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/bitflags/1.3.2/download"
+              ],
+              "strip_prefix": "bitflags-1.3.2",
+              "build_file": "@@rules_rust+//tools/rust_analyzer/3rdparty/crates:BUILD.bitflags-1.3.2.bazel"
+            }
+          },
+          "rrra__cc-1.0.79": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/cc/1.0.79/download"
+              ],
+              "strip_prefix": "cc-1.0.79",
+              "build_file": "@@rules_rust+//tools/rust_analyzer/3rdparty/crates:BUILD.cc-1.0.79.bazel"
+            }
+          },
+          "rrra__clap-4.3.11": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "1640e5cc7fb47dbb8338fd471b105e7ed6c3cb2aeb00c2e067127ffd3764a05d",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/clap/4.3.11/download"
+              ],
+              "strip_prefix": "clap-4.3.11",
+              "build_file": "@@rules_rust+//tools/rust_analyzer/3rdparty/crates:BUILD.clap-4.3.11.bazel"
+            }
+          },
+          "rrra__clap_builder-4.3.11": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "98c59138d527eeaf9b53f35a77fcc1fad9d883116070c63d5de1c7dc7b00c72b",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/clap_builder/4.3.11/download"
+              ],
+              "strip_prefix": "clap_builder-4.3.11",
+              "build_file": "@@rules_rust+//tools/rust_analyzer/3rdparty/crates:BUILD.clap_builder-4.3.11.bazel"
+            }
+          },
+          "rrra__clap_derive-4.3.2": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "b8cd2b2a819ad6eec39e8f1d6b53001af1e5469f8c177579cdaeb313115b825f",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/clap_derive/4.3.2/download"
+              ],
+              "strip_prefix": "clap_derive-4.3.2",
+              "build_file": "@@rules_rust+//tools/rust_analyzer/3rdparty/crates:BUILD.clap_derive-4.3.2.bazel"
+            }
+          },
+          "rrra__clap_lex-0.5.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "2da6da31387c7e4ef160ffab6d5e7f00c42626fe39aea70a7b0f1773f7dd6c1b",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/clap_lex/0.5.0/download"
+              ],
+              "strip_prefix": "clap_lex-0.5.0",
+              "build_file": "@@rules_rust+//tools/rust_analyzer/3rdparty/crates:BUILD.clap_lex-0.5.0.bazel"
+            }
+          },
+          "rrra__colorchoice-1.0.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/colorchoice/1.0.0/download"
+              ],
+              "strip_prefix": "colorchoice-1.0.0",
+              "build_file": "@@rules_rust+//tools/rust_analyzer/3rdparty/crates:BUILD.colorchoice-1.0.0.bazel"
+            }
+          },
+          "rrra__either-1.8.1": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/either/1.8.1/download"
+              ],
+              "strip_prefix": "either-1.8.1",
+              "build_file": "@@rules_rust+//tools/rust_analyzer/3rdparty/crates:BUILD.either-1.8.1.bazel"
+            }
+          },
+          "rrra__env_logger-0.10.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "85cdab6a89accf66733ad5a1693a4dcced6aeff64602b634530dd73c1f3ee9f0",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/env_logger/0.10.0/download"
+              ],
+              "strip_prefix": "env_logger-0.10.0",
+              "build_file": "@@rules_rust+//tools/rust_analyzer/3rdparty/crates:BUILD.env_logger-0.10.0.bazel"
+            }
+          },
+          "rrra__errno-0.3.1": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "4bcfec3a70f97c962c307b2d2c56e358cf1d00b558d74262b5f929ee8cc7e73a",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/errno/0.3.1/download"
+              ],
+              "strip_prefix": "errno-0.3.1",
+              "build_file": "@@rules_rust+//tools/rust_analyzer/3rdparty/crates:BUILD.errno-0.3.1.bazel"
+            }
+          },
+          "rrra__errno-dragonfly-0.1.2": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/errno-dragonfly/0.1.2/download"
+              ],
+              "strip_prefix": "errno-dragonfly-0.1.2",
+              "build_file": "@@rules_rust+//tools/rust_analyzer/3rdparty/crates:BUILD.errno-dragonfly-0.1.2.bazel"
+            }
+          },
+          "rrra__heck-0.4.1": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/heck/0.4.1/download"
+              ],
+              "strip_prefix": "heck-0.4.1",
+              "build_file": "@@rules_rust+//tools/rust_analyzer/3rdparty/crates:BUILD.heck-0.4.1.bazel"
+            }
+          },
+          "rrra__hermit-abi-0.3.2": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "443144c8cdadd93ebf52ddb4056d257f5b52c04d3c804e657d19eb73fc33668b",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/hermit-abi/0.3.2/download"
+              ],
+              "strip_prefix": "hermit-abi-0.3.2",
+              "build_file": "@@rules_rust+//tools/rust_analyzer/3rdparty/crates:BUILD.hermit-abi-0.3.2.bazel"
+            }
+          },
+          "rrra__humantime-2.1.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/humantime/2.1.0/download"
+              ],
+              "strip_prefix": "humantime-2.1.0",
+              "build_file": "@@rules_rust+//tools/rust_analyzer/3rdparty/crates:BUILD.humantime-2.1.0.bazel"
+            }
+          },
+          "rrra__io-lifetimes-1.0.11": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/io-lifetimes/1.0.11/download"
+              ],
+              "strip_prefix": "io-lifetimes-1.0.11",
+              "build_file": "@@rules_rust+//tools/rust_analyzer/3rdparty/crates:BUILD.io-lifetimes-1.0.11.bazel"
+            }
+          },
+          "rrra__is-terminal-0.4.7": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "adcf93614601c8129ddf72e2d5633df827ba6551541c6d8c59520a371475be1f",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/is-terminal/0.4.7/download"
+              ],
+              "strip_prefix": "is-terminal-0.4.7",
+              "build_file": "@@rules_rust+//tools/rust_analyzer/3rdparty/crates:BUILD.is-terminal-0.4.7.bazel"
+            }
+          },
+          "rrra__itertools-0.11.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/itertools/0.11.0/download"
+              ],
+              "strip_prefix": "itertools-0.11.0",
+              "build_file": "@@rules_rust+//tools/rust_analyzer/3rdparty/crates:BUILD.itertools-0.11.0.bazel"
+            }
+          },
+          "rrra__itoa-1.0.8": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "62b02a5381cc465bd3041d84623d0fa3b66738b52b8e2fc3bab8ad63ab032f4a",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/itoa/1.0.8/download"
+              ],
+              "strip_prefix": "itoa-1.0.8",
+              "build_file": "@@rules_rust+//tools/rust_analyzer/3rdparty/crates:BUILD.itoa-1.0.8.bazel"
+            }
+          },
+          "rrra__libc-0.2.147": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/libc/0.2.147/download"
+              ],
+              "strip_prefix": "libc-0.2.147",
+              "build_file": "@@rules_rust+//tools/rust_analyzer/3rdparty/crates:BUILD.libc-0.2.147.bazel"
+            }
+          },
+          "rrra__linux-raw-sys-0.3.8": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/linux-raw-sys/0.3.8/download"
+              ],
+              "strip_prefix": "linux-raw-sys-0.3.8",
+              "build_file": "@@rules_rust+//tools/rust_analyzer/3rdparty/crates:BUILD.linux-raw-sys-0.3.8.bazel"
+            }
+          },
+          "rrra__log-0.4.19": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "b06a4cde4c0f271a446782e3eff8de789548ce57dbc8eca9292c27f4a42004b4",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/log/0.4.19/download"
+              ],
+              "strip_prefix": "log-0.4.19",
+              "build_file": "@@rules_rust+//tools/rust_analyzer/3rdparty/crates:BUILD.log-0.4.19.bazel"
+            }
+          },
+          "rrra__memchr-2.5.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/memchr/2.5.0/download"
+              ],
+              "strip_prefix": "memchr-2.5.0",
+              "build_file": "@@rules_rust+//tools/rust_analyzer/3rdparty/crates:BUILD.memchr-2.5.0.bazel"
+            }
+          },
+          "rrra__once_cell-1.18.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/once_cell/1.18.0/download"
+              ],
+              "strip_prefix": "once_cell-1.18.0",
+              "build_file": "@@rules_rust+//tools/rust_analyzer/3rdparty/crates:BUILD.once_cell-1.18.0.bazel"
+            }
+          },
+          "rrra__proc-macro2-1.0.64": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "78803b62cbf1f46fde80d7c0e803111524b9877184cfe7c3033659490ac7a7da",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/proc-macro2/1.0.64/download"
+              ],
+              "strip_prefix": "proc-macro2-1.0.64",
+              "build_file": "@@rules_rust+//tools/rust_analyzer/3rdparty/crates:BUILD.proc-macro2-1.0.64.bazel"
+            }
+          },
+          "rrra__quote-1.0.29": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "573015e8ab27661678357f27dc26460738fd2b6c86e46f386fde94cb5d913105",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/quote/1.0.29/download"
+              ],
+              "strip_prefix": "quote-1.0.29",
+              "build_file": "@@rules_rust+//tools/rust_analyzer/3rdparty/crates:BUILD.quote-1.0.29.bazel"
+            }
+          },
+          "rrra__regex-1.9.1": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "b2eae68fc220f7cf2532e4494aded17545fce192d59cd996e0fe7887f4ceb575",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/regex/1.9.1/download"
+              ],
+              "strip_prefix": "regex-1.9.1",
+              "build_file": "@@rules_rust+//tools/rust_analyzer/3rdparty/crates:BUILD.regex-1.9.1.bazel"
+            }
+          },
+          "rrra__regex-automata-0.3.3": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "39354c10dd07468c2e73926b23bb9c2caca74c5501e38a35da70406f1d923310",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/regex-automata/0.3.3/download"
+              ],
+              "strip_prefix": "regex-automata-0.3.3",
+              "build_file": "@@rules_rust+//tools/rust_analyzer/3rdparty/crates:BUILD.regex-automata-0.3.3.bazel"
+            }
+          },
+          "rrra__regex-syntax-0.7.4": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "e5ea92a5b6195c6ef2a0295ea818b312502c6fc94dde986c5553242e18fd4ce2",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/regex-syntax/0.7.4/download"
+              ],
+              "strip_prefix": "regex-syntax-0.7.4",
+              "build_file": "@@rules_rust+//tools/rust_analyzer/3rdparty/crates:BUILD.regex-syntax-0.7.4.bazel"
+            }
+          },
+          "rrra__rustix-0.37.23": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "4d69718bf81c6127a49dc64e44a742e8bb9213c0ff8869a22c308f84c1d4ab06",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/rustix/0.37.23/download"
+              ],
+              "strip_prefix": "rustix-0.37.23",
+              "build_file": "@@rules_rust+//tools/rust_analyzer/3rdparty/crates:BUILD.rustix-0.37.23.bazel"
+            }
+          },
+          "rrra__ryu-1.0.14": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "fe232bdf6be8c8de797b22184ee71118d63780ea42ac85b61d1baa6d3b782ae9",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/ryu/1.0.14/download"
+              ],
+              "strip_prefix": "ryu-1.0.14",
+              "build_file": "@@rules_rust+//tools/rust_analyzer/3rdparty/crates:BUILD.ryu-1.0.14.bazel"
+            }
+          },
+          "rrra__serde-1.0.171": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "30e27d1e4fd7659406c492fd6cfaf2066ba8773de45ca75e855590f856dc34a9",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/serde/1.0.171/download"
+              ],
+              "strip_prefix": "serde-1.0.171",
+              "build_file": "@@rules_rust+//tools/rust_analyzer/3rdparty/crates:BUILD.serde-1.0.171.bazel"
+            }
+          },
+          "rrra__serde_derive-1.0.171": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "389894603bd18c46fa56231694f8d827779c0951a667087194cf9de94ed24682",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/serde_derive/1.0.171/download"
+              ],
+              "strip_prefix": "serde_derive-1.0.171",
+              "build_file": "@@rules_rust+//tools/rust_analyzer/3rdparty/crates:BUILD.serde_derive-1.0.171.bazel"
+            }
+          },
+          "rrra__serde_json-1.0.102": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "b5062a995d481b2308b6064e9af76011f2921c35f97b0468811ed9f6cd91dfed",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/serde_json/1.0.102/download"
+              ],
+              "strip_prefix": "serde_json-1.0.102",
+              "build_file": "@@rules_rust+//tools/rust_analyzer/3rdparty/crates:BUILD.serde_json-1.0.102.bazel"
+            }
+          },
+          "rrra__strsim-0.10.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/strsim/0.10.0/download"
+              ],
+              "strip_prefix": "strsim-0.10.0",
+              "build_file": "@@rules_rust+//tools/rust_analyzer/3rdparty/crates:BUILD.strsim-0.10.0.bazel"
+            }
+          },
+          "rrra__syn-2.0.25": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "15e3fc8c0c74267e2df136e5e5fb656a464158aa57624053375eb9c8c6e25ae2",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/syn/2.0.25/download"
+              ],
+              "strip_prefix": "syn-2.0.25",
+              "build_file": "@@rules_rust+//tools/rust_analyzer/3rdparty/crates:BUILD.syn-2.0.25.bazel"
+            }
+          },
+          "rrra__termcolor-1.2.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "be55cf8942feac5c765c2c993422806843c9a9a45d4d5c407ad6dd2ea95eb9b6",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/termcolor/1.2.0/download"
+              ],
+              "strip_prefix": "termcolor-1.2.0",
+              "build_file": "@@rules_rust+//tools/rust_analyzer/3rdparty/crates:BUILD.termcolor-1.2.0.bazel"
+            }
+          },
+          "rrra__unicode-ident-1.0.10": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "22049a19f4a68748a168c0fc439f9516686aa045927ff767eca0a85101fb6e73",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/unicode-ident/1.0.10/download"
+              ],
+              "strip_prefix": "unicode-ident-1.0.10",
+              "build_file": "@@rules_rust+//tools/rust_analyzer/3rdparty/crates:BUILD.unicode-ident-1.0.10.bazel"
+            }
+          },
+          "rrra__utf8parse-0.2.1": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/utf8parse/0.2.1/download"
+              ],
+              "strip_prefix": "utf8parse-0.2.1",
+              "build_file": "@@rules_rust+//tools/rust_analyzer/3rdparty/crates:BUILD.utf8parse-0.2.1.bazel"
+            }
+          },
+          "rrra__winapi-0.3.9": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/winapi/0.3.9/download"
+              ],
+              "strip_prefix": "winapi-0.3.9",
+              "build_file": "@@rules_rust+//tools/rust_analyzer/3rdparty/crates:BUILD.winapi-0.3.9.bazel"
+            }
+          },
+          "rrra__winapi-i686-pc-windows-gnu-0.4.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/winapi-i686-pc-windows-gnu/0.4.0/download"
+              ],
+              "strip_prefix": "winapi-i686-pc-windows-gnu-0.4.0",
+              "build_file": "@@rules_rust+//tools/rust_analyzer/3rdparty/crates:BUILD.winapi-i686-pc-windows-gnu-0.4.0.bazel"
+            }
+          },
+          "rrra__winapi-util-0.1.5": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/winapi-util/0.1.5/download"
+              ],
+              "strip_prefix": "winapi-util-0.1.5",
+              "build_file": "@@rules_rust+//tools/rust_analyzer/3rdparty/crates:BUILD.winapi-util-0.1.5.bazel"
+            }
+          },
+          "rrra__winapi-x86_64-pc-windows-gnu-0.4.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/winapi-x86_64-pc-windows-gnu/0.4.0/download"
+              ],
+              "strip_prefix": "winapi-x86_64-pc-windows-gnu-0.4.0",
+              "build_file": "@@rules_rust+//tools/rust_analyzer/3rdparty/crates:BUILD.winapi-x86_64-pc-windows-gnu-0.4.0.bazel"
+            }
+          },
+          "rrra__windows-sys-0.48.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/windows-sys/0.48.0/download"
+              ],
+              "strip_prefix": "windows-sys-0.48.0",
+              "build_file": "@@rules_rust+//tools/rust_analyzer/3rdparty/crates:BUILD.windows-sys-0.48.0.bazel"
+            }
+          },
+          "rrra__windows-targets-0.48.1": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "05d4b17490f70499f20b9e791dcf6a299785ce8af4d709018206dc5b4953e95f",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/windows-targets/0.48.1/download"
+              ],
+              "strip_prefix": "windows-targets-0.48.1",
+              "build_file": "@@rules_rust+//tools/rust_analyzer/3rdparty/crates:BUILD.windows-targets-0.48.1.bazel"
+            }
+          },
+          "rrra__windows_aarch64_gnullvm-0.48.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "91ae572e1b79dba883e0d315474df7305d12f569b400fcf90581b06062f7e1bc",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/windows_aarch64_gnullvm/0.48.0/download"
+              ],
+              "strip_prefix": "windows_aarch64_gnullvm-0.48.0",
+              "build_file": "@@rules_rust+//tools/rust_analyzer/3rdparty/crates:BUILD.windows_aarch64_gnullvm-0.48.0.bazel"
+            }
+          },
+          "rrra__windows_aarch64_msvc-0.48.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "b2ef27e0d7bdfcfc7b868b317c1d32c641a6fe4629c171b8928c7b08d98d7cf3",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/windows_aarch64_msvc/0.48.0/download"
+              ],
+              "strip_prefix": "windows_aarch64_msvc-0.48.0",
+              "build_file": "@@rules_rust+//tools/rust_analyzer/3rdparty/crates:BUILD.windows_aarch64_msvc-0.48.0.bazel"
+            }
+          },
+          "rrra__windows_i686_gnu-0.48.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "622a1962a7db830d6fd0a69683c80a18fda201879f0f447f065a3b7467daa241",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/windows_i686_gnu/0.48.0/download"
+              ],
+              "strip_prefix": "windows_i686_gnu-0.48.0",
+              "build_file": "@@rules_rust+//tools/rust_analyzer/3rdparty/crates:BUILD.windows_i686_gnu-0.48.0.bazel"
+            }
+          },
+          "rrra__windows_i686_msvc-0.48.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "4542c6e364ce21bf45d69fdd2a8e455fa38d316158cfd43b3ac1c5b1b19f8e00",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/windows_i686_msvc/0.48.0/download"
+              ],
+              "strip_prefix": "windows_i686_msvc-0.48.0",
+              "build_file": "@@rules_rust+//tools/rust_analyzer/3rdparty/crates:BUILD.windows_i686_msvc-0.48.0.bazel"
+            }
+          },
+          "rrra__windows_x86_64_gnu-0.48.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "ca2b8a661f7628cbd23440e50b05d705db3686f894fc9580820623656af974b1",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/windows_x86_64_gnu/0.48.0/download"
+              ],
+              "strip_prefix": "windows_x86_64_gnu-0.48.0",
+              "build_file": "@@rules_rust+//tools/rust_analyzer/3rdparty/crates:BUILD.windows_x86_64_gnu-0.48.0.bazel"
+            }
+          },
+          "rrra__windows_x86_64_gnullvm-0.48.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "7896dbc1f41e08872e9d5e8f8baa8fdd2677f29468c4e156210174edc7f7b953",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/windows_x86_64_gnullvm/0.48.0/download"
+              ],
+              "strip_prefix": "windows_x86_64_gnullvm-0.48.0",
+              "build_file": "@@rules_rust+//tools/rust_analyzer/3rdparty/crates:BUILD.windows_x86_64_gnullvm-0.48.0.bazel"
+            }
+          },
+          "rrra__windows_x86_64_msvc-0.48.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/windows_x86_64_msvc/0.48.0/download"
+              ],
+              "strip_prefix": "windows_x86_64_msvc-0.48.0",
+              "build_file": "@@rules_rust+//tools/rust_analyzer/3rdparty/crates:BUILD.windows_x86_64_msvc-0.48.0.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen_cli": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "08f61e21873f51e3059a8c7c3eef81ede7513d161cfc60751c7b2ffa6ed28270",
+              "urls": [
+                "https://static.crates.io/crates/wasm-bindgen-cli/wasm-bindgen-cli-0.2.92.crate"
+              ],
+              "type": "tar.gz",
+              "strip_prefix": "wasm-bindgen-cli-0.2.92",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty:BUILD.wasm-bindgen-cli.bazel",
+              "patch_args": [
+                "-p1"
+              ],
+              "patches": [
+                "@@rules_rust+//wasm_bindgen/3rdparty/patches:resolver.patch"
+              ]
+            }
+          },
+          "rules_rust_wasm_bindgen__adler-1.0.2": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/adler/1.0.2/download"
+              ],
+              "strip_prefix": "adler-1.0.2",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.adler-1.0.2.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__aho-corasick-1.0.2": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "43f6cb1bf222025340178f382c426f13757b2960e89779dfcb319c32542a5a41",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/aho-corasick/1.0.2/download"
+              ],
+              "strip_prefix": "aho-corasick-1.0.2",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.aho-corasick-1.0.2.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__alloc-no-stdlib-2.0.4": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/alloc-no-stdlib/2.0.4/download"
+              ],
+              "strip_prefix": "alloc-no-stdlib-2.0.4",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.alloc-no-stdlib-2.0.4.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__alloc-stdlib-0.2.2": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "94fb8275041c72129eb51b7d0322c29b8387a0386127718b096429201a5d6ece",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/alloc-stdlib/0.2.2/download"
+              ],
+              "strip_prefix": "alloc-stdlib-0.2.2",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.alloc-stdlib-0.2.2.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__android-tzdata-0.1.1": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/android-tzdata/0.1.1/download"
+              ],
+              "strip_prefix": "android-tzdata-0.1.1",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.android-tzdata-0.1.1.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__android_system_properties-0.1.5": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/android_system_properties/0.1.5/download"
+              ],
+              "strip_prefix": "android_system_properties-0.1.5",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.android_system_properties-0.1.5.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__anyhow-1.0.71": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "9c7d0618f0e0b7e8ff11427422b64564d5fb0be1940354bfe2e0529b18a9d9b8",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/anyhow/1.0.71/download"
+              ],
+              "strip_prefix": "anyhow-1.0.71",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.anyhow-1.0.71.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__ascii-1.1.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "d92bec98840b8f03a5ff5413de5293bfcd8bf96467cf5452609f939ec6f5de16",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/ascii/1.1.0/download"
+              ],
+              "strip_prefix": "ascii-1.1.0",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.ascii-1.1.0.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__assert_cmd-1.0.8": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "c98233c6673d8601ab23e77eb38f999c51100d46c5703b17288c57fddf3a1ffe",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/assert_cmd/1.0.8/download"
+              ],
+              "strip_prefix": "assert_cmd-1.0.8",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.assert_cmd-1.0.8.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__atty-0.2.14": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/atty/0.2.14/download"
+              ],
+              "strip_prefix": "atty-0.2.14",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.atty-0.2.14.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__autocfg-1.1.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/autocfg/1.1.0/download"
+              ],
+              "strip_prefix": "autocfg-1.1.0",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.autocfg-1.1.0.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__base64-0.13.1": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/base64/0.13.1/download"
+              ],
+              "strip_prefix": "base64-0.13.1",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.base64-0.13.1.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__base64-0.21.5": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "35636a1494ede3b646cc98f74f8e62c773a38a659ebc777a2cf26b9b74171df9",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/base64/0.21.5/download"
+              ],
+              "strip_prefix": "base64-0.21.5",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.base64-0.21.5.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__bitflags-1.3.2": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/bitflags/1.3.2/download"
+              ],
+              "strip_prefix": "bitflags-1.3.2",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.bitflags-1.3.2.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__brotli-decompressor-2.5.1": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "4e2e4afe60d7dd600fdd3de8d0f08c2b7ec039712e3b6137ff98b7004e82de4f",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/brotli-decompressor/2.5.1/download"
+              ],
+              "strip_prefix": "brotli-decompressor-2.5.1",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.brotli-decompressor-2.5.1.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__bstr-0.2.17": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "ba3569f383e8f1598449f1a423e72e99569137b47740b1da11ef19af3d5c3223",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/bstr/0.2.17/download"
+              ],
+              "strip_prefix": "bstr-0.2.17",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.bstr-0.2.17.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__buf_redux-0.8.4": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "b953a6887648bb07a535631f2bc00fbdb2a2216f135552cb3f534ed136b9c07f",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/buf_redux/0.8.4/download"
+              ],
+              "strip_prefix": "buf_redux-0.8.4",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.buf_redux-0.8.4.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__bumpalo-3.13.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "a3e2c3daef883ecc1b5d58c15adae93470a91d425f3532ba1695849656af3fc1",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/bumpalo/3.13.0/download"
+              ],
+              "strip_prefix": "bumpalo-3.13.0",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.bumpalo-3.13.0.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__cc-1.0.83": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "f1174fb0b6ec23863f8b971027804a42614e347eafb0a95bf0b12cdae21fc4d0",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/cc/1.0.83/download"
+              ],
+              "strip_prefix": "cc-1.0.83",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.cc-1.0.83.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__cfg-if-1.0.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/cfg-if/1.0.0/download"
+              ],
+              "strip_prefix": "cfg-if-1.0.0",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.cfg-if-1.0.0.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__chrono-0.4.26": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "ec837a71355b28f6556dbd569b37b3f363091c0bd4b2e735674521b4c5fd9bc5",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/chrono/0.4.26/download"
+              ],
+              "strip_prefix": "chrono-0.4.26",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.chrono-0.4.26.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__chunked_transfer-1.4.1": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "cca491388666e04d7248af3f60f0c40cfb0991c72205595d7c396e3510207d1a",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/chunked_transfer/1.4.1/download"
+              ],
+              "strip_prefix": "chunked_transfer-1.4.1",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.chunked_transfer-1.4.1.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__core-foundation-sys-0.8.4": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/core-foundation-sys/0.8.4/download"
+              ],
+              "strip_prefix": "core-foundation-sys-0.8.4",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.core-foundation-sys-0.8.4.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__crc32fast-1.3.2": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/crc32fast/1.3.2/download"
+              ],
+              "strip_prefix": "crc32fast-1.3.2",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.crc32fast-1.3.2.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__crossbeam-channel-0.5.8": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "a33c2bf77f2df06183c3aa30d1e96c0695a313d4f9c453cc3762a6db39f99200",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/crossbeam-channel/0.5.8/download"
+              ],
+              "strip_prefix": "crossbeam-channel-0.5.8",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.crossbeam-channel-0.5.8.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__crossbeam-deque-0.8.3": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "ce6fd6f855243022dcecf8702fef0c297d4338e226845fe067f6341ad9fa0cef",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/crossbeam-deque/0.8.3/download"
+              ],
+              "strip_prefix": "crossbeam-deque-0.8.3",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.crossbeam-deque-0.8.3.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__crossbeam-epoch-0.9.15": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "ae211234986c545741a7dc064309f67ee1e5ad243d0e48335adc0484d960bcc7",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/crossbeam-epoch/0.9.15/download"
+              ],
+              "strip_prefix": "crossbeam-epoch-0.9.15",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.crossbeam-epoch-0.9.15.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__crossbeam-utils-0.8.16": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "5a22b2d63d4d1dc0b7f1b6b2747dd0088008a9be28b6ddf0b1e7d335e3037294",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/crossbeam-utils/0.8.16/download"
+              ],
+              "strip_prefix": "crossbeam-utils-0.8.16",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.crossbeam-utils-0.8.16.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__diff-0.1.13": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/diff/0.1.13/download"
+              ],
+              "strip_prefix": "diff-0.1.13",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.diff-0.1.13.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__difference-2.0.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "524cbf6897b527295dff137cec09ecf3a05f4fddffd7dfcd1585403449e74198",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/difference/2.0.0/download"
+              ],
+              "strip_prefix": "difference-2.0.0",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.difference-2.0.0.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__difflib-0.4.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/difflib/0.4.0/download"
+              ],
+              "strip_prefix": "difflib-0.4.0",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.difflib-0.4.0.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__doc-comment-0.3.3": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/doc-comment/0.3.3/download"
+              ],
+              "strip_prefix": "doc-comment-0.3.3",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.doc-comment-0.3.3.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__docopt-1.1.1": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "7f3f119846c823f9eafcf953a8f6ffb6ed69bf6240883261a7f13b634579a51f",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/docopt/1.1.1/download"
+              ],
+              "strip_prefix": "docopt-1.1.1",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.docopt-1.1.1.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__either-1.8.1": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/either/1.8.1/download"
+              ],
+              "strip_prefix": "either-1.8.1",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.either-1.8.1.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__env_logger-0.8.4": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "a19187fea3ac7e84da7dacf48de0c45d63c6a76f9490dae389aead16c243fce3",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/env_logger/0.8.4/download"
+              ],
+              "strip_prefix": "env_logger-0.8.4",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.env_logger-0.8.4.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__equivalent-1.0.1": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/equivalent/1.0.1/download"
+              ],
+              "strip_prefix": "equivalent-1.0.1",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.equivalent-1.0.1.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__errno-0.3.1": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "4bcfec3a70f97c962c307b2d2c56e358cf1d00b558d74262b5f929ee8cc7e73a",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/errno/0.3.1/download"
+              ],
+              "strip_prefix": "errno-0.3.1",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.errno-0.3.1.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__errno-dragonfly-0.1.2": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/errno-dragonfly/0.1.2/download"
+              ],
+              "strip_prefix": "errno-dragonfly-0.1.2",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.errno-dragonfly-0.1.2.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__fallible-iterator-0.2.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/fallible-iterator/0.2.0/download"
+              ],
+              "strip_prefix": "fallible-iterator-0.2.0",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.fallible-iterator-0.2.0.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__fastrand-1.9.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "e51093e27b0797c359783294ca4f0a911c270184cb10f85783b118614a1501be",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/fastrand/1.9.0/download"
+              ],
+              "strip_prefix": "fastrand-1.9.0",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.fastrand-1.9.0.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__filetime-0.2.21": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "5cbc844cecaee9d4443931972e1289c8ff485cb4cc2767cb03ca139ed6885153",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/filetime/0.2.21/download"
+              ],
+              "strip_prefix": "filetime-0.2.21",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.filetime-0.2.21.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__flate2-1.0.28": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "46303f565772937ffe1d394a4fac6f411c6013172fadde9dcdb1e147a086940e",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/flate2/1.0.28/download"
+              ],
+              "strip_prefix": "flate2-1.0.28",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.flate2-1.0.28.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__float-cmp-0.8.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "e1267f4ac4f343772758f7b1bdcbe767c218bbab93bb432acbf5162bbf85a6c4",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/float-cmp/0.8.0/download"
+              ],
+              "strip_prefix": "float-cmp-0.8.0",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.float-cmp-0.8.0.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__form_urlencoded-1.2.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "a62bc1cf6f830c2ec14a513a9fb124d0a213a629668a4186f329db21fe045652",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/form_urlencoded/1.2.0/download"
+              ],
+              "strip_prefix": "form_urlencoded-1.2.0",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.form_urlencoded-1.2.0.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__getrandom-0.2.10": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "be4136b2a15dd319360be1c07d9933517ccf0be8f16bf62a3bee4f0d618df427",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/getrandom/0.2.10/download"
+              ],
+              "strip_prefix": "getrandom-0.2.10",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.getrandom-0.2.10.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__gimli-0.26.2": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "22030e2c5a68ec659fde1e949a745124b48e6fa8b045b7ed5bd1fe4ccc5c4e5d",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/gimli/0.26.2/download"
+              ],
+              "strip_prefix": "gimli-0.26.2",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.gimli-0.26.2.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__hashbrown-0.12.3": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/hashbrown/0.12.3/download"
+              ],
+              "strip_prefix": "hashbrown-0.12.3",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.hashbrown-0.12.3.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__hashbrown-0.14.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "2c6201b9ff9fd90a5a3bac2e56a830d0caa509576f0e503818ee82c181b3437a",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/hashbrown/0.14.0/download"
+              ],
+              "strip_prefix": "hashbrown-0.14.0",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.hashbrown-0.14.0.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__heck-0.3.3": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/heck/0.3.3/download"
+              ],
+              "strip_prefix": "heck-0.3.3",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.heck-0.3.3.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__hermit-abi-0.1.19": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/hermit-abi/0.1.19/download"
+              ],
+              "strip_prefix": "hermit-abi-0.1.19",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.hermit-abi-0.1.19.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__hermit-abi-0.3.2": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "443144c8cdadd93ebf52ddb4056d257f5b52c04d3c804e657d19eb73fc33668b",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/hermit-abi/0.3.2/download"
+              ],
+              "strip_prefix": "hermit-abi-0.3.2",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.hermit-abi-0.3.2.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__httparse-1.8.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "d897f394bad6a705d5f4104762e116a75639e470d80901eed05a860a95cb1904",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/httparse/1.8.0/download"
+              ],
+              "strip_prefix": "httparse-1.8.0",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.httparse-1.8.0.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__httpdate-1.0.2": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/httpdate/1.0.2/download"
+              ],
+              "strip_prefix": "httpdate-1.0.2",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.httpdate-1.0.2.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__humantime-2.1.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/humantime/2.1.0/download"
+              ],
+              "strip_prefix": "humantime-2.1.0",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.humantime-2.1.0.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__iana-time-zone-0.1.57": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "2fad5b825842d2b38bd206f3e81d6957625fd7f0a361e345c30e01a0ae2dd613",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/iana-time-zone/0.1.57/download"
+              ],
+              "strip_prefix": "iana-time-zone-0.1.57",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.iana-time-zone-0.1.57.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__iana-time-zone-haiku-0.1.2": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/iana-time-zone-haiku/0.1.2/download"
+              ],
+              "strip_prefix": "iana-time-zone-haiku-0.1.2",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.iana-time-zone-haiku-0.1.2.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__id-arena-2.2.1": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "25a2bc672d1148e28034f176e01fffebb08b35768468cc954630da77a1449005",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/id-arena/2.2.1/download"
+              ],
+              "strip_prefix": "id-arena-2.2.1",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.id-arena-2.2.1.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__idna-0.4.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "7d20d6b07bfbc108882d88ed8e37d39636dcc260e15e30c45e6ba089610b917c",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/idna/0.4.0/download"
+              ],
+              "strip_prefix": "idna-0.4.0",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.idna-0.4.0.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__indexmap-1.9.3": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/indexmap/1.9.3/download"
+              ],
+              "strip_prefix": "indexmap-1.9.3",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.indexmap-1.9.3.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__indexmap-2.0.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "d5477fe2230a79769d8dc68e0eabf5437907c0457a5614a9e8dddb67f65eb65d",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/indexmap/2.0.0/download"
+              ],
+              "strip_prefix": "indexmap-2.0.0",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.indexmap-2.0.0.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__instant-0.1.12": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/instant/0.1.12/download"
+              ],
+              "strip_prefix": "instant-0.1.12",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.instant-0.1.12.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__io-lifetimes-1.0.11": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/io-lifetimes/1.0.11/download"
+              ],
+              "strip_prefix": "io-lifetimes-1.0.11",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.io-lifetimes-1.0.11.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__itertools-0.10.5": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/itertools/0.10.5/download"
+              ],
+              "strip_prefix": "itertools-0.10.5",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.itertools-0.10.5.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__itoa-1.0.8": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "62b02a5381cc465bd3041d84623d0fa3b66738b52b8e2fc3bab8ad63ab032f4a",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/itoa/1.0.8/download"
+              ],
+              "strip_prefix": "itoa-1.0.8",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.itoa-1.0.8.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__js-sys-0.3.64": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "c5f195fe497f702db0f318b07fdd68edb16955aed830df8363d837542f8f935a",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/js-sys/0.3.64/download"
+              ],
+              "strip_prefix": "js-sys-0.3.64",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.js-sys-0.3.64.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__lazy_static-1.4.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/lazy_static/1.4.0/download"
+              ],
+              "strip_prefix": "lazy_static-1.4.0",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.lazy_static-1.4.0.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__leb128-0.2.5": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "884e2677b40cc8c339eaefcb701c32ef1fd2493d71118dc0ca4b6a736c93bd67",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/leb128/0.2.5/download"
+              ],
+              "strip_prefix": "leb128-0.2.5",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.leb128-0.2.5.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__libc-0.2.150": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "89d92a4743f9a61002fae18374ed11e7973f530cb3a3255fb354818118b2203c",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/libc/0.2.150/download"
+              ],
+              "strip_prefix": "libc-0.2.150",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.libc-0.2.150.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__linux-raw-sys-0.3.8": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/linux-raw-sys/0.3.8/download"
+              ],
+              "strip_prefix": "linux-raw-sys-0.3.8",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.linux-raw-sys-0.3.8.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__log-0.4.19": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "b06a4cde4c0f271a446782e3eff8de789548ce57dbc8eca9292c27f4a42004b4",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/log/0.4.19/download"
+              ],
+              "strip_prefix": "log-0.4.19",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.log-0.4.19.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__memchr-2.5.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/memchr/2.5.0/download"
+              ],
+              "strip_prefix": "memchr-2.5.0",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.memchr-2.5.0.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__memoffset-0.9.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "5a634b1c61a95585bd15607c6ab0c4e5b226e695ff2800ba0cdccddf208c406c",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/memoffset/0.9.0/download"
+              ],
+              "strip_prefix": "memoffset-0.9.0",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.memoffset-0.9.0.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__mime-0.3.17": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/mime/0.3.17/download"
+              ],
+              "strip_prefix": "mime-0.3.17",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.mime-0.3.17.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__mime_guess-2.0.4": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "4192263c238a5f0d0c6bfd21f336a313a4ce1c450542449ca191bb657b4642ef",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/mime_guess/2.0.4/download"
+              ],
+              "strip_prefix": "mime_guess-2.0.4",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.mime_guess-2.0.4.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__miniz_oxide-0.7.1": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "e7810e0be55b428ada41041c41f32c9f1a42817901b4ccf45fa3d4b6561e74c7",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/miniz_oxide/0.7.1/download"
+              ],
+              "strip_prefix": "miniz_oxide-0.7.1",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.miniz_oxide-0.7.1.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__multipart-0.18.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "00dec633863867f29cb39df64a397cdf4a6354708ddd7759f70c7fb51c5f9182",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/multipart/0.18.0/download"
+              ],
+              "strip_prefix": "multipart-0.18.0",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.multipart-0.18.0.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__normalize-line-endings-0.3.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/normalize-line-endings/0.3.0/download"
+              ],
+              "strip_prefix": "normalize-line-endings-0.3.0",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.normalize-line-endings-0.3.0.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__num-traits-0.2.15": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/num-traits/0.2.15/download"
+              ],
+              "strip_prefix": "num-traits-0.2.15",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.num-traits-0.2.15.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__num_cpus-1.16.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/num_cpus/1.16.0/download"
+              ],
+              "strip_prefix": "num_cpus-1.16.0",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.num_cpus-1.16.0.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__num_threads-0.1.6": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "2819ce041d2ee131036f4fc9d6ae7ae125a3a40e97ba64d04fe799ad9dabbb44",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/num_threads/0.1.6/download"
+              ],
+              "strip_prefix": "num_threads-0.1.6",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.num_threads-0.1.6.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__once_cell-1.18.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/once_cell/1.18.0/download"
+              ],
+              "strip_prefix": "once_cell-1.18.0",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.once_cell-1.18.0.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__percent-encoding-2.3.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "9b2a4787296e9989611394c33f193f676704af1686e70b8f8033ab5ba9a35a94",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/percent-encoding/2.3.0/download"
+              ],
+              "strip_prefix": "percent-encoding-2.3.0",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.percent-encoding-2.3.0.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__ppv-lite86-0.2.17": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/ppv-lite86/0.2.17/download"
+              ],
+              "strip_prefix": "ppv-lite86-0.2.17",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.ppv-lite86-0.2.17.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__predicates-1.0.8": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "f49cfaf7fdaa3bfacc6fa3e7054e65148878354a5cfddcf661df4c851f8021df",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/predicates/1.0.8/download"
+              ],
+              "strip_prefix": "predicates-1.0.8",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.predicates-1.0.8.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__predicates-2.1.5": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "59230a63c37f3e18569bdb90e4a89cbf5bf8b06fea0b84e65ea10cc4df47addd",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/predicates/2.1.5/download"
+              ],
+              "strip_prefix": "predicates-2.1.5",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.predicates-2.1.5.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__predicates-core-1.0.6": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "b794032607612e7abeb4db69adb4e33590fa6cf1149e95fd7cb00e634b92f174",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/predicates-core/1.0.6/download"
+              ],
+              "strip_prefix": "predicates-core-1.0.6",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.predicates-core-1.0.6.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__predicates-tree-1.0.9": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "368ba315fb8c5052ab692e68a0eefec6ec57b23a36959c14496f0b0df2c0cecf",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/predicates-tree/1.0.9/download"
+              ],
+              "strip_prefix": "predicates-tree-1.0.9",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.predicates-tree-1.0.9.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__proc-macro2-1.0.64": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "78803b62cbf1f46fde80d7c0e803111524b9877184cfe7c3033659490ac7a7da",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/proc-macro2/1.0.64/download"
+              ],
+              "strip_prefix": "proc-macro2-1.0.64",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.proc-macro2-1.0.64.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__quick-error-1.2.3": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/quick-error/1.2.3/download"
+              ],
+              "strip_prefix": "quick-error-1.2.3",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.quick-error-1.2.3.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__quote-1.0.29": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "573015e8ab27661678357f27dc26460738fd2b6c86e46f386fde94cb5d913105",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/quote/1.0.29/download"
+              ],
+              "strip_prefix": "quote-1.0.29",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.quote-1.0.29.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__rand-0.8.5": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/rand/0.8.5/download"
+              ],
+              "strip_prefix": "rand-0.8.5",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.rand-0.8.5.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__rand_chacha-0.3.1": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/rand_chacha/0.3.1/download"
+              ],
+              "strip_prefix": "rand_chacha-0.3.1",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.rand_chacha-0.3.1.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__rand_core-0.6.4": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/rand_core/0.6.4/download"
+              ],
+              "strip_prefix": "rand_core-0.6.4",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.rand_core-0.6.4.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__rayon-1.7.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "1d2df5196e37bcc87abebc0053e20787d73847bb33134a69841207dd0a47f03b",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/rayon/1.7.0/download"
+              ],
+              "strip_prefix": "rayon-1.7.0",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.rayon-1.7.0.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__rayon-core-1.11.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "4b8f95bd6966f5c87776639160a66bd8ab9895d9d4ab01ddba9fc60661aebe8d",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/rayon-core/1.11.0/download"
+              ],
+              "strip_prefix": "rayon-core-1.11.0",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.rayon-core-1.11.0.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__redox_syscall-0.2.16": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/redox_syscall/0.2.16/download"
+              ],
+              "strip_prefix": "redox_syscall-0.2.16",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.redox_syscall-0.2.16.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__redox_syscall-0.3.5": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/redox_syscall/0.3.5/download"
+              ],
+              "strip_prefix": "redox_syscall-0.3.5",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.redox_syscall-0.3.5.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__regex-1.9.1": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "b2eae68fc220f7cf2532e4494aded17545fce192d59cd996e0fe7887f4ceb575",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/regex/1.9.1/download"
+              ],
+              "strip_prefix": "regex-1.9.1",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.regex-1.9.1.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__regex-automata-0.1.10": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/regex-automata/0.1.10/download"
+              ],
+              "strip_prefix": "regex-automata-0.1.10",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.regex-automata-0.1.10.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__regex-automata-0.3.3": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "39354c10dd07468c2e73926b23bb9c2caca74c5501e38a35da70406f1d923310",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/regex-automata/0.3.3/download"
+              ],
+              "strip_prefix": "regex-automata-0.3.3",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.regex-automata-0.3.3.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__regex-syntax-0.7.4": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "e5ea92a5b6195c6ef2a0295ea818b312502c6fc94dde986c5553242e18fd4ce2",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/regex-syntax/0.7.4/download"
+              ],
+              "strip_prefix": "regex-syntax-0.7.4",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.regex-syntax-0.7.4.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__ring-0.17.5": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "fb0205304757e5d899b9c2e448b867ffd03ae7f988002e47cd24954391394d0b",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/ring/0.17.5/download"
+              ],
+              "strip_prefix": "ring-0.17.5",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.ring-0.17.5.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__rouille-3.6.2": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "3716fbf57fc1084d7a706adf4e445298d123e4a44294c4e8213caf1b85fcc921",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/rouille/3.6.2/download"
+              ],
+              "strip_prefix": "rouille-3.6.2",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.rouille-3.6.2.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__rustc-demangle-0.1.23": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/rustc-demangle/0.1.23/download"
+              ],
+              "strip_prefix": "rustc-demangle-0.1.23",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.rustc-demangle-0.1.23.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__rustix-0.37.23": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "4d69718bf81c6127a49dc64e44a742e8bb9213c0ff8869a22c308f84c1d4ab06",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/rustix/0.37.23/download"
+              ],
+              "strip_prefix": "rustix-0.37.23",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.rustix-0.37.23.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__rustls-0.21.8": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "446e14c5cda4f3f30fe71863c34ec70f5ac79d6087097ad0bb433e1be5edf04c",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/rustls/0.21.8/download"
+              ],
+              "strip_prefix": "rustls-0.21.8",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.rustls-0.21.8.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__rustls-webpki-0.101.7": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/rustls-webpki/0.101.7/download"
+              ],
+              "strip_prefix": "rustls-webpki-0.101.7",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.rustls-webpki-0.101.7.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__ryu-1.0.14": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "fe232bdf6be8c8de797b22184ee71118d63780ea42ac85b61d1baa6d3b782ae9",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/ryu/1.0.14/download"
+              ],
+              "strip_prefix": "ryu-1.0.14",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.ryu-1.0.14.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__safemem-0.3.3": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "ef703b7cb59335eae2eb93ceb664c0eb7ea6bf567079d843e09420219668e072",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/safemem/0.3.3/download"
+              ],
+              "strip_prefix": "safemem-0.3.3",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.safemem-0.3.3.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__scopeguard-1.1.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/scopeguard/1.1.0/download"
+              ],
+              "strip_prefix": "scopeguard-1.1.0",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.scopeguard-1.1.0.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__sct-0.7.1": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/sct/0.7.1/download"
+              ],
+              "strip_prefix": "sct-0.7.1",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.sct-0.7.1.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__semver-1.0.17": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "bebd363326d05ec3e2f532ab7660680f3b02130d780c299bca73469d521bc0ed",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/semver/1.0.17/download"
+              ],
+              "strip_prefix": "semver-1.0.17",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.semver-1.0.17.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__serde-1.0.171": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "30e27d1e4fd7659406c492fd6cfaf2066ba8773de45ca75e855590f856dc34a9",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/serde/1.0.171/download"
+              ],
+              "strip_prefix": "serde-1.0.171",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.serde-1.0.171.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__serde_derive-1.0.171": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "389894603bd18c46fa56231694f8d827779c0951a667087194cf9de94ed24682",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/serde_derive/1.0.171/download"
+              ],
+              "strip_prefix": "serde_derive-1.0.171",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.serde_derive-1.0.171.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__serde_json-1.0.102": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "b5062a995d481b2308b6064e9af76011f2921c35f97b0468811ed9f6cd91dfed",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/serde_json/1.0.102/download"
+              ],
+              "strip_prefix": "serde_json-1.0.102",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.serde_json-1.0.102.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__sha1_smol-1.0.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "ae1a47186c03a32177042e55dbc5fd5aee900b8e0069a8d70fba96a9375cd012",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/sha1_smol/1.0.0/download"
+              ],
+              "strip_prefix": "sha1_smol-1.0.0",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.sha1_smol-1.0.0.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__spin-0.9.8": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/spin/0.9.8/download"
+              ],
+              "strip_prefix": "spin-0.9.8",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.spin-0.9.8.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__stable_deref_trait-1.2.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/stable_deref_trait/1.2.0/download"
+              ],
+              "strip_prefix": "stable_deref_trait-1.2.0",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.stable_deref_trait-1.2.0.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__strsim-0.10.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/strsim/0.10.0/download"
+              ],
+              "strip_prefix": "strsim-0.10.0",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.strsim-0.10.0.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__syn-1.0.109": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/syn/1.0.109/download"
+              ],
+              "strip_prefix": "syn-1.0.109",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.syn-1.0.109.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__syn-2.0.25": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "15e3fc8c0c74267e2df136e5e5fb656a464158aa57624053375eb9c8c6e25ae2",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/syn/2.0.25/download"
+              ],
+              "strip_prefix": "syn-2.0.25",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.syn-2.0.25.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__tempfile-3.6.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "31c0432476357e58790aaa47a8efb0c5138f137343f3b5f23bd36a27e3b0a6d6",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/tempfile/3.6.0/download"
+              ],
+              "strip_prefix": "tempfile-3.6.0",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.tempfile-3.6.0.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__termcolor-1.2.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "be55cf8942feac5c765c2c993422806843c9a9a45d4d5c407ad6dd2ea95eb9b6",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/termcolor/1.2.0/download"
+              ],
+              "strip_prefix": "termcolor-1.2.0",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.termcolor-1.2.0.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__termtree-0.4.1": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/termtree/0.4.1/download"
+              ],
+              "strip_prefix": "termtree-0.4.1",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.termtree-0.4.1.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__threadpool-1.8.1": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "d050e60b33d41c19108b32cea32164033a9013fe3b46cbd4457559bfbf77afaa",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/threadpool/1.8.1/download"
+              ],
+              "strip_prefix": "threadpool-1.8.1",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.threadpool-1.8.1.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__time-0.3.23": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "59e399c068f43a5d116fedaf73b203fa4f9c519f17e2b34f63221d3792f81446",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/time/0.3.23/download"
+              ],
+              "strip_prefix": "time-0.3.23",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.time-0.3.23.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__time-core-0.1.1": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "7300fbefb4dadc1af235a9cef3737cea692a9d97e1b9cbcd4ebdae6f8868e6fb",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/time-core/0.1.1/download"
+              ],
+              "strip_prefix": "time-core-0.1.1",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.time-core-0.1.1.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__tiny_http-0.12.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "389915df6413a2e74fb181895f933386023c71110878cd0825588928e64cdc82",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/tiny_http/0.12.0/download"
+              ],
+              "strip_prefix": "tiny_http-0.12.0",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.tiny_http-0.12.0.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__tinyvec-1.6.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "87cc5ceb3875bb20c2890005a4e226a4651264a5c75edb2421b52861a0a0cb50",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/tinyvec/1.6.0/download"
+              ],
+              "strip_prefix": "tinyvec-1.6.0",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.tinyvec-1.6.0.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__tinyvec_macros-0.1.1": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/tinyvec_macros/0.1.1/download"
+              ],
+              "strip_prefix": "tinyvec_macros-0.1.1",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.tinyvec_macros-0.1.1.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__twoway-0.1.8": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "59b11b2b5241ba34be09c3cc85a36e56e48f9888862e19cedf23336d35316ed1",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/twoway/0.1.8/download"
+              ],
+              "strip_prefix": "twoway-0.1.8",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.twoway-0.1.8.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__unicase-2.6.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "50f37be617794602aabbeee0be4f259dc1778fabe05e2d67ee8f79326d5cb4f6",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/unicase/2.6.0/download"
+              ],
+              "strip_prefix": "unicase-2.6.0",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.unicase-2.6.0.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__unicode-bidi-0.3.13": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "92888ba5573ff080736b3648696b70cafad7d250551175acbaa4e0385b3e1460",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/unicode-bidi/0.3.13/download"
+              ],
+              "strip_prefix": "unicode-bidi-0.3.13",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.unicode-bidi-0.3.13.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__unicode-ident-1.0.10": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "22049a19f4a68748a168c0fc439f9516686aa045927ff767eca0a85101fb6e73",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/unicode-ident/1.0.10/download"
+              ],
+              "strip_prefix": "unicode-ident-1.0.10",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.unicode-ident-1.0.10.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__unicode-normalization-0.1.22": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/unicode-normalization/0.1.22/download"
+              ],
+              "strip_prefix": "unicode-normalization-0.1.22",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.unicode-normalization-0.1.22.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__unicode-segmentation-1.10.1": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "1dd624098567895118886609431a7c3b8f516e41d30e0643f03d94592a147e36",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/unicode-segmentation/1.10.1/download"
+              ],
+              "strip_prefix": "unicode-segmentation-1.10.1",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.unicode-segmentation-1.10.1.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__untrusted-0.9.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/untrusted/0.9.0/download"
+              ],
+              "strip_prefix": "untrusted-0.9.0",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.untrusted-0.9.0.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__ureq-2.8.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "f5ccd538d4a604753ebc2f17cd9946e89b77bf87f6a8e2309667c6f2e87855e3",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/ureq/2.8.0/download"
+              ],
+              "strip_prefix": "ureq-2.8.0",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.ureq-2.8.0.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__url-2.4.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "50bff7831e19200a85b17131d085c25d7811bc4e186efdaf54bbd132994a88cb",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/url/2.4.0/download"
+              ],
+              "strip_prefix": "url-2.4.0",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.url-2.4.0.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__version_check-0.9.4": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/version_check/0.9.4/download"
+              ],
+              "strip_prefix": "version_check-0.9.4",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.version_check-0.9.4.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__wait-timeout-0.2.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/wait-timeout/0.2.0/download"
+              ],
+              "strip_prefix": "wait-timeout-0.2.0",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.wait-timeout-0.2.0.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__walrus-0.20.3": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "2c03529cd0c4400a2449f640d2f27cd1b48c3065226d15e26d98e4429ab0adb7",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/walrus/0.20.3/download"
+              ],
+              "strip_prefix": "walrus-0.20.3",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.walrus-0.20.3.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__walrus-macro-0.19.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "0a6e5bd22c71e77d60140b0bd5be56155a37e5bd14e24f5f87298040d0cc40d7",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/walrus-macro/0.19.0/download"
+              ],
+              "strip_prefix": "walrus-macro-0.19.0",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.walrus-macro-0.19.0.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__wasi-0.11.0-wasi-snapshot-preview1": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/wasi/0.11.0+wasi-snapshot-preview1/download"
+              ],
+              "strip_prefix": "wasi-0.11.0+wasi-snapshot-preview1",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.wasi-0.11.0+wasi-snapshot-preview1.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__wasm-bindgen-0.2.92": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "4be2531df63900aeb2bca0daaaddec08491ee64ceecbee5076636a3b026795a8",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/wasm-bindgen/0.2.92/download"
+              ],
+              "strip_prefix": "wasm-bindgen-0.2.92",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.wasm-bindgen-0.2.92.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__wasm-bindgen-backend-0.2.92": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "614d787b966d3989fa7bb98a654e369c762374fd3213d212cfc0251257e747da",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/wasm-bindgen-backend/0.2.92/download"
+              ],
+              "strip_prefix": "wasm-bindgen-backend-0.2.92",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.wasm-bindgen-backend-0.2.92.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__wasm-bindgen-cli-support-0.2.92": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "ca821da8c1ae6c87c5e94493939a206daa8587caff227c6032e0061a3d80817f",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/wasm-bindgen-cli-support/0.2.92/download"
+              ],
+              "strip_prefix": "wasm-bindgen-cli-support-0.2.92",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.wasm-bindgen-cli-support-0.2.92.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__wasm-bindgen-externref-xform-0.2.92": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "102582726b35a30d53157fbf8de3d0f0fed4c40c0c7951d69a034e9ef01da725",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/wasm-bindgen-externref-xform/0.2.92/download"
+              ],
+              "strip_prefix": "wasm-bindgen-externref-xform-0.2.92",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.wasm-bindgen-externref-xform-0.2.92.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__wasm-bindgen-macro-0.2.92": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "a1f8823de937b71b9460c0c34e25f3da88250760bec0ebac694b49997550d726",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/wasm-bindgen-macro/0.2.92/download"
+              ],
+              "strip_prefix": "wasm-bindgen-macro-0.2.92",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.wasm-bindgen-macro-0.2.92.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__wasm-bindgen-macro-support-0.2.92": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/wasm-bindgen-macro-support/0.2.92/download"
+              ],
+              "strip_prefix": "wasm-bindgen-macro-support-0.2.92",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.wasm-bindgen-macro-support-0.2.92.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__wasm-bindgen-multi-value-xform-0.2.92": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "3498e4799f43523d780ceff498f04d882a8dbc9719c28020034822e5952f32a4",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/wasm-bindgen-multi-value-xform/0.2.92/download"
+              ],
+              "strip_prefix": "wasm-bindgen-multi-value-xform-0.2.92",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.wasm-bindgen-multi-value-xform-0.2.92.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__wasm-bindgen-shared-0.2.92": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "af190c94f2773fdb3729c55b007a722abb5384da03bc0986df4c289bf5567e96",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/wasm-bindgen-shared/0.2.92/download"
+              ],
+              "strip_prefix": "wasm-bindgen-shared-0.2.92",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.wasm-bindgen-shared-0.2.92.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__wasm-bindgen-threads-xform-0.2.92": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "2d5add359b7f7d09a55299a9d29be54414264f2b8cf84f8c8fda5be9269b5dd9",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/wasm-bindgen-threads-xform/0.2.92/download"
+              ],
+              "strip_prefix": "wasm-bindgen-threads-xform-0.2.92",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.wasm-bindgen-threads-xform-0.2.92.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__wasm-bindgen-wasm-conventions-0.2.92": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "8c04e3607b810e76768260db3a5f2e8beb477cb089ef8726da85c8eb9bd3b575",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/wasm-bindgen-wasm-conventions/0.2.92/download"
+              ],
+              "strip_prefix": "wasm-bindgen-wasm-conventions-0.2.92",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.wasm-bindgen-wasm-conventions-0.2.92.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__wasm-bindgen-wasm-interpreter-0.2.92": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "9ea966593c8243a33eb4d643254eb97a69de04e89462f46cf6b4f506aae89b3a",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/wasm-bindgen-wasm-interpreter/0.2.92/download"
+              ],
+              "strip_prefix": "wasm-bindgen-wasm-interpreter-0.2.92",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.wasm-bindgen-wasm-interpreter-0.2.92.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__wasm-encoder-0.29.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "18c41dbd92eaebf3612a39be316540b8377c871cb9bde6b064af962984912881",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/wasm-encoder/0.29.0/download"
+              ],
+              "strip_prefix": "wasm-encoder-0.29.0",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.wasm-encoder-0.29.0.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__wasmparser-0.102.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "48134de3d7598219ab9eaf6b91b15d8e50d31da76b8519fe4ecfcec2cf35104b",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/wasmparser/0.102.0/download"
+              ],
+              "strip_prefix": "wasmparser-0.102.0",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.wasmparser-0.102.0.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__wasmparser-0.108.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "76c956109dcb41436a39391139d9b6e2d0a5e0b158e1293ef352ec977e5e36c5",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/wasmparser/0.108.0/download"
+              ],
+              "strip_prefix": "wasmparser-0.108.0",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.wasmparser-0.108.0.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__wasmparser-0.80.2": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "449167e2832691a1bff24cde28d2804e90e09586a448c8e76984792c44334a6b",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/wasmparser/0.80.2/download"
+              ],
+              "strip_prefix": "wasmparser-0.80.2",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.wasmparser-0.80.2.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__wasmprinter-0.2.60": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "b76cb909fe3d9b0de58cee1f4072247e680ff5cc1558ccad2790a9de14a23993",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/wasmprinter/0.2.60/download"
+              ],
+              "strip_prefix": "wasmprinter-0.2.60",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.wasmprinter-0.2.60.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__webpki-roots-0.25.2": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "14247bb57be4f377dfb94c72830b8ce8fc6beac03cf4bf7b9732eadd414123fc",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/webpki-roots/0.25.2/download"
+              ],
+              "strip_prefix": "webpki-roots-0.25.2",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.webpki-roots-0.25.2.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__winapi-0.3.9": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/winapi/0.3.9/download"
+              ],
+              "strip_prefix": "winapi-0.3.9",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.winapi-0.3.9.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__winapi-i686-pc-windows-gnu-0.4.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/winapi-i686-pc-windows-gnu/0.4.0/download"
+              ],
+              "strip_prefix": "winapi-i686-pc-windows-gnu-0.4.0",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.winapi-i686-pc-windows-gnu-0.4.0.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__winapi-util-0.1.5": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/winapi-util/0.1.5/download"
+              ],
+              "strip_prefix": "winapi-util-0.1.5",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.winapi-util-0.1.5.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__winapi-x86_64-pc-windows-gnu-0.4.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/winapi-x86_64-pc-windows-gnu/0.4.0/download"
+              ],
+              "strip_prefix": "winapi-x86_64-pc-windows-gnu-0.4.0",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.winapi-x86_64-pc-windows-gnu-0.4.0.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__windows-0.48.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "e686886bc078bc1b0b600cac0147aadb815089b6e4da64016cbd754b6342700f",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/windows/0.48.0/download"
+              ],
+              "strip_prefix": "windows-0.48.0",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.windows-0.48.0.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__windows-sys-0.48.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/windows-sys/0.48.0/download"
+              ],
+              "strip_prefix": "windows-sys-0.48.0",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.windows-sys-0.48.0.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__windows-targets-0.48.1": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "05d4b17490f70499f20b9e791dcf6a299785ce8af4d709018206dc5b4953e95f",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/windows-targets/0.48.1/download"
+              ],
+              "strip_prefix": "windows-targets-0.48.1",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.windows-targets-0.48.1.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__windows_aarch64_gnullvm-0.48.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "91ae572e1b79dba883e0d315474df7305d12f569b400fcf90581b06062f7e1bc",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/windows_aarch64_gnullvm/0.48.0/download"
+              ],
+              "strip_prefix": "windows_aarch64_gnullvm-0.48.0",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.windows_aarch64_gnullvm-0.48.0.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__windows_aarch64_msvc-0.48.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "b2ef27e0d7bdfcfc7b868b317c1d32c641a6fe4629c171b8928c7b08d98d7cf3",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/windows_aarch64_msvc/0.48.0/download"
+              ],
+              "strip_prefix": "windows_aarch64_msvc-0.48.0",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.windows_aarch64_msvc-0.48.0.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__windows_i686_gnu-0.48.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "622a1962a7db830d6fd0a69683c80a18fda201879f0f447f065a3b7467daa241",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/windows_i686_gnu/0.48.0/download"
+              ],
+              "strip_prefix": "windows_i686_gnu-0.48.0",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.windows_i686_gnu-0.48.0.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__windows_i686_msvc-0.48.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "4542c6e364ce21bf45d69fdd2a8e455fa38d316158cfd43b3ac1c5b1b19f8e00",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/windows_i686_msvc/0.48.0/download"
+              ],
+              "strip_prefix": "windows_i686_msvc-0.48.0",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.windows_i686_msvc-0.48.0.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__windows_x86_64_gnu-0.48.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "ca2b8a661f7628cbd23440e50b05d705db3686f894fc9580820623656af974b1",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/windows_x86_64_gnu/0.48.0/download"
+              ],
+              "strip_prefix": "windows_x86_64_gnu-0.48.0",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.windows_x86_64_gnu-0.48.0.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__windows_x86_64_gnullvm-0.48.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "7896dbc1f41e08872e9d5e8f8baa8fdd2677f29468c4e156210174edc7f7b953",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/windows_x86_64_gnullvm/0.48.0/download"
+              ],
+              "strip_prefix": "windows_x86_64_gnullvm-0.48.0",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.windows_x86_64_gnullvm-0.48.0.bazel"
+            }
+          },
+          "rules_rust_wasm_bindgen__windows_x86_64_msvc-0.48.0": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/windows_x86_64_msvc/0.48.0/download"
+              ],
+              "strip_prefix": "windows_x86_64_msvc-0.48.0",
+              "build_file": "@@rules_rust+//wasm_bindgen/3rdparty/crates:BUILD.windows_x86_64_msvc-0.48.0.bazel"
+            }
+          },
+          "rules_rust_test_load_arbitrary_tool": {
+            "repoRuleId": "@@rules_rust+//test/load_arbitrary_tool:load_arbitrary_tool_test.bzl%_load_arbitrary_tool_test",
+            "attributes": {}
+          },
+          "generated_inputs_in_external_repo": {
+            "repoRuleId": "@@rules_rust+//test/generated_inputs:external_repo.bzl%_generated_inputs_in_external_repo",
+            "attributes": {}
+          },
+          "libc": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "build_file_content": "load(\"@rules_rust//rust:defs.bzl\", \"rust_library\")\n\nrust_library(\n    name = \"libc\",\n    srcs = glob([\"src/**/*.rs\"]),\n    edition = \"2015\",\n    rustc_flags = [\n        # In most cases, warnings in 3rd party crates are not interesting as\n        # they're out of the control of consumers. The flag here silences\n        # warnings. For more details see:\n        # https://doc.rust-lang.org/rustc/lints/levels.html\n        \"--cap-lints=allow\",\n    ],\n    visibility = [\"//visibility:public\"],\n)\n",
+              "sha256": "1ac4c2ac6ed5a8fb9020c166bc63316205f1dc78d4b964ad31f4f21eb73f0c6d",
+              "strip_prefix": "libc-0.2.20",
+              "urls": [
+                "https://mirror.bazel.build/github.com/rust-lang/libc/archive/0.2.20.zip",
+                "https://github.com/rust-lang/libc/archive/0.2.20.zip"
+              ]
+            }
+          },
+          "rules_rust_toolchain_test_target_json": {
+            "repoRuleId": "@@rules_rust+//test/unit/toolchain:toolchain_test_utils.bzl%rules_rust_toolchain_test_target_json_repository",
+            "attributes": {
+              "target_json": "@@rules_rust+//test/unit/toolchain:toolchain-test-triple.json"
+            }
+          },
+          "com_google_googleapis": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "urls": [
+                "https://github.com/googleapis/googleapis/archive/18becb1d1426feb7399db144d7beeb3284f1ccb0.zip"
+              ],
+              "strip_prefix": "googleapis-18becb1d1426feb7399db144d7beeb3284f1ccb0",
+              "sha256": "b8c487191eb942361af905e40172644eab490190e717c3d09bf83e87f3994fff"
+            }
+          },
+          "rules_python": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "778aaeab3e6cfd56d681c89f5c10d7ad6bf8d2f1a72de9de55b23081b2d31618",
+              "strip_prefix": "rules_python-0.34.0",
+              "url": "https://github.com/bazelbuild/rules_python/releases/download/0.34.0/rules_python-0.34.0.tar.gz"
+            }
+          }
+        },
+        "moduleExtensionMetadata": {
+          "explicitRootModuleDirectDeps": [
+            "rules_rust_tinyjson",
+            "cui",
+            "cui__anyhow-1.0.89",
+            "cui__camino-1.1.9",
+            "cui__cargo-lock-10.0.0",
+            "cui__cargo-platform-0.1.7",
+            "cui__cargo_metadata-0.18.1",
+            "cui__cargo_toml-0.20.5",
+            "cui__cfg-expr-0.17.0",
+            "cui__clap-4.3.11",
+            "cui__crates-index-3.2.0",
+            "cui__hex-0.4.3",
+            "cui__indoc-2.0.5",
+            "cui__itertools-0.13.0",
+            "cui__normpath-1.3.0",
+            "cui__once_cell-1.20.2",
+            "cui__pathdiff-0.2.2",
+            "cui__regex-1.11.0",
+            "cui__semver-1.0.23",
+            "cui__serde-1.0.210",
+            "cui__serde_json-1.0.129",
+            "cui__serde_starlark-0.1.16",
+            "cui__sha2-0.10.8",
+            "cui__spdx-0.10.6",
+            "cui__tempfile-3.13.0",
+            "cui__tera-1.19.1",
+            "cui__textwrap-0.16.1",
+            "cui__toml-0.8.19",
+            "cui__tracing-0.1.40",
+            "cui__tracing-subscriber-0.3.18",
+            "cui__url-2.5.2",
+            "cui__maplit-1.0.2",
+            "cargo_bazel.buildifier-darwin-amd64",
+            "cargo_bazel.buildifier-darwin-arm64",
+            "cargo_bazel.buildifier-linux-amd64",
+            "cargo_bazel.buildifier-linux-arm64",
+            "cargo_bazel.buildifier-linux-s390x",
+            "cargo_bazel.buildifier-windows-amd64.exe",
+            "rules_rust_prost__heck",
+            "rules_rust_prost",
+            "rules_rust_prost__h2-0.4.6",
+            "rules_rust_prost__prost-0.13.1",
+            "rules_rust_prost__prost-types-0.13.1",
+            "rules_rust_prost__protoc-gen-prost-0.4.0",
+            "rules_rust_prost__protoc-gen-tonic-0.4.1",
+            "rules_rust_prost__tokio-1.39.3",
+            "rules_rust_prost__tokio-stream-0.1.15",
+            "rules_rust_prost__tonic-0.12.1",
+            "rules_rust_proto__grpc-0.6.2",
+            "rules_rust_proto__grpc-compiler-0.6.2",
+            "rules_rust_proto__log-0.4.17",
+            "rules_rust_proto__protobuf-2.8.2",
+            "rules_rust_proto__protobuf-codegen-2.8.2",
+            "rules_rust_proto__tls-api-0.1.22",
+            "rules_rust_proto__tls-api-stub-0.1.22",
+            "llvm-raw",
+            "rules_rust_bindgen__bindgen-cli-0.70.1",
+            "rules_rust_bindgen__bindgen-0.70.1",
+            "rules_rust_bindgen__clang-sys-1.8.1",
+            "rules_rust_bindgen__clap-4.5.17",
+            "rules_rust_bindgen__clap_complete-4.5.26",
+            "rules_rust_bindgen__env_logger-0.10.2",
+            "rrra__anyhow-1.0.71",
+            "rrra__clap-4.3.11",
+            "rrra__env_logger-0.10.0",
+            "rrra__itertools-0.11.0",
+            "rrra__log-0.4.19",
+            "rrra__serde-1.0.171",
+            "rrra__serde_json-1.0.102",
+            "rules_rust_wasm_bindgen_cli",
+            "rules_rust_wasm_bindgen__anyhow-1.0.71",
+            "rules_rust_wasm_bindgen__docopt-1.1.1",
+            "rules_rust_wasm_bindgen__env_logger-0.8.4",
+            "rules_rust_wasm_bindgen__log-0.4.19",
+            "rules_rust_wasm_bindgen__rouille-3.6.2",
+            "rules_rust_wasm_bindgen__serde-1.0.171",
+            "rules_rust_wasm_bindgen__serde_derive-1.0.171",
+            "rules_rust_wasm_bindgen__serde_json-1.0.102",
+            "rules_rust_wasm_bindgen__ureq-2.8.0",
+            "rules_rust_wasm_bindgen__walrus-0.20.3",
+            "rules_rust_wasm_bindgen__wasm-bindgen-0.2.92",
+            "rules_rust_wasm_bindgen__wasm-bindgen-cli-support-0.2.92",
+            "rules_rust_wasm_bindgen__wasm-bindgen-shared-0.2.92",
+            "rules_rust_wasm_bindgen__assert_cmd-1.0.8",
+            "rules_rust_wasm_bindgen__diff-0.1.13",
+            "rules_rust_wasm_bindgen__predicates-1.0.8",
+            "rules_rust_wasm_bindgen__rayon-1.7.0",
+            "rules_rust_wasm_bindgen__tempfile-3.6.0",
+            "rules_rust_wasm_bindgen__wasmparser-0.102.0",
+            "rules_rust_wasm_bindgen__wasmprinter-0.2.60",
+            "rules_rust_test_load_arbitrary_tool",
+            "generated_inputs_in_external_repo",
+            "libc",
+            "rules_rust_toolchain_test_target_json",
+            "com_google_googleapis",
+            "rules_python"
+          ],
+          "explicitRootModuleDirectDevDeps": [],
+          "useAllRepos": "NO",
+          "reproducible": false
+        },
+        "recordedRepoMappingEntries": [
+          [
+            "bazel_tools",
+            "rules_cc",
+            "rules_cc+"
+          ],
+          [
+            "rules_cc+",
+            "bazel_tools",
+            "bazel_tools"
+          ],
+          [
+            "rules_cc+",
+            "rules_cc",
+            "rules_cc+"
+          ],
+          [
+            "rules_rust+",
+            "bazel_skylib",
+            "bazel_skylib+"
+          ],
+          [
+            "rules_rust+",
+            "bazel_tools",
+            "bazel_tools"
+          ],
+          [
+            "rules_rust+",
+            "cui__anyhow-1.0.89",
+            "rules_rust++i+cui__anyhow-1.0.89"
+          ],
+          [
+            "rules_rust+",
+            "cui__camino-1.1.9",
+            "rules_rust++i+cui__camino-1.1.9"
+          ],
+          [
+            "rules_rust+",
+            "cui__cargo-lock-10.0.0",
+            "rules_rust++i+cui__cargo-lock-10.0.0"
+          ],
+          [
+            "rules_rust+",
+            "cui__cargo-platform-0.1.7",
+            "rules_rust++i+cui__cargo-platform-0.1.7"
+          ],
+          [
+            "rules_rust+",
+            "cui__cargo_metadata-0.18.1",
+            "rules_rust++i+cui__cargo_metadata-0.18.1"
+          ],
+          [
+            "rules_rust+",
+            "cui__cargo_toml-0.20.5",
+            "rules_rust++i+cui__cargo_toml-0.20.5"
+          ],
+          [
+            "rules_rust+",
+            "cui__cfg-expr-0.17.0",
+            "rules_rust++i+cui__cfg-expr-0.17.0"
+          ],
+          [
+            "rules_rust+",
+            "cui__clap-4.3.11",
+            "rules_rust++i+cui__clap-4.3.11"
+          ],
+          [
+            "rules_rust+",
+            "cui__crates-index-3.2.0",
+            "rules_rust++i+cui__crates-index-3.2.0"
+          ],
+          [
+            "rules_rust+",
+            "cui__hex-0.4.3",
+            "rules_rust++i+cui__hex-0.4.3"
+          ],
+          [
+            "rules_rust+",
+            "cui__indoc-2.0.5",
+            "rules_rust++i+cui__indoc-2.0.5"
+          ],
+          [
+            "rules_rust+",
+            "cui__itertools-0.13.0",
+            "rules_rust++i+cui__itertools-0.13.0"
+          ],
+          [
+            "rules_rust+",
+            "cui__maplit-1.0.2",
+            "rules_rust++i+cui__maplit-1.0.2"
+          ],
+          [
+            "rules_rust+",
+            "cui__normpath-1.3.0",
+            "rules_rust++i+cui__normpath-1.3.0"
+          ],
+          [
+            "rules_rust+",
+            "cui__once_cell-1.20.2",
+            "rules_rust++i+cui__once_cell-1.20.2"
+          ],
+          [
+            "rules_rust+",
+            "cui__pathdiff-0.2.2",
+            "rules_rust++i+cui__pathdiff-0.2.2"
+          ],
+          [
+            "rules_rust+",
+            "cui__regex-1.11.0",
+            "rules_rust++i+cui__regex-1.11.0"
+          ],
+          [
+            "rules_rust+",
+            "cui__semver-1.0.23",
+            "rules_rust++i+cui__semver-1.0.23"
+          ],
+          [
+            "rules_rust+",
+            "cui__serde-1.0.210",
+            "rules_rust++i+cui__serde-1.0.210"
+          ],
+          [
+            "rules_rust+",
+            "cui__serde_json-1.0.129",
+            "rules_rust++i+cui__serde_json-1.0.129"
+          ],
+          [
+            "rules_rust+",
+            "cui__serde_starlark-0.1.16",
+            "rules_rust++i+cui__serde_starlark-0.1.16"
+          ],
+          [
+            "rules_rust+",
+            "cui__sha2-0.10.8",
+            "rules_rust++i+cui__sha2-0.10.8"
+          ],
+          [
+            "rules_rust+",
+            "cui__spdx-0.10.6",
+            "rules_rust++i+cui__spdx-0.10.6"
+          ],
+          [
+            "rules_rust+",
+            "cui__tempfile-3.13.0",
+            "rules_rust++i+cui__tempfile-3.13.0"
+          ],
+          [
+            "rules_rust+",
+            "cui__tera-1.19.1",
+            "rules_rust++i+cui__tera-1.19.1"
+          ],
+          [
+            "rules_rust+",
+            "cui__textwrap-0.16.1",
+            "rules_rust++i+cui__textwrap-0.16.1"
+          ],
+          [
+            "rules_rust+",
+            "cui__toml-0.8.19",
+            "rules_rust++i+cui__toml-0.8.19"
+          ],
+          [
+            "rules_rust+",
+            "cui__tracing-0.1.40",
+            "rules_rust++i+cui__tracing-0.1.40"
+          ],
+          [
+            "rules_rust+",
+            "cui__tracing-subscriber-0.3.18",
+            "rules_rust++i+cui__tracing-subscriber-0.3.18"
+          ],
+          [
+            "rules_rust+",
+            "cui__url-2.5.2",
+            "rules_rust++i+cui__url-2.5.2"
+          ],
+          [
+            "rules_rust+",
+            "rrra__anyhow-1.0.71",
+            "rules_rust++i+rrra__anyhow-1.0.71"
+          ],
+          [
+            "rules_rust+",
+            "rrra__clap-4.3.11",
+            "rules_rust++i+rrra__clap-4.3.11"
+          ],
+          [
+            "rules_rust+",
+            "rrra__env_logger-0.10.0",
+            "rules_rust++i+rrra__env_logger-0.10.0"
+          ],
+          [
+            "rules_rust+",
+            "rrra__itertools-0.11.0",
+            "rules_rust++i+rrra__itertools-0.11.0"
+          ],
+          [
+            "rules_rust+",
+            "rrra__log-0.4.19",
+            "rules_rust++i+rrra__log-0.4.19"
+          ],
+          [
+            "rules_rust+",
+            "rrra__serde-1.0.171",
+            "rules_rust++i+rrra__serde-1.0.171"
+          ],
+          [
+            "rules_rust+",
+            "rrra__serde_json-1.0.102",
+            "rules_rust++i+rrra__serde_json-1.0.102"
+          ],
+          [
+            "rules_rust+",
+            "rules_cc",
+            "rules_cc+"
+          ],
+          [
+            "rules_rust+",
+            "rules_rust",
+            "rules_rust+"
+          ],
+          [
+            "rules_rust+",
+            "rules_rust_bindgen__bindgen-0.70.1",
+            "rules_rust++i+rules_rust_bindgen__bindgen-0.70.1"
+          ],
+          [
+            "rules_rust+",
+            "rules_rust_bindgen__clang-sys-1.8.1",
+            "rules_rust++i+rules_rust_bindgen__clang-sys-1.8.1"
+          ],
+          [
+            "rules_rust+",
+            "rules_rust_bindgen__clap-4.5.17",
+            "rules_rust++i+rules_rust_bindgen__clap-4.5.17"
+          ],
+          [
+            "rules_rust+",
+            "rules_rust_bindgen__clap_complete-4.5.26",
+            "rules_rust++i+rules_rust_bindgen__clap_complete-4.5.26"
+          ],
+          [
+            "rules_rust+",
+            "rules_rust_bindgen__env_logger-0.10.2",
+            "rules_rust++i+rules_rust_bindgen__env_logger-0.10.2"
+          ],
+          [
+            "rules_rust+",
+            "rules_rust_prost__h2-0.4.6",
+            "rules_rust++i+rules_rust_prost__h2-0.4.6"
+          ],
+          [
+            "rules_rust+",
+            "rules_rust_prost__prost-0.13.1",
+            "rules_rust++i+rules_rust_prost__prost-0.13.1"
+          ],
+          [
+            "rules_rust+",
+            "rules_rust_prost__prost-types-0.13.1",
+            "rules_rust++i+rules_rust_prost__prost-types-0.13.1"
+          ],
+          [
+            "rules_rust+",
+            "rules_rust_prost__protoc-gen-prost-0.4.0",
+            "rules_rust++i+rules_rust_prost__protoc-gen-prost-0.4.0"
+          ],
+          [
+            "rules_rust+",
+            "rules_rust_prost__protoc-gen-tonic-0.4.1",
+            "rules_rust++i+rules_rust_prost__protoc-gen-tonic-0.4.1"
+          ],
+          [
+            "rules_rust+",
+            "rules_rust_prost__tokio-1.39.3",
+            "rules_rust++i+rules_rust_prost__tokio-1.39.3"
+          ],
+          [
+            "rules_rust+",
+            "rules_rust_prost__tokio-stream-0.1.15",
+            "rules_rust++i+rules_rust_prost__tokio-stream-0.1.15"
+          ],
+          [
+            "rules_rust+",
+            "rules_rust_prost__tonic-0.12.1",
+            "rules_rust++i+rules_rust_prost__tonic-0.12.1"
+          ],
+          [
+            "rules_rust+",
+            "rules_rust_proto__grpc-0.6.2",
+            "rules_rust++i+rules_rust_proto__grpc-0.6.2"
+          ],
+          [
+            "rules_rust+",
+            "rules_rust_proto__grpc-compiler-0.6.2",
+            "rules_rust++i+rules_rust_proto__grpc-compiler-0.6.2"
+          ],
+          [
+            "rules_rust+",
+            "rules_rust_proto__log-0.4.17",
+            "rules_rust++i+rules_rust_proto__log-0.4.17"
+          ],
+          [
+            "rules_rust+",
+            "rules_rust_proto__protobuf-2.8.2",
+            "rules_rust++i+rules_rust_proto__protobuf-2.8.2"
+          ],
+          [
+            "rules_rust+",
+            "rules_rust_proto__protobuf-codegen-2.8.2",
+            "rules_rust++i+rules_rust_proto__protobuf-codegen-2.8.2"
+          ],
+          [
+            "rules_rust+",
+            "rules_rust_proto__tls-api-0.1.22",
+            "rules_rust++i+rules_rust_proto__tls-api-0.1.22"
+          ],
+          [
+            "rules_rust+",
+            "rules_rust_proto__tls-api-stub-0.1.22",
+            "rules_rust++i+rules_rust_proto__tls-api-stub-0.1.22"
+          ],
+          [
+            "rules_rust+",
+            "rules_rust_wasm_bindgen__anyhow-1.0.71",
+            "rules_rust++i+rules_rust_wasm_bindgen__anyhow-1.0.71"
+          ],
+          [
+            "rules_rust+",
+            "rules_rust_wasm_bindgen__assert_cmd-1.0.8",
+            "rules_rust++i+rules_rust_wasm_bindgen__assert_cmd-1.0.8"
+          ],
+          [
+            "rules_rust+",
+            "rules_rust_wasm_bindgen__diff-0.1.13",
+            "rules_rust++i+rules_rust_wasm_bindgen__diff-0.1.13"
+          ],
+          [
+            "rules_rust+",
+            "rules_rust_wasm_bindgen__docopt-1.1.1",
+            "rules_rust++i+rules_rust_wasm_bindgen__docopt-1.1.1"
+          ],
+          [
+            "rules_rust+",
+            "rules_rust_wasm_bindgen__env_logger-0.8.4",
+            "rules_rust++i+rules_rust_wasm_bindgen__env_logger-0.8.4"
+          ],
+          [
+            "rules_rust+",
+            "rules_rust_wasm_bindgen__log-0.4.19",
+            "rules_rust++i+rules_rust_wasm_bindgen__log-0.4.19"
+          ],
+          [
+            "rules_rust+",
+            "rules_rust_wasm_bindgen__predicates-1.0.8",
+            "rules_rust++i+rules_rust_wasm_bindgen__predicates-1.0.8"
+          ],
+          [
+            "rules_rust+",
+            "rules_rust_wasm_bindgen__rayon-1.7.0",
+            "rules_rust++i+rules_rust_wasm_bindgen__rayon-1.7.0"
+          ],
+          [
+            "rules_rust+",
+            "rules_rust_wasm_bindgen__rouille-3.6.2",
+            "rules_rust++i+rules_rust_wasm_bindgen__rouille-3.6.2"
+          ],
+          [
+            "rules_rust+",
+            "rules_rust_wasm_bindgen__serde-1.0.171",
+            "rules_rust++i+rules_rust_wasm_bindgen__serde-1.0.171"
+          ],
+          [
+            "rules_rust+",
+            "rules_rust_wasm_bindgen__serde_derive-1.0.171",
+            "rules_rust++i+rules_rust_wasm_bindgen__serde_derive-1.0.171"
+          ],
+          [
+            "rules_rust+",
+            "rules_rust_wasm_bindgen__serde_json-1.0.102",
+            "rules_rust++i+rules_rust_wasm_bindgen__serde_json-1.0.102"
+          ],
+          [
+            "rules_rust+",
+            "rules_rust_wasm_bindgen__tempfile-3.6.0",
+            "rules_rust++i+rules_rust_wasm_bindgen__tempfile-3.6.0"
+          ],
+          [
+            "rules_rust+",
+            "rules_rust_wasm_bindgen__ureq-2.8.0",
+            "rules_rust++i+rules_rust_wasm_bindgen__ureq-2.8.0"
+          ],
+          [
+            "rules_rust+",
+            "rules_rust_wasm_bindgen__walrus-0.20.3",
+            "rules_rust++i+rules_rust_wasm_bindgen__walrus-0.20.3"
+          ],
+          [
+            "rules_rust+",
+            "rules_rust_wasm_bindgen__wasm-bindgen-0.2.92",
+            "rules_rust++i+rules_rust_wasm_bindgen__wasm-bindgen-0.2.92"
+          ],
+          [
+            "rules_rust+",
+            "rules_rust_wasm_bindgen__wasm-bindgen-cli-support-0.2.92",
+            "rules_rust++i+rules_rust_wasm_bindgen__wasm-bindgen-cli-support-0.2.92"
+          ],
+          [
+            "rules_rust+",
+            "rules_rust_wasm_bindgen__wasm-bindgen-shared-0.2.92",
+            "rules_rust++i+rules_rust_wasm_bindgen__wasm-bindgen-shared-0.2.92"
+          ],
+          [
+            "rules_rust+",
+            "rules_rust_wasm_bindgen__wasmparser-0.102.0",
+            "rules_rust++i+rules_rust_wasm_bindgen__wasmparser-0.102.0"
+          ],
+          [
+            "rules_rust+",
+            "rules_rust_wasm_bindgen__wasmprinter-0.2.60",
+            "rules_rust++i+rules_rust_wasm_bindgen__wasmprinter-0.2.60"
+          ]
+        ]
+      }
+    }
+  }
+}

--- a/integration_test/consumer/BUILD.bazel
+++ b/integration_test/consumer/BUILD.bazel
@@ -1,0 +1,40 @@
+"""Code consumers that use generated headers/modules."""
+
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_test")
+load("@rules_rust//rust:defs.bzl", "rust_binary", "rust_test")
+
+# C++ binary that uses generated header
+cc_binary(
+    name = "test_cpp",
+    srcs = ["test_cpp.cc"],
+    deps = ["//:test_params_cc"],
+)
+
+# C++ test
+cc_test(
+    name = "test_cpp_test",
+    srcs = ["test_cpp.cc"],
+    deps = ["//:test_params_cc"],
+)
+
+# Rust binary that uses generated module
+rust_binary(
+    name = "test_rust",
+    srcs = [
+        "test_rust.rs",
+        "//:test_params_rust",
+    ],
+    crate_root = "test_rust.rs",
+    edition = "2021",
+)
+
+# Rust test
+rust_test(
+    name = "test_rust_test",
+    srcs = [
+        "test_rust.rs",
+        "//:test_params_rust",
+    ],
+    crate_root = "test_rust.rs",
+    edition = "2021",
+)

--- a/integration_test/consumer/test_cpp.cc
+++ b/integration_test/consumer/test_cpp.cc
@@ -1,0 +1,26 @@
+#include <iostream>
+#include "test_params_header.h"  // Root package - no prefix needed
+
+int main() {
+    // Test that generated constants are accessible
+    std::cout << "Max Speed: " << root::MAX_SPEED << " m/s" << std::endl;
+    std::cout << "Min Braking Distance: " << root::MIN_BRAKING_DISTANCE << " m" << std::endl;
+    std::cout << "Update Rate: " << root::UPDATE_RATE << " Hz" << std::endl;
+
+    // Basic validation
+    if (root::MAX_SPEED != 30.0) {
+        std::cerr << "ERROR: MAX_SPEED has wrong value!" << std::endl;
+        return 1;
+    }
+    if (root::MIN_BRAKING_DISTANCE != 50.0) {
+        std::cerr << "ERROR: MIN_BRAKING_DISTANCE has wrong value!" << std::endl;
+        return 1;
+    }
+    if (root::UPDATE_RATE != 100) {
+        std::cerr << "ERROR: UPDATE_RATE has wrong value!" << std::endl;
+        return 1;
+    }
+
+    std::cout << "C++ integration test PASSED" << std::endl;
+    return 0;
+}

--- a/integration_test/consumer/test_rust.rs
+++ b/integration_test/consumer/test_rust.rs
@@ -1,0 +1,28 @@
+// Include generated parameters
+include!("../test_params_rust.rs");
+
+fn main() {
+    // Test that generated constants are accessible
+    println!("Max Speed: {} m/s", MAX_SPEED);
+    println!("Min Braking Distance: {} m", MIN_BRAKING_DISTANCE);
+    println!("Update Rate: {} Hz", UPDATE_RATE);
+
+    // Basic validation
+    assert_eq!(MAX_SPEED, 30.0, "MAX_SPEED has wrong value!");
+    assert_eq!(MIN_BRAKING_DISTANCE, 50.0, "MIN_BRAKING_DISTANCE has wrong value!");
+    assert_eq!(UPDATE_RATE, 100, "UPDATE_RATE has wrong value!");
+
+    println!("Rust integration test PASSED");
+}
+
+#[cfg(test)]
+mod tests {
+    include!("../test_params_rust.rs");
+
+    #[test]
+    fn test_constants() {
+        assert_eq!(MAX_SPEED, 30.0);
+        assert_eq!(MIN_BRAKING_DISTANCE, 50.0);
+        assert_eq!(UPDATE_RATE, 100);
+    }
+}

--- a/integration_test/requirements/BUILD.bazel
+++ b/integration_test/requirements/BUILD.bazel
@@ -1,0 +1,17 @@
+"""Integration test requirements."""
+
+load("@fire//fire/starlark:requirements.bzl", "requirement_library")
+
+# Export parameter file for dependency tracking
+filegroup(
+    name = "test_params",
+    srcs = ["//:test_params.bzl"],
+)
+
+# System requirements
+requirement_library(
+    name = "integration_requirements",
+    srcs = glob(["*.md"]),
+    visibility = ["//visibility:public"],
+    deps = [":test_params"],
+)

--- a/integration_test/requirements/REQ-INT-001.md
+++ b/integration_test/requirements/REQ-INT-001.md
@@ -1,0 +1,18 @@
+# Speed Limit Requirement
+
+## REQ-INT-001
+
+```yaml
+sil: ASIL-B
+version: 1
+```
+
+**Maximum Speed Constraint**
+
+The system SHALL NOT exceed the maximum speed defined by [@max_speed](test_params.bzl#max_speed).
+
+This requirement ensures safe operation within design limits.
+
+### Verification
+
+Tested by [test_speed_limit](//:test_speed_limit).

--- a/integration_test/requirements/REQ-INT-002.md
+++ b/integration_test/requirements/REQ-INT-002.md
@@ -1,0 +1,20 @@
+# Braking Distance Requirement
+
+## REQ-INT-002
+
+```yaml
+sil: ASIL-C
+version: 1
+```
+
+**Minimum Braking Distance**
+
+The system SHALL maintain a minimum braking distance of [@min_braking_distance](test_params.bzl#min_braking_distance) when operating at maximum speed [REQ-INT-001](requirements/REQ-INT-001.md?version=1#REQ-INT-001).
+
+### Rationale
+
+This requirement is derived from [REQ-INT-001](requirements/REQ-INT-001.md?version=1#REQ-INT-001) to ensure safe stopping distance.
+
+### Verification
+
+Tested by [test_braking](//:test_braking).

--- a/integration_test/requirements/REQ-INT-003.md
+++ b/integration_test/requirements/REQ-INT-003.md
@@ -1,0 +1,16 @@
+# Update Rate Requirement
+
+## REQ-INT-003
+
+```yaml
+sil: ASIL-D
+version: 1
+```
+
+**System Update Rate**
+
+The system SHALL process sensor data and update control outputs at [@update_rate](test_params.bzl#update_rate) Hz.
+
+### Verification
+
+Tested by [test_update_rate](//:test_update_rate).

--- a/integration_test/run.sh
+++ b/integration_test/run.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+# Integration test runner for fire requirements management system
+#
+# This script tests the end-to-end workflow of consuming fire as
+# a Bazel module dependency.
+
+set -euo pipefail
+
+cd "$(dirname "$0")"
+
+echo "========================================="
+echo "Fire Integration Test"
+echo "========================================="
+echo ""
+
+# Run all Bazel tests
+echo "Running all Bazel tests..."
+if ! bazel test //... --test_output=errors; then
+    echo "❌ FAIL: Bazel tests failed"
+    exit 1
+fi
+echo "✅ PASS: All Bazel tests passed"
+echo ""
+
+# Verify generated reports exist
+echo "Verifying generated reports..."
+FAILURES=0
+
+if [ -f bazel-bin/compliance_report.md ]; then
+    echo "✅ Compliance report generated"
+else
+    echo "❌ Compliance report not found"
+    FAILURES=$((FAILURES + 1))
+fi
+
+if [ -f bazel-bin/coverage_report.md ]; then
+    echo "✅ Coverage report generated"
+else
+    echo "❌ Coverage report not found"
+    FAILURES=$((FAILURES + 1))
+fi
+
+if [ -f bazel-bin/traceability_report.md ]; then
+    echo "✅ Traceability report generated"
+else
+    echo "❌ Traceability report not found"
+    FAILURES=$((FAILURES + 1))
+fi
+
+echo ""
+
+if [ $FAILURES -eq 0 ]; then
+    echo "========================================="
+    echo "Integration Test PASSED"
+    echo "========================================="
+    exit 0
+else
+    echo "========================================="
+    echo "Integration Test FAILED"
+    echo "========================================="
+    exit 1
+fi

--- a/integration_test/test_dummy.sh
+++ b/integration_test/test_dummy.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+# Dummy test that always passes
+exit 0

--- a/integration_test/test_params.bzl
+++ b/integration_test/test_params.bzl
@@ -1,0 +1,22 @@
+"""Test parameters for integration test."""
+
+TEST_PARAMS = [
+    {
+        "description": "Maximum allowed speed in m/s",
+        "name": "max_speed",
+        "type": "float",
+        "value": 30.0,
+    },
+    {
+        "description": "Minimum braking distance in meters",
+        "name": "min_braking_distance",
+        "type": "float",
+        "value": 50.0,
+    },
+    {
+        "description": "System update rate in Hz",
+        "name": "update_rate",
+        "type": "integer",
+        "value": 100,
+    },
+]


### PR DESCRIPTION
## Summary
- Created standalone integration test workspace that consumes fire as a Bazel module via `local_path_override`
- Fixed include path issue in `cc_parameter_library` by removing `includes = ["."]` and using repository-relative paths
- Added CI job to run integration tests on every PR

## Changes

### Integration Test Structure
Created `integration_test/` directory as a separate Bazel workspace:
- **MODULE.bazel**: Consumes fire using `local_path_override` to test the current development version
- **test_params.bzl**: Defines test parameters (max_speed, min_braking_distance, update_rate)
- **requirements/**: Three test requirements demonstrating:
  - Cross-references between requirements
  - Parameter references from requirements  
  - Different safety integrity levels (ASIL-B, ASIL-C, ASIL-D)
- **consumer/**: C++ and Rust code that consumes generated parameters
- **run.sh**: Test runner that validates all tests pass and all reports generate successfully

### Code Generation Fix
- **fire/starlark/parameters.bzl**: 
  - Removed problematic `includes = ["."]` from `cc_parameter_library`
  - This approach violated Bazel's explicit include path philosophy
  - Now uses repository-relative include paths (e.g., `#include "examples/header.h"`)
  - Added documentation clarifying the include path requirements
- **examples/vehicle_params_test.cc**: Updated include from `"vehicle_params_header.h"` to `"examples/vehicle_params_header.h"`

### CI Integration  
- **.github/workflows/ci.yaml**: Added `integration-test` job that:
  - Runs after pre-commit and test jobs pass
  - Executes `./integration_test/run.sh` to validate end-to-end functionality
- **.bazelignore**: Excludes `integration_test/` from main workspace to prevent Bazel query conflicts

## Test Coverage
The integration test validates:
- ✅ Parameter library code generation for C++ and Rust
- ✅ Requirement validation with cross-references between requirements
- ✅ Parameter references from requirement documents
- ✅ All three report types (compliance, coverage, traceability)
- ✅ Consuming fire as an external Bazel module dependency

## Verification

Local testing:
```bash
# Run main repo tests (136 tests)
bazel test //...

# Run integration test
cd integration_test && ./run.sh
```

All existing tests continue to pass. Integration test validates:
- 5 Bazel tests (C++ consumer, Rust consumer, 3 dummy test targets)
- 3 generated reports (compliance, coverage, traceability)

## Why This Matters

This integration test provides confidence that fire works correctly when consumed as a dependency, not just when testing within the fire repository itself. It catches issues like the include path problem that only manifested when fire was used as an external module.

🤖 Generated with [Claude Code](https://claude.com/claude-code)