### PR TITLE
Remove Bazel cache from CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -42,15 +42,6 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Mount bazel cache
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cache/bazel
-          key: bazel-${{ runner.os }}-${{ hashFiles('MODULE.bazel', 'fire/starlark/*.bzl', 'fire/starlark/*.py', 'requirements.txt') }}
-          restore-keys: |
-            bazel-${{ runner.os }}-
-
       - name: Run Bazel tests
         run: bazel test //... --test_output=errors
 
@@ -76,15 +67,6 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-
-      - name: Mount bazel cache
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cache/bazel
-          key: bazel-integration-${{ hashFiles('MODULE.bazel', 'fire/starlark/*.bzl', 'fire/starlark/*.py', 'requirements.txt') }}
-          restore-keys: |
-            bazel-integration-
 
       - name: Run integration test
         run: |


### PR DESCRIPTION
## Summary
Remove problematic Bazel cache configuration from CI workflow.

## Problem
The Bazel cache was causing intermittent CI failures due to cache invalidation issues. Stale cached artifacts would cause builds to fail when code changed.

## Solution
Remove the Bazel cache mounting from both the test job and integration test job. Fresh builds are more reliable.

## Test Plan
- [x] CI workflow syntax is valid
- CI will now run fresh builds without cache-related failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)