### PR TITLE
Remove success messages from validation checks

### DIFF
--- a/fire/starlark/validate_cross_references.py
+++ b/fire/starlark/validate_cross_references.py
@@ -392,7 +392,6 @@ def main():
             print(f"  ERROR: {error}")
         sys.exit(1)
     else:
-        print(f"Cross-reference validation passed for {len(requirement_files)} requirement(s)")
         sys.exit(0)
 
 

--- a/fire/starlark/validate_parameters.py
+++ b/fire/starlark/validate_parameters.py
@@ -75,7 +75,6 @@ def main():
             print(f"  ERROR: {error}")
         sys.exit(1)
 
-    print(f"Parameter validation passed for {args.yaml_file}")
     sys.exit(0)
 
 


### PR DESCRIPTION
## Summary
- Remove verbose output for successful parameter validation
- Remove verbose output for successful cross-reference validation
- Errors are still printed when validation fails

## Changes
- `fire/starlark/validate_parameters.py`: Remove "Parameter validation passed" message
- `fire/starlark/validate_cross_references.py`: Remove "Cross-reference validation passed" message

## Test Plan
- [x] All 5 integration tests passing
- [x] Verified error messages still appear on validation failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)