### PR TITLE
Include Python files in CI cache keys

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -47,7 +47,7 @@ jobs:
         with:
           path: |
             ~/.cache/bazel
-          key: bazel-${{ runner.os }}-${{ hashFiles('MODULE.bazel', 'WORKSPACE', '**/*.bzl') }}
+          key: bazel-${{ runner.os }}-${{ hashFiles('MODULE.bazel', 'WORKSPACE', '**/*.bzl', 'fire/starlark/*.py', 'requirements.txt') }}
           restore-keys: |
             bazel-${{ runner.os }}-
 
@@ -82,7 +82,7 @@ jobs:
         with:
           path: |
             ~/.cache/bazel
-          key: bazel-integration-${{ hashFiles('MODULE.bazel', 'WORKSPACE', '**/*.bzl') }}
+          key: bazel-integration-${{ hashFiles('MODULE.bazel', 'WORKSPACE', '**/*.bzl', 'fire/starlark/*.py', 'requirements.txt') }}
           restore-keys: |
             bazel-integration-
 


### PR DESCRIPTION
## Summary
Fix CI cache invalidation issues by including Python files in cache key hashes.

## Problem
The CI cache key only hashed `.bzl` files, so when Python scripts like `validate_cross_references.py` or `generate_report.py` changed, the old cache was restored with stale compiled outputs, causing build failures.

## Solution
Add `fire/starlark/*.py` and `requirements.txt` to the cache key hashes for both:
- Main test job
- Integration test job

## Test Plan
- [x] CI workflow syntax is valid
- Future PRs with Python changes will get fresh caches

🤖 Generated with [Claude Code](https://claude.com/claude-code)