### PR TITLE
Depend on parameter_library instead of raw YAML in requirement_library

### DIFF
--- a/examples/BUILD.bazel
+++ b/examples/BUILD.bazel
@@ -143,17 +143,11 @@ rust_test(
     edition = "2021",
 )
 
-# Export parameter YAML file for dependency tracking
-filegroup(
-    name = "vehicle_params_yaml",
-    srcs = ["vehicle_params.yaml"],
-)
-
 # Validate requirement documents (system requirements)
 requirement_library(
     name = "vehicle_requirements",
     srcs = glob(["requirements/*.md"]),
-    deps = [":vehicle_params_yaml"],  # System requirements reference parameter files
+    deps = [":vehicle_params"],  # System requirements reference parameter files
 )
 
 # Validate software component requirement documents
@@ -165,7 +159,7 @@ requirement_library(
         "vehicle_status/doc/*.swreq.md",
     ]),
     deps = [
-        ":vehicle_params_yaml",  # Component requirements also reference parameter files
+        ":vehicle_params",  # Component requirements also reference parameter files
         ":vehicle_requirements",  # Component requirements reference system requirements
     ],
 )

--- a/fire/starlark/validate_cross_references.py
+++ b/fire/starlark/validate_cross_references.py
@@ -163,9 +163,18 @@ def validate_parameter_reference(param_name, param_path, workspace_root):
     # Convert to absolute path
     abs_path = os.path.join(workspace_root, file_path)
 
-    # Check if file exists
+    # Check if file exists, or try the _validated.yaml version from parameter_library
     if not os.path.exists(abs_path):
-        return False, f"Parameter file does not exist: {file_path}"
+        # parameter_library outputs foo_validated.yaml from foo.yaml
+        if file_path.endswith('.yaml'):
+            validated_path = file_path[:-5] + '_validated.yaml'
+            validated_abs_path = os.path.join(workspace_root, validated_path)
+            if os.path.exists(validated_abs_path):
+                abs_path = validated_abs_path
+            else:
+                return False, f"Parameter file does not exist: {file_path}"
+        else:
+            return False, f"Parameter file does not exist: {file_path}"
 
     # Read file and check if parameter is defined
     try:
@@ -309,7 +318,12 @@ def validate_requirement_file(file_path, workspace_root, allowed_deps=None):
             # Remove fragment if present
             normalized_path = normalized_path.split('#')[0] if '#' in normalized_path else normalized_path
 
-            if normalized_path not in allowed_deps:
+            # Check both the original path and the _validated.yaml version from parameter_library
+            validated_path = None
+            if normalized_path.endswith('.yaml'):
+                validated_path = normalized_path[:-5] + '_validated.yaml'
+
+            if normalized_path not in allowed_deps and (validated_path is None or validated_path not in allowed_deps):
                 errors.append(
                     f"{file_path}: References parameter file '{param_path}' which is not in declared dependencies.\n"
                     f"       Add the target containing '{normalized_path}' to 'deps' in your requirement_library().\n"

--- a/integration_test/requirements/BUILD.bazel
+++ b/integration_test/requirements/BUILD.bazel
@@ -2,16 +2,10 @@
 
 load("@fire//fire/starlark:requirements.bzl", "requirement_library")
 
-# Export parameter file for dependency tracking
-filegroup(
-    name = "test_params",
-    srcs = ["//:test_params.yaml"],
-)
-
 # System requirements
 requirement_library(
     name = "integration_requirements",
     srcs = glob(["*.md"]),
     visibility = ["//visibility:public"],
-    deps = [":test_params"],
+    deps = ["//:test_params"],
 )


### PR DESCRIPTION
## Summary
- Update requirement_library deps to use parameter_library targets instead of raw YAML files
- Update validate_cross_references.py to handle _validated.yaml files from parameter_library
- This ensures parameters are validated before requirements are checked

## Changes

### fire/starlark/validate_cross_references.py
- Check for `_validated.yaml` suffix when validating parameter file existence
- Accept both original path and validated path in dependency checking

### examples/BUILD.bazel
- Change deps from `:vehicle_params_yaml` to `:vehicle_params`
- Remove unused `vehicle_params_yaml` filegroup

### integration_test/requirements/BUILD.bazel
- Change deps from raw YAML filegroup to `//:test_params` parameter_library

## Test Plan
- [x] All 14 regular tests passing
- [x] All 3 failure tests passing
- [x] All 5 integration tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)