### PR TITLE
Fix unittests for metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,12 +306,7 @@ Requirements are written in Markdown with YAML code blocks for each requirement:
 
 ## REQ-VEL-001
 
-<!-- TODO: Update to new pipe-separated format: SIL: ASIL-D | Sec: false | Version: 2 -->
-```yaml
-sil: ASIL-D
-sec: false
-version: 2
-```
+SIL: ASIL-D | Sec: false | Version: 2
 
 **Maximum Vehicle Velocity**
 
@@ -508,13 +503,8 @@ system_function: /examples/system_functions/braking_control.sysarch.md
 
 ## REQ_BC_CALCULATE_FORCE
 
-<!-- TODO: Update to new pipe-separated format: SIL: ASIL-D | Sec: false | Parent: [REQ-BRK-001](...) -->
-```yaml
-sil: ASIL-D
-sec: false
-```
+SIL: ASIL-D | Sec: false | Parent: [REQ-BRK-001](/examples/requirements/braking_requirements.sysreq.md?version=1#REQ-BRK-001)
 
-Derived from [REQ-BRK-001](/examples/requirements/braking_requirements.sysreq.md?version=1#REQ-BRK-001).
 The brake controller component shall calculate the required brake force...
 
 ````

--- a/examples/README.md
+++ b/examples/README.md
@@ -175,12 +175,7 @@ Example format:
 ````markdown
 ## REQ-BRK-001
 
-<!-- TODO: Update to new pipe-separated format: SIL: ASIL-C | Sec: true | Version: 1 -->
-```yaml
-sil: ASIL-C
-sec: true
-version: 1
-```
+SIL: ASIL-C | Sec: true | Version: 1
 
 **Emergency Braking Distance**
 
@@ -213,13 +208,8 @@ Example format:
 ````markdown
 ## REQ_BC_CALCULATE_FORCE
 
-<!-- TODO: Update to new pipe-separated format: SIL: ASIL-D | Sec: false | Parent: [REQ-BRK-001](...) -->
-```yaml
-sil: ASIL-D
-sec: false
-```
+SIL: ASIL-D | Sec: false | Parent: [REQ-BRK-001](/examples/requirements/braking_requirements.sysreq.md?version=1#REQ-BRK-001)
 
-Derived from [REQ-BRK-001](/examples/requirements/braking_requirements.sysreq.md?version=1#REQ-BRK-001).
 The brake controller component shall calculate the required brake force...
 
 ````

--- a/fire/starlark/generate_report.py
+++ b/fire/starlark/generate_report.py
@@ -2,15 +2,13 @@
 """Generate requirement reports from markdown files."""
 
 import sys
-import re
-from pathlib import Path
 
 
 def parse_simple_yaml(yaml_text):
-    """Simple YAML parser for requirement frontmatter.
+    """DEPRECATED: Simple YAML parser for requirement frontmatter.
 
-    TODO: DEPRECATED - Frontmatter is no longer used for requirements.
-    Remove this function after confirming all requirements use inline metadata format.
+    This function is deprecated as requirements no longer use YAML frontmatter.
+    It remains for backward compatibility with legacy report generation.
     """
     result = {}
     lines = yaml_text.strip().split('\n')
@@ -136,16 +134,15 @@ def parse_simple_yaml(yaml_text):
 
 
 def parse_requirement_file(file_path):
-    """Parse a requirement markdown file and extract frontmatter.
+    """DEPRECATED: Parse a requirement markdown file and extract frontmatter.
 
-    TODO: DEPRECATED - This function parses document-level YAML frontmatter.
+    This function parses document-level YAML frontmatter which is deprecated.
     Requirements now use inline metadata (pipe-separated format after ## REQ-ID).
-    Update this function to parse inline metadata or remove if no longer needed.
+    This remains for backward compatibility with legacy report generation.
     """
     with open(file_path, 'r') as f:
         content = f.read()
 
-    # TODO: DEPRECATED - Frontmatter parsing below
     # Find frontmatter boundaries
     lines = content.split('\n')
     first_delimiter = None

--- a/fire/starlark/requirement_validator_test.bzl
+++ b/fire/starlark/requirement_validator_test.bzl
@@ -11,11 +11,7 @@ def _test_valid_requirement(ctx):
 
 ## REQ-001
 
-```yaml
-sil: ASIL-D
-sec: false
-version: 1
-```
+SIL: ASIL-D | Sec: false | Version: 1
 
 **Maximum Vehicle Velocity**
 
@@ -35,11 +31,7 @@ def _test_minimal_valid_requirement(ctx):
 
     content = """## REQ-MIN-001
 
-```yaml
-sil: QM
-sec: false
-version: 1
-```
+SIL: QM | Sec: false | Version: 1
 
 **Minimal Requirement**
 
@@ -52,33 +44,30 @@ This is a minimal requirement with only required fields.
     return unittest.end(env)
 
 def _test_missing_yaml_block(ctx):
-    """Test requirement without YAML block."""
+    """Test requirement without metadata."""
     env = unittest.begin(ctx)
 
     content = """## REQ-001
 
 **Some Requirement**
 
-This requirement has no YAML block.
+This requirement has no metadata.
 """
 
     err = requirement_validator.validate(content)
-    asserts.true(env, err != None, "Missing YAML block should fail")
+    asserts.true(env, err != None, "Missing metadata should fail")
     asserts.true(env, "requirement" in err.lower(), "Should mention requirement problem")
 
     return unittest.end(env)
 
 def _test_missing_required_yaml_fields(ctx):
-    """Test missing required fields in YAML block."""
+    """Test missing required fields in metadata."""
     env = unittest.begin(ctx)
 
     # Missing sil
     content = """## REQ-001
 
-```yaml
-sec: false
-version: 1
-```
+Sec: false | Version: 1
 
 **Test Requirement**
 
@@ -90,10 +79,7 @@ Body content here.
     # Missing sec
     content = """## REQ-001
 
-```yaml
-sil: QM
-version: 1
-```
+SIL: QM | Version: 1
 
 **Test Requirement**
 
@@ -105,10 +91,7 @@ Body content here.
     # Missing version
     content = """## REQ-001
 
-```yaml
-sil: QM
-sec: false
-```
+SIL: QM | Sec: false
 
 **Test Requirement**
 
@@ -126,11 +109,7 @@ def _test_invalid_requirement_id(ctx):
     # ID starting with number
     content = """## 123REQ
 
-```yaml
-sil: QM
-sec: false
-version: 1
-```
+SIL: QM | Sec: false | Version: 1
 
 **Test Requirement**
 
@@ -142,11 +121,7 @@ Body content here.
     # ID with invalid characters
     content = """## REQ@001
 
-```yaml
-sil: QM
-sec: false
-version: 1
-```
+SIL: QM | Sec: false | Version: 1
 
 **Test Requirement**
 
@@ -163,11 +138,7 @@ def _test_empty_body(ctx):
 
     content = """## REQ-001
 
-```yaml
-sil: QM
-sec: false
-version: 1
-```
+SIL: QM | Sec: false | Version: 1
 
 """
 
@@ -183,11 +154,7 @@ def _test_too_short_body(ctx):
 
     content = """## REQ-001
 
-```yaml
-sil: QM
-sec: false
-version: 1
-```
+SIL: QM | Sec: false | Version: 1
 
 **T**
 
@@ -206,11 +173,7 @@ def _test_missing_title(ctx):
 
     content = """## REQ-001
 
-```yaml
-sil: QM
-sec: false
-version: 1
-```
+SIL: QM | Sec: false | Version: 1
 
 Body content here without a title.
 """
@@ -218,31 +181,6 @@ Body content here without a title.
     err = requirement_validator.validate(content)
     asserts.true(env, err != None, "Missing title should fail")
     asserts.true(env, "title" in err.lower(), "Should mention title")
-
-    return unittest.end(env)
-
-def _test_parse_yaml_block(ctx):
-    """Test parsing YAML block values."""
-    env = unittest.begin(ctx)
-
-    content = """## REQ-001
-
-```yaml
-sil: ASIL-D
-sec: true
-version: 2
-```
-
-**Test Requirement**
-
-Body content here.
-"""
-
-    yaml_data, _ = requirement_validator.parse_yaml_block(content)
-    asserts.true(env, yaml_data != None, "Should parse YAML block")
-    asserts.equals(env, "ASIL-D", yaml_data["sil"])
-    asserts.equals(env, True, yaml_data["sec"])
-    asserts.equals(env, 2, yaml_data["version"])
 
     return unittest.end(env)
 
@@ -262,11 +200,7 @@ def _test_valid_id_formats(ctx):
     for req_id in valid_ids:
         content = """## {}
 
-```yaml
-sil: QM
-sec: false
-version: 1
-```
+SIL: QM | Sec: false | Version: 1
 
 **Test Requirement**
 
@@ -302,11 +236,7 @@ def _test_valid_sil_values(ctx):
     for sil in valid_sils:
         content = """## REQ-001
 
-```yaml
-sil: {}
-sec: false
-version: 1
-```
+SIL: {} | Sec: false | Version: 1
 
 **Test Requirement**
 
@@ -325,11 +255,7 @@ def _test_invalid_sil_values(ctx):
     # Invalid SIL value
     content = """## REQ-001
 
-```yaml
-sil: INVALID-X
-sec: false
-version: 1
-```
+SIL: INVALID-X | Sec: false | Version: 1
 
 **Test Requirement**
 
@@ -348,11 +274,7 @@ def _test_valid_sec_values(ctx):
     # sec: true
     content = """## REQ-001
 
-```yaml
-sil: QM
-sec: true
-version: 1
-```
+SIL: QM | Sec: true | Version: 1
 
 **Test Requirement**
 
@@ -364,11 +286,7 @@ Body content here with sufficient length for validation.
     # sec: false
     content = """## REQ-002
 
-```yaml
-sil: QM
-sec: false
-version: 1
-```
+SIL: QM | Sec: false | Version: 1
 
 **Test Requirement**
 
@@ -386,11 +304,7 @@ def _test_invalid_sec_values(ctx):
     # Non-boolean value (string)
     content = """## REQ-001
 
-```yaml
-sil: QM
-sec: "yes"
-version: 1
-```
+SIL: QM | Sec: "yes" | Version: 1
 
 **Test Requirement**
 
@@ -409,11 +323,7 @@ def _test_invalid_version_values(ctx):
     # Negative version
     content = """## REQ-001
 
-```yaml
-sil: QM
-sec: false
-version: -1
-```
+SIL: QM | Sec: false | Version: -1
 
 **Test Requirement**
 
@@ -425,11 +335,7 @@ Body content here with sufficient length for validation.
     # Zero version
     content = """## REQ-002
 
-```yaml
-sil: QM
-sec: false
-version: 0
-```
+SIL: QM | Sec: false | Version: 0
 
 **Test Requirement**
 
@@ -449,11 +355,7 @@ def _test_valid_version_values(ctx):
     for ver in valid_versions:
         content = """## REQ-001
 
-```yaml
-sil: QM
-sec: false
-version: {}
-```
+SIL: QM | Sec: false | Version: {}
 
 **Test Requirement**
 
@@ -471,11 +373,7 @@ def _test_sil_and_sec_combined(ctx):
 
     content = """## REQ-SEC-001
 
-```yaml
-sil: ASIL-D
-sec: true
-version: 1
-```
+SIL: ASIL-D | Sec: true | Version: 1
 
 **Security Critical Requirement**
 
@@ -495,7 +393,6 @@ invalid_requirement_id_test = unittest.make(_test_invalid_requirement_id)
 empty_body_test = unittest.make(_test_empty_body)
 too_short_body_test = unittest.make(_test_too_short_body)
 missing_title_test = unittest.make(_test_missing_title)
-parse_yaml_block_test = unittest.make(_test_parse_yaml_block)
 valid_id_formats_test = unittest.make(_test_valid_id_formats)
 valid_sil_values_test = unittest.make(_test_valid_sil_values)
 invalid_sil_values_test = unittest.make(_test_invalid_sil_values)
@@ -517,7 +414,6 @@ def requirement_validator_test_suite(name):
         empty_body_test,
         too_short_body_test,
         missing_title_test,
-        parse_yaml_block_test,
         valid_id_formats_test,
         valid_sil_values_test,
         invalid_sil_values_test,


### PR DESCRIPTION
- **Adding todos for metadata fixes**
- **Fix metadata occurences**

A lot of the metadata in the tests was still using the old yaml based metadata format. We now use the pipe format instead.
