### PR TITLE
Use Python toolchain for all scripts in rules

### DIFF
--- a/fire/starlark/BUILD.bazel
+++ b/fire/starlark/BUILD.bazel
@@ -30,5 +30,21 @@ py_binary(
     deps = ["@pip//pyyaml"],
 )
 
+# Python script for validating cross-references in requirements
+py_binary(
+    name = "validate_cross_references_script",
+    srcs = ["validate_cross_references.py"],
+    main = "validate_cross_references.py",
+    visibility = ["//visibility:public"],
+)
+
+# Python script for generating reports
+py_binary(
+    name = "generate_report_script",
+    srcs = ["generate_report.py"],
+    main = "generate_report.py",
+    visibility = ["//visibility:public"],
+)
+
 # Unit tests for validator
 validator_test_suite(name = "validator_test")

--- a/fire/starlark/reports.bzl
+++ b/fire/starlark/reports.bzl
@@ -3,8 +3,8 @@
 def _generate_report_impl(ctx):
     """Implementation of the generate_report rule."""
 
-    # Get the Python script file
-    script = ctx.file._script
+    # Get the Python script executable
+    script = ctx.executable._script
 
     # Prepare arguments
     args = ctx.actions.args()
@@ -23,12 +23,15 @@ def _generate_report_impl(ctx):
     if ctx.attr.critical_type:
         args.add("--critical-type=" + ctx.attr.critical_type)
 
+    # Get runfiles for the script
+    script_runfiles = ctx.attr._script[DefaultInfo].default_runfiles.files.to_list()
+
     # Run the Python script
     ctx.actions.run(
-        inputs = ctx.files.srcs + [script],
+        inputs = ctx.files.srcs + [script] + script_runfiles,
         outputs = [ctx.outputs.out],
-        executable = "python3",
-        arguments = [script.path] + [args],
+        executable = script,
+        arguments = [args],
         mnemonic = "GenerateReport",
         progress_message = "Generating %s report for %s" % (ctx.attr.report_type, ctx.label.name),
     )
@@ -59,8 +62,9 @@ generate_report = rule(
             doc = "Standard name for compliance reports (e.g., 'ISO 26262', 'IEC 61508')",
         ),
         "_script": attr.label(
-            default = Label("//fire/starlark:generate_report.py"),
-            allow_single_file = True,
+            default = Label("//fire/starlark:generate_report_script"),
+            executable = True,
+            cfg = "exec",
         ),
     },
     doc = """Generates requirement reports in markdown format.

--- a/fire/starlark/requirements.bzl
+++ b/fire/starlark/requirements.bzl
@@ -2,7 +2,7 @@
 
 def _validate_requirements_impl(ctx):
     """Implementation of requirement validation rule."""
-    script = ctx.file._script
+    script = ctx.executable._script
 
     # Output validation marker file
     output = ctx.outputs.out
@@ -10,31 +10,44 @@ def _validate_requirements_impl(ctx):
     # Use "." as workspace root - the sandbox will have the right structure
     workspace_root = "."
 
-    # Build command with --allowed-deps flag (always pass it to enable strict checking)
-    cmd = "python3 {script} {workspace} --allowed-deps".format(
-        script = script.path,
-        workspace = workspace_root,
-    )
+    # Build arguments list
+    args = ctx.actions.args()
+    args.add(workspace_root)
+    args.add("--allowed-deps")
 
     # Add allowed dependency paths (short_path format)
     # Include srcs in allowed deps (requirements in same target can reference each other)
     for src in ctx.files.srcs:
-        cmd += " " + src.short_path
+        args.add(src.short_path)
     for dep in ctx.files.deps:
-        cmd += " " + dep.short_path
+        args.add(dep.short_path)
 
     # Add requirement files (using short_path which is relative to workspace)
-    cmd += " --"
+    args.add("--")
     for src in ctx.files.srcs:
-        cmd += " " + src.short_path
-    cmd += " && touch " + output.path
+        args.add(src.short_path)
+
+    # Create a wrapper script that runs the validator and touches the output
+    wrapper_script = ctx.actions.declare_file(ctx.label.name + "_wrapper.sh")
+    ctx.actions.write(
+        output = wrapper_script,
+        content = """#!/bin/bash
+"$@" && touch {output}
+""".format(output = output.path),
+        is_executable = True,
+    )
+
+    # Get runfiles for the script
+    script_runfiles = ctx.attr._script[DefaultInfo].default_runfiles.files.to_list()
 
     # Run validation script
     # Note: We need to disable sandbox or make all potential reference targets available
-    ctx.actions.run_shell(
-        inputs = ctx.files.srcs + ctx.files.deps + [script],
+    ctx.actions.run(
+        inputs = ctx.files.srcs + ctx.files.deps + script_runfiles,
         outputs = [output],
-        command = cmd,
+        executable = wrapper_script,
+        arguments = [script.path, args],
+        tools = [script],
         mnemonic = "ValidateRequirements",
         progress_message = "Validating cross-references in %s" % ctx.label.name,
         use_default_shell_env = True,
@@ -62,8 +75,9 @@ _validate_requirements = rule(
             doc = "List of requirement markdown files to validate",
         ),
         "_script": attr.label(
-            default = Label("//fire/starlark:validate_cross_references.py"),
-            allow_single_file = True,
+            default = Label("//fire/starlark:validate_cross_references_script"),
+            executable = True,
+            cfg = "exec",
         ),
     },
     doc = "Validates cross-references in requirement documents",


### PR DESCRIPTION
## Summary
Update all Python scripts used in Bazel rules to use the repository's configured Python toolchain instead of the system `python3`.

## Changes

### fire/starlark/BUILD.bazel
- Add `validate_cross_references_script` py_binary
- Add `generate_report_script` py_binary

### fire/starlark/requirements.bzl
- Update `_validate_requirements_impl` to use executable script
- Change `_script` attribute to use `executable = True` and `cfg = "exec"`
- Use `ctx.actions.run` with wrapper script instead of `run_shell`

### fire/starlark/reports.bzl
- Update `_generate_report_impl` to use executable script
- Change `_script` attribute to use `executable = True` and `cfg = "exec"`
- Use `ctx.actions.run` with the executable directly

## Benefits
- Scripts use Bazel-managed Python toolchain
- Consistent Python version across all builds
- Access to pip dependencies (pyyaml) without system installation
- Better hermetic builds

## Test Plan
- [x] All 14 regular tests passing
- [x] All 3 failure tests passing
- [x] All 5 integration tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)