### PR TITLE
Add version-checking functions to code generators

### DIFF
--- a/examples/VehicleParamsTest.java
+++ b/examples/VehicleParamsTest.java
@@ -12,17 +12,17 @@ public class VehicleParamsTest {
 
     @Test
     public void testSimpleParameters() {
-        // Access simple parameters
-        assertEquals(55.0, VehicleParams.MAXIMUM_VEHICLE_VELOCITY, 0.001);
-        assertEquals(4, VehicleParams.WHEEL_COUNT);
-        assertEquals("TestVehicle", VehicleParams.VEHICLE_NAME);
-        assertEquals(false, VehicleParams.DEBUG_MODE);
+        // Access simple parameters with version check
+        assertEquals(55.0, VehicleParams.maximumVehicleVelocity(1), 0.001);
+        assertEquals(4, VehicleParams.wheelCount(1));
+        assertEquals("TestVehicle", VehicleParams.vehicleName(1));
+        assertEquals(false, VehicleParams.debugMode(1));
     }
 
     @Test
     public void testTableParameters() {
-        // Access table parameter
-        VehicleParams.BrakingDistanceTableRow[] table = VehicleParams.BRAKING_DISTANCE_TABLE;
+        // Access table parameter with version check
+        VehicleParams.BrakingDistanceTableRow[] table = VehicleParams.brakingDistanceTable(1);
 
         // Check we have the expected number of rows
         assertEquals(6, table.length);
@@ -48,7 +48,7 @@ public class VehicleParamsTest {
     public void testRecordImmutability() {
         // Records are immutable by design in Java
         // This is enforced at compile time
-        VehicleParams.BrakingDistanceTableRow row = VehicleParams.BRAKING_DISTANCE_TABLE[0];
+        VehicleParams.BrakingDistanceTableRow row = VehicleParams.brakingDistanceTable(1)[0];
 
         // row.velocity = 999.0;  // Would not compile - records are immutable
 

--- a/examples/vehicle_params_test.cc
+++ b/examples/vehicle_params_test.cc
@@ -8,48 +8,53 @@
 int main() {
     using namespace examples;
 
-    // Test simple float parameter
-    assert(MAXIMUM_VEHICLE_VELOCITY == 55.0);
-    std::cout << "✓ MAXIMUM_VEHICLE_VELOCITY = " << MAXIMUM_VEHICLE_VELOCITY << " m/s" << std::endl;
+    // Test simple float parameter with version check
+    auto max_velocity = maximum_vehicle_velocity<1>();
+    assert(max_velocity == 55.0);
+    std::cout << "✓ maximum_vehicle_velocity<1>() = " << max_velocity << " m/s" << std::endl;
 
     // Test integer parameter
-    assert(WHEEL_COUNT == 4);
-    std::cout << "✓ WHEEL_COUNT = " << WHEEL_COUNT << std::endl;
+    auto wheels = wheel_count<1>();
+    assert(wheels == 4);
+    std::cout << "✓ wheel_count<1>() = " << wheels << std::endl;
 
     // Test string parameter
-    assert(std::strcmp(VEHICLE_NAME, "TestVehicle") == 0);
-    std::cout << "✓ VEHICLE_NAME = \"" << VEHICLE_NAME << "\"" << std::endl;
+    auto name = vehicle_name<1>();
+    assert(std::strcmp(name, "TestVehicle") == 0);
+    std::cout << "✓ vehicle_name<1>() = \"" << name << "\"" << std::endl;
 
     // Test boolean parameter
-    assert(DEBUG_MODE == false);
-    std::cout << "✓ DEBUG_MODE = " << (DEBUG_MODE ? "true" : "false") << std::endl;
+    auto debug = debug_mode<1>();
+    assert(debug == false);
+    std::cout << "✓ debug_mode<1>() = " << (debug ? "true" : "false") << std::endl;
 
     // Test table parameter
+    auto table = braking_distance_table<1>();
     assert(BRAKING_DISTANCE_TABLE_SIZE == 6);
     std::cout << "✓ BRAKING_DISTANCE_TABLE_SIZE = " << BRAKING_DISTANCE_TABLE_SIZE << std::endl;
 
     // Test first row of table
-    assert(BRAKING_DISTANCE_TABLE[0].velocity == 10.0);
-    assert(BRAKING_DISTANCE_TABLE[0].friction_coefficient == 0.7);
-    assert(BRAKING_DISTANCE_TABLE[0].braking_distance == 7.1);
-    std::cout << "✓ BRAKING_DISTANCE_TABLE[0] = {"
-              << BRAKING_DISTANCE_TABLE[0].velocity << ", "
-              << BRAKING_DISTANCE_TABLE[0].friction_coefficient << ", "
-              << BRAKING_DISTANCE_TABLE[0].braking_distance << "}" << std::endl;
+    assert(table[0].velocity == 10.0);
+    assert(table[0].friction_coefficient == 0.7);
+    assert(table[0].braking_distance == 7.1);
+    std::cout << "✓ braking_distance_table<1>()[0] = {"
+              << table[0].velocity << ", "
+              << table[0].friction_coefficient << ", "
+              << table[0].braking_distance << "}" << std::endl;
 
     // Test last row of table
-    assert(BRAKING_DISTANCE_TABLE[5].velocity == 30.0);
-    assert(BRAKING_DISTANCE_TABLE[5].friction_coefficient == 0.3);
-    assert(BRAKING_DISTANCE_TABLE[5].braking_distance == 150.0);
-    std::cout << "✓ BRAKING_DISTANCE_TABLE[5] = {"
-              << BRAKING_DISTANCE_TABLE[5].velocity << ", "
-              << BRAKING_DISTANCE_TABLE[5].friction_coefficient << ", "
-              << BRAKING_DISTANCE_TABLE[5].braking_distance << "}" << std::endl;
+    assert(table[5].velocity == 30.0);
+    assert(table[5].friction_coefficient == 0.3);
+    assert(table[5].braking_distance == 150.0);
+    std::cout << "✓ braking_distance_table<1>()[5] = {"
+              << table[5].velocity << ", "
+              << table[5].friction_coefficient << ", "
+              << table[5].braking_distance << "}" << std::endl;
 
     // Test iteration over table
     double total_distance = 0.0;
     for (size_t i = 0; i < BRAKING_DISTANCE_TABLE_SIZE; ++i) {
-        total_distance += BRAKING_DISTANCE_TABLE[i].braking_distance;
+        total_distance += table[i].braking_distance;
     }
     std::cout << "✓ Total braking distance across all entries = " << total_distance << " m" << std::endl;
 

--- a/examples/vehicle_params_test.go
+++ b/examples/vehicle_params_test.go
@@ -8,27 +8,27 @@ import (
 )
 
 func TestSimpleParameters(t *testing.T) {
-	// Access simple parameters
-	if vehicle_params.MaximumVehicleVelocity != 55.0 {
-		t.Errorf("Expected MaximumVehicleVelocity = 55.0, got %f", vehicle_params.MaximumVehicleVelocity)
+	// Access simple parameters with version check
+	if vehicle_params.MaximumVehicleVelocity(1) != 55.0 {
+		t.Errorf("Expected MaximumVehicleVelocity = 55.0, got %f", vehicle_params.MaximumVehicleVelocity(1))
 	}
 
-	if vehicle_params.WheelCount != 4 {
-		t.Errorf("Expected WheelCount = 4, got %d", vehicle_params.WheelCount)
+	if vehicle_params.WheelCount(1) != 4 {
+		t.Errorf("Expected WheelCount = 4, got %d", vehicle_params.WheelCount(1))
 	}
 
-	if vehicle_params.VehicleName != "TestVehicle" {
-		t.Errorf("Expected VehicleName = TestVehicle, got %s", vehicle_params.VehicleName)
+	if vehicle_params.VehicleName(1) != "TestVehicle" {
+		t.Errorf("Expected VehicleName = TestVehicle, got %s", vehicle_params.VehicleName(1))
 	}
 
-	if vehicle_params.DebugMode != false {
-		t.Errorf("Expected DebugMode = false, got %v", vehicle_params.DebugMode)
+	if vehicle_params.DebugMode(1) != false {
+		t.Errorf("Expected DebugMode = false, got %v", vehicle_params.DebugMode(1))
 	}
 }
 
 func TestTableParameters(t *testing.T) {
-	// Access table parameter
-	table := vehicle_params.BrakingDistanceTable
+	// Access table parameter with version check
+	table := vehicle_params.BrakingDistanceTable(1)
 
 	// Check we have the expected number of rows
 	if len(table) != 6 {
@@ -71,7 +71,7 @@ func TestTableLookup(t *testing.T) {
 	var brakingDist float64
 	found := false
 
-	for _, row := range vehicle_params.BrakingDistanceTable {
+	for _, row := range vehicle_params.BrakingDistanceTable(1) {
 		if row.Velocity == velocity && row.FrictionCoefficient == friction {
 			brakingDist = row.BrakingDistance
 			found = true
@@ -91,7 +91,7 @@ func TestTableLookup(t *testing.T) {
 // Example of a benchmark using the generated parameters
 func BenchmarkTableLookup(b *testing.B) {
 	for i := 0; i < b.N; i++ {
-		for _, row := range vehicle_params.BrakingDistanceTable {
+		for _, row := range vehicle_params.BrakingDistanceTable(1) {
 			_ = row.BrakingDistance
 		}
 	}

--- a/examples/vehicle_params_test.py
+++ b/examples/vehicle_params_test.py
@@ -2,37 +2,38 @@
 
 # Import the generated parameters using repository-relative path
 from examples.vehicle_params import (
-    BRAKING_DISTANCE_TABLE_DATA,
+    braking_distance_table,
     BrakingDistanceTableRow,
-    DEBUG_MODE,
-    MAXIMUM_VEHICLE_VELOCITY,
-    VEHICLE_NAME,
-    WHEEL_COUNT,
+    debug_mode,
+    maximum_vehicle_velocity,
+    vehicle_name,
+    wheel_count,
 )
 
 
 def test_simple_parameters():
-    """Test simple parameter access."""
-    assert MAXIMUM_VEHICLE_VELOCITY == 55.0
-    assert WHEEL_COUNT == 4
-    assert VEHICLE_NAME == "TestVehicle"
-    assert DEBUG_MODE == False
+    """Test simple parameter access with version check."""
+    assert maximum_vehicle_velocity(1) == 55.0
+    assert wheel_count(1) == 4
+    assert vehicle_name(1) == "TestVehicle"
+    assert debug_mode(1) == False
 
 
 def test_table_parameters():
-    """Test table parameter access."""
+    """Test table parameter access with version check."""
     # Check we have the expected number of rows
-    assert len(BRAKING_DISTANCE_TABLE_DATA) == 6
+    table_data = braking_distance_table(1)
+    assert len(table_data) == 6
 
     # Check first row
-    first_row = BRAKING_DISTANCE_TABLE_DATA[0]
+    first_row = table_data[0]
     assert isinstance(first_row, BrakingDistanceTableRow)
     assert first_row.velocity == 10.0
     assert first_row.friction_coefficient == 0.7
     assert first_row.braking_distance == 7.1
 
     # Check that we can iterate over the table
-    velocities = [row.velocity for row in BRAKING_DISTANCE_TABLE_DATA]
+    velocities = [row.velocity for row in table_data]
     assert 10.0 in velocities
     assert 20.0 in velocities
     assert 30.0 in velocities
@@ -40,7 +41,8 @@ def test_table_parameters():
 
 def test_table_immutability():
     """Test that table rows are immutable (frozen dataclass)."""
-    first_row = BRAKING_DISTANCE_TABLE_DATA[0]
+    table_data = braking_distance_table(1)
+    first_row = table_data[0]
 
     # Try to modify a field (should raise error due to frozen=True)
     try:

--- a/examples/vehicle_params_test.rs
+++ b/examples/vehicle_params_test.rs
@@ -11,17 +11,17 @@ use vehicle_params::*;
 
 #[test]
 fn test_scalar_parameters() {
-    // Test float parameter
-    assert_eq!(MAXIMUM_VEHICLE_VELOCITY, 55.0);
+    // Test float parameter with version check
+    assert_eq!(maximum_vehicle_velocity::<1>(), 55.0);
 
-    // Test integer parameter
-    assert_eq!(WHEEL_COUNT, 4);
+    // Test integer parameter with version check
+    assert_eq!(wheel_count::<1>(), 4);
 
-    // Test string parameter
-    assert_eq!(VEHICLE_NAME, "TestVehicle");
+    // Test string parameter with version check
+    assert_eq!(vehicle_name::<1>(), "TestVehicle");
 
-    // Test boolean parameter
-    assert_eq!(DEBUG_MODE, false);
+    // Test boolean parameter with version check
+    assert_eq!(debug_mode::<1>(), false);
 }
 
 #[test]
@@ -29,17 +29,18 @@ fn test_table_parameter() {
     // Test table size constant
     assert_eq!(BRAKING_DISTANCE_TABLE_SIZE, 6);
 
-    // Test table data
-    assert_eq!(BRAKING_DISTANCE_TABLE.len(), 6);
+    // Test table data with version check
+    let table = braking_distance_table::<1>();
+    assert_eq!(table.len(), 6);
 
     // Test first row
-    let first_row = &BRAKING_DISTANCE_TABLE[0];
+    let first_row = &table[0];
     assert_eq!(first_row.velocity, 10.0);
     assert_eq!(first_row.friction_coefficient, 0.7);
     assert_eq!(first_row.braking_distance, 7.1);
 
     // Test iteration
-    for row in BRAKING_DISTANCE_TABLE {
+    for row in table {
         assert!(row.velocity > 0.0);
         assert!(row.friction_coefficient > 0.0);
         assert!(row.braking_distance > 0.0);
@@ -49,7 +50,8 @@ fn test_table_parameter() {
 #[test]
 fn test_struct_derives() {
     // Test that the struct can be copied
-    let row = BRAKING_DISTANCE_TABLE[0];
+    let table = braking_distance_table::<1>();
+    let row = table[0];
     let row_copy = row;
     assert_eq!(row.velocity, row_copy.velocity);
 

--- a/fire/starlark/generate_code.py
+++ b/fire/starlark/generate_code.py
@@ -144,22 +144,10 @@ def generate_cpp(param_data, cpp_namespace=None):
         lines.append(f"namespace {namespace} {{")
         lines.append("")
 
-    # Generate constants for simple parameters and struct definitions for tables
+    # Generate struct definitions for tables first
     for param in parameters:
-        param_name = param["name"]
-        param_type = param["type"]
-        description = param.get("description", "")
-        unit = param.get("unit", "")
-
-        # Add documentation comment
-        if description:
-            doc = description
-            if unit:
-                doc += f" - Unit: {unit}"
-            lines.append(f"/// {doc}")
-
-        if param_type == "table":
-            # Generate struct for table
+        if param["type"] == "table":
+            param_name = param["name"]
             columns = param["columns"]
             struct_name = "".join(word.capitalize() for word in param_name.split("_")) + "Row"
 
@@ -176,16 +164,31 @@ def generate_cpp(param_data, cpp_namespace=None):
             lines.append("};")
             lines.append("")
 
-            if description:
-                lines.append(f"/// {description}")
+    # Generate internal constants and accessor functions for each parameter
+    for param in parameters:
+        param_name = param["name"]
+        param_type = param["type"]
+        description = param.get("description", "")
+        unit = param.get("unit", "")
+        version = param.get("version", 1)
+        const_name = param_name.upper()
 
-            # Generate array constant
-            const_name = param_name.upper()
-            lines.append(f"constexpr {struct_name} {const_name}[] = {{")
+        # Add documentation comment
+        if description:
+            doc = description
+            if unit:
+                doc += f" - Unit: {unit}"
+            lines.append(f"/// {doc}")
 
+        if param_type == "table":
+            struct_name = "".join(word.capitalize() for word in param_name.split("_")) + "Row"
             rows = param["rows"]
+            columns = param["columns"]
+
+            # Internal array constant
+            lines.append(f"namespace detail {{")
+            lines.append(f"constexpr {struct_name} {const_name}_DATA[] = {{")
             for row in rows:
-                # rows are arrays, not dicts
                 values = []
                 for i, col in enumerate(columns):
                     val = row[i]
@@ -197,32 +200,45 @@ def generate_cpp(param_data, cpp_namespace=None):
                         values.append(str(val))
                 lines.append(f"    {{{', '.join(values)}}},")
             lines.append("};")
+            lines.append(f"}}  // namespace detail")
             lines.append("")
 
-            # Add size constant
+            # Size constant
             lines.append(f"constexpr size_t {const_name}_SIZE = {len(rows)};")
+            lines.append("")
 
-            # Add version constant for table
-            version = param.get("version", 1)
-            lines.append(f"constexpr int {const_name}_VERSION = {version};")
+            # Version-checked accessor function
+            lines.append(f"/// Access {param_name} with version check (current version: {version})")
+            lines.append(f"template<int ExpectedVersion>")
+            lines.append(f"[[nodiscard]] constexpr const {struct_name}* {param_name}() {{")
+            lines.append(f"    static_assert(ExpectedVersion <= {version},")
+            lines.append(f'        "Parameter {param_name} version {version} is older than expected version");')
+            lines.append(f"    return detail::{const_name}_DATA;")
+            lines.append(f"}}")
 
         else:
             # Simple parameter
             value = param["value"]
             cpp_type = _get_cpp_type(param_type)
-            const_name = param_name.upper()
 
+            # Internal constant
             if param_type == "string":
-                lines.append(f"constexpr const char* {const_name} = \"{value}\";")
+                lines.append(f"namespace detail {{ constexpr const char* {const_name}_VALUE = \"{value}\"; }}")
             elif param_type in ["bool", "boolean"]:
                 bool_val = "true" if value else "false"
-                lines.append(f"constexpr {cpp_type} {const_name} = {bool_val};")
+                lines.append(f"namespace detail {{ constexpr {cpp_type} {const_name}_VALUE = {bool_val}; }}")
             else:
-                lines.append(f"constexpr {cpp_type} {const_name} = {value};")
+                lines.append(f"namespace detail {{ constexpr {cpp_type} {const_name}_VALUE = {value}; }}")
+            lines.append("")
 
-            # Add version constant for simple parameter
-            version = param.get("version", 1)
-            lines.append(f"constexpr int {const_name}_VERSION = {version};")
+            # Version-checked accessor function
+            lines.append(f"/// Access {param_name} with version check (current version: {version})")
+            lines.append(f"template<int ExpectedVersion>")
+            lines.append(f"[[nodiscard]] constexpr {cpp_type} {param_name}() {{")
+            lines.append(f"    static_assert(ExpectedVersion <= {version},")
+            lines.append(f'        "Parameter {param_name} version {version} is older than expected version");')
+            lines.append(f"    return detail::{const_name}_VALUE;")
+            lines.append(f"}}")
 
         lines.append("")
 
@@ -255,9 +271,10 @@ def generate_python(param_data):
     source_label = param_data.get("source_label", "")
 
     lines = []
-    lines.append('"""Generated parameter constants."""')
+    lines.append('"""Generated parameter constants with version checking."""')
     lines.append("")
     lines.append("from dataclasses import dataclass")
+    lines.append("import warnings")
     lines.append("")
 
     # Generate dataclasses for tables
@@ -278,20 +295,21 @@ def generate_python(param_data):
 
             lines.append("")
 
-    # Generate constants
+    # Generate internal data and accessor functions
     for param in parameters:
         param_name = param["name"]
         param_type = param["type"]
         const_name = param_name.upper()
+        version = param.get("version", 1)
 
         if param_type == "table":
             class_name = "".join(word.capitalize() for word in param_name.split("_")) + "Row"
             rows = param["rows"]
             columns = param["columns"]
 
-            lines.append(f"{const_name}_DATA = [")
+            # Internal data
+            lines.append(f"_{const_name}_DATA = [")
             for row in rows:
-                # rows are arrays, not dicts
                 values = []
                 for i, col in enumerate(columns):
                     val = row[i]
@@ -301,18 +319,47 @@ def generate_python(param_data):
                         values.append(f'{col["name"]}={val}')
                 lines.append(f"    {class_name}({', '.join(values)}),")
             lines.append("]")
-            # Add version constant for table
-            version = param.get("version", 1)
-            lines.append(f"{const_name}_VERSION = {version}")
+            lines.append("")
+
+            # Version-checked accessor function
+            lines.append(f"def {param_name}(expected_version: int) -> list[{class_name}]:")
+            lines.append(f'    """Access {param_name} with version check (current version: {version})."""')
+            lines.append(f"    if expected_version > {version}:")
+            lines.append(f'        raise RuntimeError(')
+            lines.append(f'            f"Parameter {param_name} version {version} is older than expected version {{expected_version}}"')
+            lines.append(f'        )')
+            lines.append(f"    if expected_version < {version}:")
+            lines.append(f'        warnings.warn(')
+            lines.append(f'            f"Parameter {param_name} has been updated to version {version}, expected {{expected_version}}",')
+            lines.append(f'            DeprecationWarning,')
+            lines.append(f'            stacklevel=2')
+            lines.append(f'        )')
+            lines.append(f"    return _{const_name}_DATA")
         else:
             value = param["value"]
+            py_type = _get_python_type(param_type)
+
+            # Internal value
             if param_type == "string":
-                lines.append(f'{const_name} = "{value}"')
+                lines.append(f'_{const_name}_VALUE = "{value}"')
             else:
-                lines.append(f"{const_name} = {value}")
-            # Add version constant for simple parameter
-            version = param.get("version", 1)
-            lines.append(f"{const_name}_VERSION = {version}")
+                lines.append(f"_{const_name}_VALUE = {value}")
+            lines.append("")
+
+            # Version-checked accessor function
+            lines.append(f"def {param_name}(expected_version: int) -> {py_type}:")
+            lines.append(f'    """Access {param_name} with version check (current version: {version})."""')
+            lines.append(f"    if expected_version > {version}:")
+            lines.append(f'        raise RuntimeError(')
+            lines.append(f'            f"Parameter {param_name} version {version} is older than expected version {{expected_version}}"')
+            lines.append(f'        )')
+            lines.append(f"    if expected_version < {version}:")
+            lines.append(f'        warnings.warn(')
+            lines.append(f'            f"Parameter {param_name} has been updated to version {version}, expected {{expected_version}}",')
+            lines.append(f'            DeprecationWarning,')
+            lines.append(f'            stacklevel=2')
+            lines.append(f'        )')
+            lines.append(f"    return _{const_name}_VALUE")
 
         lines.append("")
 
@@ -341,6 +388,10 @@ def generate_go(param_data):
     lines = []
     lines.append(f"package {package_name}")
     lines.append("")
+    lines.append("import (")
+    lines.append('    "fmt"')
+    lines.append(")")
+    lines.append("")
 
     # Generate structs for tables
     for param in parameters:
@@ -360,20 +411,22 @@ def generate_go(param_data):
             lines.append("}")
             lines.append("")
 
-    # Generate constants
+    # Generate internal data and accessor functions
     for param in parameters:
         param_name = param["name"]
         param_type = param["type"]
-        const_name = "".join(word.capitalize() for word in param_name.split("_"))
+        func_name = "".join(word.capitalize() for word in param_name.split("_"))
+        const_name = param_name.upper()
+        version = param.get("version", 1)
 
         if param_type == "table":
             struct_name = "".join(word.capitalize() for word in param_name.split("_")) + "Row"
             rows = param["rows"]
             columns = param["columns"]
 
-            lines.append(f"var {const_name} = []{struct_name}{{")
+            # Internal data
+            lines.append(f"var {const_name.lower()}Data = []{struct_name}{{")
             for row in rows:
-                # rows are arrays, not dicts
                 values = []
                 for i, col in enumerate(columns):
                     col_name = "".join(word.capitalize() for word in col["name"].split("_"))
@@ -384,21 +437,44 @@ def generate_go(param_data):
                         values.append(f"{col_name}: {val}")
                 lines.append(f"    {{{', '.join(values)}}},")
             lines.append("}")
-            # Add version constant for table
-            version = param.get("version", 1)
-            lines.append(f"const {const_name}Version = {version}")
+            lines.append("")
+
+            # Version-checked accessor function
+            lines.append(f"// {func_name} returns {param_name} with version check (current version: {version})")
+            lines.append(f"func {func_name}(expectedVersion int) []{struct_name} {{")
+            lines.append(f"    if expectedVersion > {version} {{")
+            lines.append(f'        panic(fmt.Sprintf("Parameter {param_name} version {version} is older than expected version %d", expectedVersion))')
+            lines.append(f"    }}")
+            lines.append(f"    if expectedVersion < {version} {{")
+            lines.append(f'        fmt.Printf("Warning: Parameter {param_name} has been updated to version {version}, expected %d\\n", expectedVersion)')
+            lines.append(f"    }}")
+            lines.append(f"    return {const_name.lower()}Data")
+            lines.append("}")
         else:
             value = param["value"]
+            go_type = _get_go_type(param_type)
+
+            # Internal value
             if param_type == "string":
-                lines.append(f'const {const_name} = "{value}"')
+                lines.append(f'var {const_name.lower()}Value = "{value}"')
             elif param_type in ["bool", "boolean"]:
                 bool_val = "true" if value else "false"
-                lines.append(f"const {const_name} = {bool_val}")
+                lines.append(f"var {const_name.lower()}Value = {bool_val}")
             else:
-                lines.append(f"const {const_name} = {value}")
-            # Add version constant for simple parameter
-            version = param.get("version", 1)
-            lines.append(f"const {const_name}Version = {version}")
+                lines.append(f"var {const_name.lower()}Value {go_type} = {value}")
+            lines.append("")
+
+            # Version-checked accessor function
+            lines.append(f"// {func_name} returns {param_name} with version check (current version: {version})")
+            lines.append(f"func {func_name}(expectedVersion int) {go_type} {{")
+            lines.append(f"    if expectedVersion > {version} {{")
+            lines.append(f'        panic(fmt.Sprintf("Parameter {param_name} version {version} is older than expected version %d", expectedVersion))')
+            lines.append(f"    }}")
+            lines.append(f"    if expectedVersion < {version} {{")
+            lines.append(f'        fmt.Printf("Warning: Parameter {param_name} has been updated to version {version}, expected %d\\n", expectedVersion)')
+            lines.append(f"    }}")
+            lines.append(f"    return {const_name.lower()}Value")
+            lines.append("}")
 
         lines.append("")
 
@@ -422,7 +498,7 @@ def generate_rust(param_data):
     parameters = param_data["parameters"]
 
     lines = []
-    lines.append("// Generated parameter constants")
+    lines.append("// Generated parameter constants with version checking")
     lines.append("")
 
     # Generate structs for tables
@@ -444,20 +520,21 @@ def generate_rust(param_data):
             lines.append("}")
             lines.append("")
 
-    # Generate constants
+    # Generate internal data and accessor functions
     for param in parameters:
         param_name = param["name"]
         param_type = param["type"]
         const_name = param_name.upper()
+        version = param.get("version", 1)
 
         if param_type == "table":
             struct_name = "".join(word.capitalize() for word in param_name.split("_")) + "Row"
             rows = param["rows"]
             columns = param["columns"]
 
-            lines.append(f"pub const {const_name}: [{struct_name}; {len(rows)}] = [")
+            # Internal data
+            lines.append(f"const {const_name}_DATA: [{struct_name}; {len(rows)}] = [")
             for row in rows:
-                # rows are arrays, not dicts
                 values = []
                 for i, col in enumerate(columns):
                     col_name = col["name"]
@@ -468,27 +545,43 @@ def generate_rust(param_data):
                         values.append(f"{col_name}: {val}")
                 lines.append(f"    {struct_name} {{ {', '.join(values)} }},")
             lines.append("];")
+            lines.append("")
+
+            # Size constant
+            lines.append(f"pub const {const_name}_SIZE: usize = {len(rows)};")
+            lines.append("")
+
+            # Version-checked accessor function using const generics
+            lines.append(f"/// Access {param_name} with version check (current version: {version})")
+            lines.append(f"pub const fn {param_name}<const EXPECTED_VERSION: i32>() -> &'static [{struct_name}; {len(rows)}] {{")
+            lines.append(f"    const CURRENT_VERSION: i32 = {version};")
+            lines.append(f"    assert!(EXPECTED_VERSION <= CURRENT_VERSION,")
+            lines.append(f'        "Parameter {param_name} version is older than expected version");')
+            lines.append(f"    // Note: Rust doesn't have compile-time warnings, version upgrade notices should be handled by tooling")
+            lines.append(f"    &{const_name}_DATA")
+            lines.append("}")
         else:
             value = param["value"]
             rust_type = _get_rust_type(param_type)
+
+            # Internal value
             if param_type == "string":
-                lines.append(f'pub const {const_name}: &str = "{value}";')
+                lines.append(f'const {const_name}_VALUE: &str = "{value}";')
             else:
-                lines.append(f"pub const {const_name}: {rust_type} = {str(value).lower()};")
+                lines.append(f"const {const_name}_VALUE: {rust_type} = {str(value).lower()};")
+            lines.append("")
+
+            # Version-checked accessor function using const generics
+            lines.append(f"/// Access {param_name} with version check (current version: {version})")
+            lines.append(f"pub const fn {param_name}<const EXPECTED_VERSION: i32>() -> {rust_type} {{")
+            lines.append(f"    const CURRENT_VERSION: i32 = {version};")
+            lines.append(f"    assert!(EXPECTED_VERSION <= CURRENT_VERSION,")
+            lines.append(f'        "Parameter {param_name} version is older than expected version");')
+            lines.append(f"    // Note: Rust doesn't have compile-time warnings, version upgrade notices should be handled by tooling")
+            lines.append(f"    {const_name}_VALUE")
+            lines.append("}")
 
         lines.append("")
-
-    # Add size and version constants for tables, version constants for simple params
-    for param in parameters:
-        const_name = param["name"].upper()
-        version = param.get("version", 1)
-        if param["type"] == "table":
-            lines.append(f"pub const {const_name}_SIZE: usize = {len(param['rows'])};")
-            lines.append(f"pub const {const_name}_VERSION: i32 = {version};")
-            lines.append("")
-        else:
-            lines.append(f"pub const {const_name}_VERSION: i32 = {version};")
-            lines.append("")
 
     return "\n".join(lines)
 
@@ -517,7 +610,7 @@ def generate_java(param_data):
     lines.append(f"package {namespace};")
     lines.append("")
     lines.append("/**")
-    lines.append(" * Generated parameter definitions.")
+    lines.append(" * Generated parameter definitions with version checking.")
     lines.append(" */")
     lines.append(f"public final class {class_name} {{")
     lines.append("")
@@ -553,13 +646,18 @@ def generate_java(param_data):
             lines.append(f"    public record {record_name}({', '.join(fields)}) {{}}")
             lines.append("")
 
-    # Generate constants
+    # Generate internal data and accessor methods
     for param in parameters:
         param_name = param["name"]
         param_type = param["type"]
         description = param.get("description", "")
         unit = param.get("unit", "")
         const_name = param_name.upper()
+        version = param.get("version", 1)
+
+        # Method name in camelCase
+        method_name_parts = param_name.split("_")
+        method_name = method_name_parts[0] + "".join(word.capitalize() for word in method_name_parts[1:])
 
         if param_type == "table":
             # Generate array of records
@@ -567,9 +665,9 @@ def generate_java(param_data):
             rows = param["rows"]
             columns = param["columns"]
 
-            lines.append(f"    public static final {record_name}[] {const_name} = {{")
+            # Internal data
+            lines.append(f"    private static final {record_name}[] {const_name}_DATA = {{")
             for row in rows:
-                # rows are arrays, not dicts
                 values = []
                 for i, col in enumerate(columns):
                     val = row[i]
@@ -581,33 +679,61 @@ def generate_java(param_data):
                         values.append(str(val))
                 lines.append(f"        new {record_name}({', '.join(values)}),")
             lines.append("    };")
-            # Add version constant for table
-            version = param.get("version", 1)
-            lines.append(f"    public static final int {const_name}_VERSION = {version};")
+            lines.append("")
+
+            # Version-checked accessor method
+            lines.append("    /**")
+            lines.append(f"     * Access {param_name} with version check (current version: {version}).")
+            lines.append("     * @param expectedVersion the expected version")
+            lines.append(f"     * @return the {param_name} data")
+            lines.append(f"     * @throws IllegalArgumentException if expected version is newer than current version {version}")
+            lines.append("     */")
+            lines.append(f"    public static {record_name}[] {method_name}(int expectedVersion) {{")
+            lines.append(f"        if (expectedVersion > {version}) {{")
+            lines.append(f'            throw new IllegalArgumentException(')
+            lines.append(f'                "Parameter {param_name} version {version} is older than expected version " + expectedVersion);')
+            lines.append(f"        }}")
+            lines.append(f"        if (expectedVersion < {version}) {{")
+            lines.append(f'            System.err.println("Warning: Parameter {param_name} has been updated to version {version}, expected " + expectedVersion);')
+            lines.append(f"        }}")
+            lines.append(f"        return {const_name}_DATA;")
+            lines.append("    }")
         else:
-            # Simple constant
+            # Simple parameter
             value = param["value"]
             java_type = _get_java_type(param_type)
 
-            # Add documentation
-            if description or unit:
-                lines.append("    /**")
-                if description:
-                    lines.append(f"     * {description}")
-                if unit:
-                    lines.append(f"     * Unit: {unit}")
-                lines.append("     */")
-
+            # Internal value
             if param_type == "string":
-                lines.append(f'    public static final {java_type} {const_name} = "{value}";')
+                lines.append(f'    private static final {java_type} {const_name}_VALUE = "{value}";')
             elif param_type in ["bool", "boolean"]:
                 bool_val = "true" if value else "false"
-                lines.append(f"    public static final {java_type} {const_name} = {bool_val};")
+                lines.append(f"    private static final {java_type} {const_name}_VALUE = {bool_val};")
             else:
-                lines.append(f"    public static final {java_type} {const_name} = {value};")
-            # Add version constant for simple parameter
-            version = param.get("version", 1)
-            lines.append(f"    public static final int {const_name}_VERSION = {version};")
+                lines.append(f"    private static final {java_type} {const_name}_VALUE = {value};")
+            lines.append("")
+
+            # Version-checked accessor method
+            lines.append("    /**")
+            if description:
+                lines.append(f"     * {description}")
+            if unit:
+                lines.append(f"     * Unit: {unit}")
+            lines.append(f"     * Access {param_name} with version check (current version: {version}).")
+            lines.append("     * @param expectedVersion the expected version")
+            lines.append(f"     * @return the {param_name} value")
+            lines.append(f"     * @throws IllegalArgumentException if expected version is newer than current version {version}")
+            lines.append("     */")
+            lines.append(f"    public static {java_type} {method_name}(int expectedVersion) {{")
+            lines.append(f"        if (expectedVersion > {version}) {{")
+            lines.append(f'            throw new IllegalArgumentException(')
+            lines.append(f'                "Parameter {param_name} version {version} is older than expected version " + expectedVersion);')
+            lines.append(f"        }}")
+            lines.append(f"        if (expectedVersion < {version}) {{")
+            lines.append(f'            System.err.println("Warning: Parameter {param_name} has been updated to version {version}, expected " + expectedVersion);')
+            lines.append(f"        }}")
+            lines.append(f"        return {const_name}_VALUE;")
+            lines.append("    }")
 
         lines.append("")
 

--- a/integration_test/consumer/test_cpp.cc
+++ b/integration_test/consumer/test_cpp.cc
@@ -2,22 +2,22 @@
 #include "test_params.h"  // Root package - no prefix needed
 
 int main() {
-    // Test that generated constants are accessible
-    std::cout << "Max Speed: " << root::MAX_SPEED << " m/s" << std::endl;
-    std::cout << "Min Braking Distance: " << root::MIN_BRAKING_DISTANCE << " m" << std::endl;
-    std::cout << "Update Rate: " << root::UPDATE_RATE << " Hz" << std::endl;
+    // Test that generated constants are accessible via version-checked functions
+    std::cout << "Max Speed: " << root::max_speed<1>() << " m/s" << std::endl;
+    std::cout << "Min Braking Distance: " << root::min_braking_distance<1>() << " m" << std::endl;
+    std::cout << "Update Rate: " << root::update_rate<1>() << " Hz" << std::endl;
 
     // Basic validation
-    if (root::MAX_SPEED != 30.0) {
-        std::cerr << "ERROR: MAX_SPEED has wrong value!" << std::endl;
+    if (root::max_speed<1>() != 30.0) {
+        std::cerr << "ERROR: max_speed has wrong value!" << std::endl;
         return 1;
     }
-    if (root::MIN_BRAKING_DISTANCE != 50.0) {
-        std::cerr << "ERROR: MIN_BRAKING_DISTANCE has wrong value!" << std::endl;
+    if (root::min_braking_distance<1>() != 50.0) {
+        std::cerr << "ERROR: min_braking_distance has wrong value!" << std::endl;
         return 1;
     }
-    if (root::UPDATE_RATE != 100) {
-        std::cerr << "ERROR: UPDATE_RATE has wrong value!" << std::endl;
+    if (root::update_rate<1>() != 100) {
+        std::cerr << "ERROR: update_rate has wrong value!" << std::endl;
         return 1;
     }
 

--- a/integration_test/consumer/test_rust.rs
+++ b/integration_test/consumer/test_rust.rs
@@ -2,15 +2,15 @@
 include!("../test_params.rs");
 
 fn main() {
-    // Test that generated constants are accessible
-    println!("Max Speed: {} m/s", MAX_SPEED);
-    println!("Min Braking Distance: {} m", MIN_BRAKING_DISTANCE);
-    println!("Update Rate: {} Hz", UPDATE_RATE);
+    // Test that generated constants are accessible via version-checked functions
+    println!("Max Speed: {} m/s", max_speed::<1>());
+    println!("Min Braking Distance: {} m", min_braking_distance::<1>());
+    println!("Update Rate: {} Hz", update_rate::<1>());
 
     // Basic validation
-    assert_eq!(MAX_SPEED, 30.0, "MAX_SPEED has wrong value!");
-    assert_eq!(MIN_BRAKING_DISTANCE, 50.0, "MIN_BRAKING_DISTANCE has wrong value!");
-    assert_eq!(UPDATE_RATE, 100, "UPDATE_RATE has wrong value!");
+    assert_eq!(max_speed::<1>(), 30.0, "max_speed has wrong value!");
+    assert_eq!(min_braking_distance::<1>(), 50.0, "min_braking_distance has wrong value!");
+    assert_eq!(update_rate::<1>(), 100, "update_rate has wrong value!");
 
     println!("Rust integration test PASSED");
 }
@@ -21,8 +21,8 @@ mod tests {
 
     #[test]
     fn test_constants() {
-        assert_eq!(MAX_SPEED, 30.0);
-        assert_eq!(MIN_BRAKING_DISTANCE, 50.0);
-        assert_eq!(UPDATE_RATE, 100);
+        assert_eq!(max_speed::<1>(), 30.0);
+        assert_eq!(min_braking_distance::<1>(), 50.0);
+        assert_eq!(update_rate::<1>(), 100);
     }
 }


### PR DESCRIPTION
## Summary
- Replace direct constant access with version-checked function calls across all code generators
- C++, Python, Go, Rust, and Java all now use functions that take expected version as parameter
- Version mismatch causes compile/runtime errors when expected version > actual version
- Python, Go, Java emit warnings when expected version < actual version

## API Changes

| Language | Before | After |
|----------|--------|-------|
| C++ | `PARAMETER_NAME` | `parameter_name<1>()` |
| Python | `PARAMETER_NAME` | `parameter_name(1)` |
| Go | `ParameterName` | `ParameterName(1)` |
| Rust | `PARAMETER_NAME` | `parameter_name::<1>()` |
| Java | `PARAMETER_NAME` | `parameterName(1)` |

## Version Checking Behavior

- **Expected > Actual**: Compile-time error (C++, Rust) or runtime error (Python, Go, Java)
- **Expected < Actual**: Deprecation warning (Python, Go, Java) or silent pass (C++, Rust)
- **Expected = Actual**: Success

## Test Plan
- [x] All 14 main tests passing
- [x] All 5 integration tests passing
- [x] Updated all example tests to use new API
- [x] Updated integration test consumers to use new API

## Motivation
This change enables safer parameter consumption by requiring callers to explicitly declare which parameter version they depend on. When parameters are updated, consumers using older versions will get clear feedback about the version mismatch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)