### PR TITLE
Update CI badge to modern GitHub Actions workflow format

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Fire - Requirements Management System for Bazel
 
-[![CI](https://github.com/nesono/fire/workflows/CI/badge.svg)](https://github.com/nesono/fire/actions)
+[![CI](https://github.com/nesono/fire/actions/workflows/ci.yaml/badge.svg)](https://github.com/nesono/fire/actions/workflows/ci.yaml)
 
 Fire is a Bazel module for managing safety-critical system requirements, parameters, and their relationships through Bazel's dependency graph.
 


### PR DESCRIPTION
## Summary
- Updated CI status badge to use the modern GitHub Actions workflow format

## Changes
- Changed badge URL from `/workflows/CI/badge.svg` to `/actions/workflows/ci.yaml/badge.svg`
- Updated badge link to point directly to the workflow page instead of general actions page

## Benefits
✅ Uses current recommended GitHub Actions badge format
✅ Includes workflow file name for clarity
✅ Links directly to specific workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)