### PR TITLE
Only generating source files - they need to be turned into a lib downstream

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -18,12 +18,6 @@ bazel_dep(name = "rules_python", version = "1.7.0")
 # Skylib for starlark utilities
 bazel_dep(name = "bazel_skylib", version = "1.9.0")
 
-# Language rules - consumers need these if they use the corresponding *_parameter_library rules
-bazel_dep(name = "rules_cc", version = "0.2.16")
-bazel_dep(name = "rules_go", version = "0.59.0")
-bazel_dep(name = "rules_rust", version = "0.68.1")
-bazel_dep(name = "rules_java", version = "9.3.0")
-
 # Python toolchain and pip dependencies for validation scripts
 python = use_extension("@rules_python//python/extensions:python.bzl", "python")
 python.toolchain(python_version = "3.11")
@@ -39,6 +33,11 @@ use_repo(pip, "pip")
 # =============================================================================
 # Development dependencies - only needed for developing/testing this module
 # =============================================================================
+
+bazel_dep(name = "rules_cc", version = "0.2.16", dev_dependency = True)
+bazel_dep(name = "rules_go", version = "0.59.0", dev_dependency = True)
+bazel_dep(name = "rules_rust", version = "0.68.1", dev_dependency = True)
+bazel_dep(name = "rules_java", version = "9.3.0", dev_dependency = True)
 
 # Rust toolchain for running Rust tests
 rust = use_extension("@rules_rust//rust:extensions.bzl", "rust", dev_dependency = True)

--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 
 [![CI](https://github.com/nesono/fire/actions/workflows/ci.yaml/badge.svg)](https://github.com/nesono/fire/actions/workflows/ci.yaml)
 
-Fire is a Bazel module for managing safety-critical system requirements, parameters, and their relationships through Bazel's dependency graph.
+Fire is a Bazel module for managing safety-critical system requirements,
+parameters, and their relationships through Bazel's dependency graph.
 
 It is based on the following basic concepts:
 
@@ -17,9 +18,21 @@ It is based on the following basic concepts:
 
 ### Consume Fire
 
+Add Fire to your `MODULE.bazel`:
+
 ```starlark
 bazel_dep(name = "fire", version = "0.1.2")
+
+# Add language rules for the languages you want to use
+bazel_dep(name = "rules_cc", version = "0.2.16")      # For C++ code generation
+bazel_dep(name = "rules_python", version = "1.7.0")   # For Python code generation
+# Add rules_rust, rules_go, rules_java as needed
 ```
+
+**Important**: Fire provides code generation functions that output source
+files. You are responsible for wrapping these in your language's library rules.
+This keeps Fire's dependencies minimal - Fire only depends on rules_python (for
+YAML validation).
 
 ### Define Parameter Libraries
 
@@ -64,23 +77,30 @@ parameters:
 In your `BUILD.bazel` file (e.g., in `vehicle/dynamics/`):
 
 ```starlark
-load("@fire//fire/starlark:parameters.bzl", "parameter_library", "cc_parameter_library")
-load("@rules_cc//cc:defs.bzl", "cc_test")
+load("@fire//fire/starlark:parameters.bzl", "parameter_library")
+load("@fire//fire/starlark:codegen.bzl", "generate_cc_parameters")
+load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test")
 
-# Validate parameters from YAML file
-# Namespace auto-derived from package path: vehicle/dynamics -> vehicle::dynamics
+# Step 1: Validate parameters from YAML file
 parameter_library(
     name = "vehicle_params",
     src = "vehicle_params.yaml",
 )
 
-# Create C++ library from parameters
-cc_parameter_library(
-    name = "vehicle_params_cc",
+# Step 2: Generate C++ header file
+generate_cc_parameters(
+    name = "vehicle_params_h",
     parameter_library = ":vehicle_params",
+    namespace = "vehicle::dynamics",  # Optional namespace
 )
 
-# Use generated parameters in C++ code
+# Step 3: Wrap in cc_library (you control this)
+cc_library(
+    name = "vehicle_params_cc",
+    hdrs = [":vehicle_params_h"],
+)
+
+# Step 4: Use generated parameters in C++ code
 cc_test(
     name = "dynamics_test",
     srcs = ["dynamics_test.cc"],

--- a/examples/BUILD.bazel
+++ b/examples/BUILD.bazel
@@ -1,17 +1,10 @@
-load("@rules_cc//cc:defs.bzl", "cc_test")
-load("@rules_go//go:def.bzl", "go_test")
-load("@rules_java//java:defs.bzl", "java_test")
-load("@rules_python//python:defs.bzl", "py_test")
+load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test")
+load("@rules_go//go:def.bzl", "go_library", "go_test")
+load("@rules_java//java:defs.bzl", "java_library", "java_test")
+load("@rules_python//python:defs.bzl", "py_library", "py_test")
 load("@rules_rust//rust:defs.bzl", "rust_test")
-load(
-    "//fire/starlark:parameters.bzl",
-    "cc_parameter_library",
-    "go_parameter_library",
-    "java_parameter_library",
-    "parameter_library",
-    "python_parameter_library",
-    "rust_parameter_library",
-)
+load("//fire/starlark:codegen.bzl", "generate_cc_parameters", "generate_go_parameters", "generate_java_parameters", "generate_python_parameters", "generate_rust_parameters")
+load("//fire/starlark:parameters.bzl", "parameter_library")
 load("//fire/starlark:reports.bzl", "generate_report")
 load("//fire/starlark:requirements.bzl", "requirement_library")
 
@@ -22,71 +15,116 @@ parameter_library(
     src = "vehicle_params.yaml",
 )
 
-# Generate C++ library with parameters
-# Consumes vehicle_params.yaml and generates vehicle_params.h
-# Uses default namespace from package path (examples)
-cc_parameter_library(
-    name = "vehicle_params_cc",
+# Generate C++ header with parameters
+# Consumes vehicle_params (validated YAML) and generates vehicle_params.h
+generate_cc_parameters(
+    name = "vehicle_params_h",
     base_name = "vehicle_params",
     parameter_library = ":vehicle_params",
 )
 
-# Example: C++ library with custom namespace
-cc_parameter_library(
-    name = "vehicle_params_cc_custom_ns",
+# Wrap in cc_library
+cc_library(
+    name = "vehicle_params_cc",
+    hdrs = [":vehicle_params_h"],
+)
+
+# Example: C++ header with custom namespace
+generate_cc_parameters(
+    name = "vehicle_params_custom_ns_h",
     base_name = "vehicle_params_custom_ns",
     namespace = "my_project::vehicle::params",
     parameter_library = ":vehicle_params",
 )
 
-# Generate Python library with parameters
-# Consumes vehicle_params.yaml and generates vehicle_params.py
-python_parameter_library(
-    name = "vehicle_params_py",
+# Wrap in cc_library
+cc_library(
+    name = "vehicle_params_cc_custom_ns",
+    hdrs = [":vehicle_params_custom_ns_h"],
+)
+
+# Generate Python module with parameters
+# Consumes vehicle_params (validated YAML) and generates vehicle_params.py
+generate_python_parameters(
+    name = "vehicle_params_py_src",
     base_name = "vehicle_params",
     parameter_library = ":vehicle_params",
 )
 
+# Wrap in py_library
+py_library(
+    name = "vehicle_params_py",
+    srcs = [":vehicle_params_py_src"],
+)
+
 # Example: Second Python library (demonstrates multiple targets from same params)
-python_parameter_library(
-    name = "vehicle_params_py_alt",
+generate_python_parameters(
+    name = "vehicle_params_py_alt_src",
+    base_name = "vehicle_params_py_alt",
     parameter_library = ":vehicle_params",
 )
 
-# Generate Java parameters
-# Consumes vehicle_params.yaml and generates VehicleParams.java
-java_parameter_library(
-    name = "vehicle_params_java",
+py_library(
+    name = "vehicle_params_py_alt",
+    srcs = [":vehicle_params_py_alt_src"],
+)
+
+# Generate Java class with parameters
+# Consumes vehicle_params (validated YAML) and generates VehicleParams.java
+generate_java_parameters(
+    name = "vehicle_params_java_src",
     class_name = "VehicleParams",
     package_prefix = "com.example",
     parameter_library = ":vehicle_params",
 )
 
-# Generate Go library with parameters
-# Consumes vehicle_params.yaml and generates vehicle_params.go
-go_parameter_library(
-    name = "vehicle_params_go",
+# Wrap in java_library
+java_library(
+    name = "vehicle_params_java",
+    srcs = [":vehicle_params_java_src"],
+)
+
+# Generate Go source with parameters
+# Consumes vehicle_params (validated YAML) and generates vehicle_params.go
+generate_go_parameters(
+    name = "vehicle_params_go_src",
     base_name = "vehicle_params",
     parameter_library = ":vehicle_params",
 )
 
+# Wrap in go_library
+go_library(
+    name = "vehicle_params_go",
+    srcs = [":vehicle_params_go_src"],
+    importpath = "examples/vehicle_params",
+)
+
 # Example: Second Go library (demonstrates multiple targets from same params)
-go_parameter_library(
-    name = "vehicle_params_go_alt",
+generate_go_parameters(
+    name = "vehicle_params_go_alt_src",
+    base_name = "vehicle_params_alt",
     parameter_library = ":vehicle_params",
 )
 
-# Generate Rust parameters
-# Consumes vehicle_params.yaml and generates vehicle_params.rs
-rust_parameter_library(
+go_library(
+    name = "vehicle_params_go_alt",
+    srcs = [":vehicle_params_go_alt_src"],
+    importpath = "examples/vehicle_params_go_alt",
+)
+
+# Generate Rust module with parameters
+# Consumes vehicle_params (validated YAML) and generates vehicle_params.rs
+# Rust can use generated .rs files directly in srcs (no wrapper needed)
+generate_rust_parameters(
     name = "vehicle_params_rs",
     base_name = "vehicle_params",
     parameter_library = ":vehicle_params",
 )
 
-# Example: Second Rust library (demonstrates multiple targets from same params)
-rust_parameter_library(
+# Example: Second Rust module (demonstrates multiple targets from same params)
+generate_rust_parameters(
     name = "vehicle_params_rs_alt",
+    base_name = "vehicle_params_rs_alt",
     parameter_library = ":vehicle_params",
 )
 

--- a/fire/starlark/codegen.bzl
+++ b/fire/starlark/codegen.bzl
@@ -1,0 +1,274 @@
+"""Code generation functions for parameter libraries.
+
+This file provides functions that generate source code from parameter libraries.
+Consumers are responsible for wrapping the generated files in their language-specific
+library rules (cc_library, rust_library, go_library, etc.).
+
+This design keeps Fire's dependencies minimal - Fire only needs rules_python for
+validation. Consumers control which language rules they use and which versions.
+"""
+
+def generate_cc_parameters(
+        name,
+        parameter_library,
+        base_name = None,
+        namespace = None,
+        visibility = None):
+    """Generate C++ header file from parameter library.
+
+    This rule generates a .h file. Consumers should wrap it in cc_library.
+
+    Args:
+        name: Name of the generation target
+        parameter_library: Label of the parameter_library target (the validated YAML)
+        base_name: Base name for output file (optional, defaults to name)
+        namespace: Optional C++ namespace (use :: for nested, e.g., "outer::inner")
+        visibility: Visibility of the generated header
+
+    Example:
+        load("@fire//fire/starlark:parameters.bzl", "parameter_library")
+        load("@fire//fire/starlark:codegen.bzl", "generate_cc_parameters")
+        load("@rules_cc//cc:defs.bzl", "cc_library")
+
+        parameter_library(
+            name = "vehicle_params",
+            src = "vehicle_params.yaml",
+        )
+
+        generate_cc_parameters(
+            name = "vehicle_params_h",
+            parameter_library = ":vehicle_params",
+            namespace = "vehicle",
+        )
+
+        cc_library(
+            name = "vehicle_params_cc",
+            hdrs = [":vehicle_params_h"],
+        )
+    """
+    if not base_name:
+        base_name = name
+
+    # Build command with optional namespace
+    cmd = "$(location @fire//fire/starlark:generate_code_script) cpp $< $@"
+    if namespace:
+        cmd += " --namespace='{}'".format(namespace)
+
+    native.genrule(
+        name = name,
+        srcs = [parameter_library],
+        outs = [base_name + ".h"],
+        cmd = cmd,
+        tools = ["@fire//fire/starlark:generate_code_script"],
+        visibility = visibility if visibility else ["//visibility:public"],
+    )
+
+def generate_python_parameters(
+        name,
+        parameter_library,
+        base_name = None,
+        visibility = None):
+    """Generate Python module from parameter library.
+
+    This rule generates a .py file. Consumers should wrap it in py_library.
+
+    Args:
+        name: Name of the generation target
+        parameter_library: Label of the parameter_library target (the validated YAML)
+        base_name: Base name for output file (optional, defaults to name)
+        visibility: Visibility of the generated module
+
+    Example:
+        load("@fire//fire/starlark:parameters.bzl", "parameter_library")
+        load("@fire//fire/starlark:codegen.bzl", "generate_python_parameters")
+        load("@rules_python//python:defs.bzl", "py_library")
+
+        parameter_library(
+            name = "vehicle_params",
+            src = "vehicle_params.yaml",
+        )
+
+        generate_python_parameters(
+            name = "vehicle_params_py_src",
+            parameter_library = ":vehicle_params",
+        )
+
+        py_library(
+            name = "vehicle_params_py",
+            srcs = [":vehicle_params_py_src"],
+        )
+    """
+    if not base_name:
+        base_name = name
+
+    native.genrule(
+        name = name,
+        srcs = [parameter_library],
+        outs = [base_name + ".py"],
+        cmd = "$(location @fire//fire/starlark:generate_code_script) python $< $@",
+        tools = ["@fire//fire/starlark:generate_code_script"],
+        visibility = visibility if visibility else ["//visibility:public"],
+    )
+
+def generate_java_parameters(
+        name,
+        parameter_library,
+        class_name = None,
+        package_prefix = None,
+        visibility = None):
+    """Generate Java class from parameter library.
+
+    This rule generates a .java file. Consumers should wrap it in java_library.
+
+    Args:
+        name: Name of the generation target
+        parameter_library: Label of the parameter_library target (the validated YAML)
+        class_name: Name of the generated class (optional, derived from name if not provided)
+        package_prefix: Optional package prefix (e.g., "com.example")
+        visibility: Visibility of the generated class
+
+    Example:
+        load("@fire//fire/starlark:parameters.bzl", "parameter_library")
+        load("@fire//fire/starlark:codegen.bzl", "generate_java_parameters")
+        load("@rules_java//java:defs.bzl", "java_library")
+
+        parameter_library(
+            name = "vehicle_params",
+            src = "vehicle_params.yaml",
+        )
+
+        generate_java_parameters(
+            name = "vehicle_params_java_src",
+            parameter_library = ":vehicle_params",
+            class_name = "VehicleParams",
+            package_prefix = "com.example",
+        )
+
+        java_library(
+            name = "vehicle_params_java",
+            srcs = [":vehicle_params_java_src"],
+        )
+    """
+
+    # Derive class_name if not provided
+    if not class_name:
+        base_name = name
+        parts = base_name.split("_")
+        class_name = "".join([word.capitalize() for word in parts])
+
+    # Build command with optional package prefix
+    cmd = "$(location @fire//fire/starlark:generate_code_script) java $< $@ --class-name='{}'".format(class_name)
+    if package_prefix:
+        cmd += " --namespace='{}'".format(package_prefix)
+
+    native.genrule(
+        name = name,
+        srcs = [parameter_library],
+        outs = [class_name + ".java"],
+        cmd = cmd,
+        tools = ["@fire//fire/starlark:generate_code_script"],
+        visibility = visibility if visibility else ["//visibility:public"],
+    )
+
+def generate_go_parameters(
+        name,
+        parameter_library,
+        base_name = None,
+        package_name = None,
+        visibility = None):
+    """Generate Go source file from parameter library.
+
+    This rule generates a .go file. Consumers should wrap it in go_library.
+
+    Args:
+        name: Name of the generation target
+        parameter_library: Label of the parameter_library target (the validated YAML)
+        base_name: Base name for output file (optional, defaults to name)
+        package_name: Go package name (optional, derived from base_name if not provided)
+        visibility: Visibility of the generated source
+
+    Example:
+        load("@fire//fire/starlark:parameters.bzl", "parameter_library")
+        load("@fire//fire/starlark:codegen.bzl", "generate_go_parameters")
+        load("@rules_go//go:def.bzl", "go_library")
+
+        parameter_library(
+            name = "vehicle_params",
+            src = "vehicle_params.yaml",
+        )
+
+        generate_go_parameters(
+            name = "vehicle_params_go_src",
+            parameter_library = ":vehicle_params",
+        )
+
+        go_library(
+            name = "vehicle_params_go",
+            srcs = [":vehicle_params_go_src"],
+            importpath = "github.com/example/vehicle_params",
+        )
+    """
+    if not base_name:
+        base_name = name
+
+    # Derive package name if not provided
+    if not package_name:
+        package_name = base_name.replace("_", "")
+
+    native.genrule(
+        name = name,
+        srcs = [parameter_library],
+        outs = [base_name + ".go"],
+        cmd = "$(location @fire//fire/starlark:generate_code_script) go $< $@ --namespace='{}'".format(package_name),
+        tools = ["@fire//fire/starlark:generate_code_script"],
+        visibility = visibility if visibility else ["//visibility:public"],
+    )
+
+def generate_rust_parameters(
+        name,
+        parameter_library,
+        base_name = None,
+        visibility = None):
+    """Generate Rust module from parameter library.
+
+    This rule generates a .rs file. Consumers can include it directly in
+    rust_library/rust_binary/rust_test srcs.
+
+    Args:
+        name: Name of the generation target
+        parameter_library: Label of the parameter_library target (the validated YAML)
+        base_name: Base name for output file (optional, defaults to name)
+        visibility: Visibility of the generated module
+
+    Example:
+        load("@fire//fire/starlark:parameters.bzl", "parameter_library")
+        load("@fire//fire/starlark:codegen.bzl", "generate_rust_parameters")
+        load("@rules_rust//rust:defs.bzl", "rust_library")
+
+        parameter_library(
+            name = "vehicle_params",
+            src = "vehicle_params.yaml",
+        )
+
+        generate_rust_parameters(
+            name = "vehicle_params_rs",
+            parameter_library = ":vehicle_params",
+        )
+
+        # Can use directly in srcs (Rust doesn't need a separate library wrapper)
+        rust_test(
+            name = "test",
+            srcs = ["test.rs", ":vehicle_params_rs"],
+        )
+    """
+    if not base_name:
+        base_name = name
+
+    native.genrule(
+        name = name,
+        srcs = [parameter_library],
+        outs = [base_name + ".rs"],
+        cmd = "$(location @fire//fire/starlark:generate_code_script) rust $< $@",
+        tools = ["@fire//fire/starlark:generate_code_script"],
+        visibility = visibility if visibility else ["//visibility:public"],
+    )

--- a/fire/starlark/failure_test/parameter_version/BUILD.bazel
+++ b/fire/starlark/failure_test/parameter_version/BUILD.bazel
@@ -7,12 +7,13 @@ These tests verify that version mismatch detection works correctly:
 They are tagged as 'manual' and 'failure_test' so they don't run in normal test runs.
 """
 
-load("@rules_cc//cc:defs.bzl", "cc_binary")
-load("@rules_go//go:def.bzl", "go_binary")
-load("@rules_java//java:defs.bzl", "java_binary")
-load("@rules_python//python:defs.bzl", "py_binary")
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
+load("@rules_go//go:def.bzl", "go_binary", "go_library")
+load("@rules_java//java:defs.bzl", "java_binary", "java_library")
+load("@rules_python//python:defs.bzl", "py_binary", "py_library")
 load("@rules_rust//rust:defs.bzl", "rust_binary")
-load("//fire/starlark:parameters.bzl", "cc_parameter_library", "go_parameter_library", "java_parameter_library", "parameter_library", "python_parameter_library", "rust_parameter_library")
+load("//fire/starlark:codegen.bzl", "generate_cc_parameters", "generate_go_parameters", "generate_java_parameters", "generate_python_parameters", "generate_rust_parameters")
+load("//fire/starlark:parameters.bzl", "parameter_library")
 
 # Generate parameter library from test YAML
 parameter_library(
@@ -20,37 +21,62 @@ parameter_library(
     src = "test_params.yaml",
 )
 
-# Generate code for each language
-cc_parameter_library(
-    name = "test_params_cc",
+# Generate C++ code
+generate_cc_parameters(
+    name = "test_params_h",
     base_name = "test_params",
     namespace = "test",
     parameter_library = ":test_params",
 )
 
-python_parameter_library(
+cc_library(
+    name = "test_params_cc",
+    hdrs = [":test_params_h"],
+)
+
+# Generate Python code
+generate_python_parameters(
+    name = "test_params_py_src",
+    base_name = "test_params",
+    parameter_library = ":test_params",
+)
+
+py_library(
     name = "test_params_py",
+    srcs = [":test_params_py_src"],
+)
+
+# Generate Go code
+generate_go_parameters(
+    name = "test_params_go_src",
     base_name = "test_params",
     parameter_library = ":test_params",
 )
 
-go_parameter_library(
+go_library(
     name = "test_params_go",
-    base_name = "test_params",
-    parameter_library = ":test_params",
+    srcs = [":test_params_go_src"],
+    importpath = "fire/starlark/failure_test/parameter_version/test_params",
 )
 
-rust_parameter_library(
+# Generate Rust code
+generate_rust_parameters(
     name = "test_params_rust",
     base_name = "test_params",
     parameter_library = ":test_params",
 )
 
-java_parameter_library(
-    name = "test_params_java",
+# Generate Java code
+generate_java_parameters(
+    name = "test_params_java_src",
     class_name = "TestParams",
     package_prefix = "fire.starlark.failure_test.parameter_version",
     parameter_library = ":test_params",
+)
+
+java_library(
+    name = "test_params_java",
+    srcs = [":test_params_java_src"],
 )
 
 # =============================================================================

--- a/fire/starlark/parameters.bzl
+++ b/fire/starlark/parameters.bzl
@@ -2,12 +2,18 @@
 
 Parameters are defined in YAML files and validated at build time using JSON schema.
 Code is generated for multiple languages from the validated YAML.
-"""
 
-load("@rules_cc//cc:defs.bzl", "cc_library")
-load("@rules_go//go:def.bzl", "go_library")
-load("@rules_java//java:defs.bzl", "java_library")
-load("@rules_python//python:defs.bzl", "py_library")
+This file provides only parameter validation (parameter_library).
+For code generation, use @fire//fire/starlark:codegen.bzl which provides:
+  - generate_cc_parameters()      - generates .h files
+  - generate_python_parameters()  - generates .py files
+  - generate_java_parameters()    - generates .java files
+  - generate_go_parameters()      - generates .go files
+  - generate_rust_parameters()    - generates .rs files
+
+Consumers are responsible for wrapping generated files in their own language libraries.
+This keeps Fire's dependencies minimal - Fire only needs rules_python for validation.
+"""
 
 def parameter_library(
         name,
@@ -34,16 +40,27 @@ def parameter_library(
         #     unit: m/s
         #     description: Maximum velocity
 
-        # Create parameter library
+        # In BUILD.bazel:
+        load("@fire//fire/starlark:parameters.bzl", "parameter_library")
+        load("@fire//fire/starlark:codegen.bzl", "generate_cc_parameters")
+        load("@rules_cc//cc:defs.bzl", "cc_library")
+
+        # Validate parameters
         parameter_library(
             name = "vehicle_params",
             src = "vehicle_params.yaml",
         )
 
-        # Generate code for different languages
-        cc_parameter_library(
-            name = "vehicle_params_cc",
+        # Generate C++ code
+        generate_cc_parameters(
+            name = "vehicle_params_h",
             parameter_library = ":vehicle_params",
+        )
+
+        # Wrap in cc_library
+        cc_library(
+            name = "vehicle_params_cc",
+            hdrs = [":vehicle_params_h"],
         )
     """
 
@@ -85,282 +102,4 @@ def parameter_library(
         name = name,
         srcs = [":" + validation_name],
         visibility = visibility if visibility else ["//visibility:public"],
-    )
-
-def cc_parameter_library(
-        name,
-        parameter_library,
-        base_name = None,
-        namespace = None,
-        **kwargs):
-    """Generate C++ header and create cc_library from parameter_library.
-
-    Args:
-        name: Name of the cc_library
-        parameter_library: Label of the parameter_library target (the YAML file)
-        base_name: Base name for output file (optional, defaults to name with _cc suffix removed)
-        namespace: Optional C++ namespace (use :: for nested namespaces, e.g., "outer::inner")
-        **kwargs: Additional arguments for cc_library
-
-    Example:
-        parameter_library(
-            name = "vehicle_params",
-            src = "vehicle_params.yaml",
-        )
-
-        cc_parameter_library(
-            name = "vehicle_params_cc",
-            parameter_library = ":vehicle_params",
-            namespace = "my_project::params",  # Optional
-        )
-        # Generates: vehicle_params.h
-        # Include as: #include "examples/vehicle_params.h"
-
-    Note:
-        Headers should be included using repository-relative paths.
-        For example, if the header is in package "examples", use:
-            #include "examples/header_name.h"
-    """
-
-    # Derive base_name if not provided
-    if not base_name:
-        # Strip common suffixes
-        base_name = name
-
-    # Build command with namespace (only if explicitly provided)
-    if namespace:
-        cmd = "$(location @fire//fire/starlark:generate_code_script) cpp $< $@ --namespace='{}'".format(namespace)
-    else:
-        cmd = "$(location @fire//fire/starlark:generate_code_script) cpp $< $@"
-
-    # Create a generated header file using the Python script
-    header_target = name + "_header"
-    native.genrule(
-        name = header_target,
-        srcs = [parameter_library],
-        outs = [base_name + ".h"],
-        cmd = cmd,
-        tools = ["@fire//fire/starlark:generate_code_script"],
-        visibility = ["//visibility:public"],
-    )
-
-    # Wrap in cc_library
-    cc_library(
-        name = name,
-        hdrs = [":" + header_target],
-        **kwargs
-    )
-
-def python_parameter_library(
-        name,
-        parameter_library,
-        base_name = None,
-        **kwargs):
-    """Generate Python module and create py_library from parameter_library.
-
-    Args:
-        name: Name of the py_library
-        parameter_library: Label of the parameter_library target (the YAML file)
-        base_name: Base name for output file (optional, defaults to name with _py suffix removed)
-        **kwargs: Additional arguments for py_library
-
-    Example:
-        parameter_library(
-            name = "vehicle_params",
-            src = "vehicle_params.yaml",
-        )
-
-        python_parameter_library(
-            name = "vehicle_params_py",
-            parameter_library = ":vehicle_params",
-        )
-        # Generates: vehicle_params.py
-        # Import as: from examples.vehicle_params import ...
-    """
-
-    # Derive base_name if not provided
-    if not base_name:
-        # Strip common suffixes
-        base_name = name
-
-    # Create a generated Python file using the Python script
-    py_file_target = name + "_file"
-    native.genrule(
-        name = py_file_target,
-        srcs = [parameter_library],
-        outs = [base_name + ".py"],
-        cmd = "$(location @fire//fire/starlark:generate_code_script) python $< $@",
-        tools = ["@fire//fire/starlark:generate_code_script"],
-        visibility = ["//visibility:public"],
-    )
-
-    # Wrap in py_library
-    py_library(
-        name = name,
-        srcs = [":" + py_file_target],
-        imports = [".."],
-        **kwargs
-    )
-
-def java_parameter_library(
-        name,
-        parameter_library,
-        class_name = None,
-        package_prefix = None):
-    """Generate Java class from parameter_library.
-
-    Args:
-        name: Name of the Bazel target
-        parameter_library: Label of the parameter_library target (the YAML file)
-        class_name: Name of the generated class (optional, derived from target name if not provided)
-        package_prefix: Optional package prefix (e.g., "com.example")
-
-    Example:
-        parameter_library(
-            name = "vehicle_params",
-            src = "vehicle_params.yaml",
-        )
-
-        java_parameter_library(
-            name = "vehicle_params_java",
-            parameter_library = ":vehicle_params",
-            class_name = "VehicleParams",  # Optional
-            package_prefix = "com.example",  # Optional
-        )
-        # Generates: VehicleParams.java (or derived from target name)
-    """
-
-    # Derive class_name if not provided
-    if not class_name:
-        # Strip common suffixes and convert to PascalCase
-        base_name = name
-        parts = base_name.split("_")
-        class_name = "".join([word.capitalize() for word in parts])
-
-    java_file_target = name + "_file"
-
-    # Build command with namespace (only if explicitly provided)
-    if package_prefix:
-        cmd = "$(location @fire//fire/starlark:generate_code_script) java $< $@ --class-name='{}' --namespace='{}'".format(class_name, package_prefix)
-    else:
-        cmd = "$(location @fire//fire/starlark:generate_code_script) java $< $@ --class-name='{}'".format(class_name)
-
-    native.genrule(
-        name = java_file_target,
-        srcs = [parameter_library],
-        outs = [class_name + ".java"],
-        cmd = cmd,
-        tools = ["@fire//fire/starlark:generate_code_script"],
-        visibility = ["//visibility:public"],
-    )
-
-    # Wrap in java_library
-    java_library(
-        name = name,
-        srcs = [":" + java_file_target],
-        visibility = ["//visibility:public"],
-    )
-
-def go_parameter_library(
-        name,
-        parameter_library,
-        base_name = None,
-        importpath = None,
-        **kwargs):
-    """Generate Go package and create go_library from parameter_library.
-
-    Args:
-        name: Name of the go_library
-        parameter_library: Label of the parameter_library target (the YAML file)
-        base_name: Base name for output file (optional, defaults to name with _go suffix removed)
-        importpath: Go import path (optional, defaults to package path + "/" + base_name)
-        **kwargs: Additional arguments for go_library
-
-    Example:
-        parameter_library(
-            name = "vehicle_params",
-            src = "vehicle_params.yaml",
-        )
-
-        go_parameter_library(
-            name = "vehicle_params_go",
-            parameter_library = ":vehicle_params",
-        )
-        # Generates: vehicle_params.go
-        # Import as: import vehicle_params "examples/vehicle_params"
-    """
-
-    # Derive base_name if not provided
-    if not base_name:
-        # Strip common suffixes
-        base_name = name
-
-    # Derive importpath if not provided
-    if not importpath:
-        pkg = native.package_name()
-        if pkg:
-            importpath = pkg + "/" + base_name
-        else:
-            importpath = base_name
-
-    # Use base_name as Go package name
-    go_package = base_name.replace("_", "")
-
-    # Create a generated Go file using the Python script
-    go_file_target = name + "_file"
-    native.genrule(
-        name = go_file_target,
-        srcs = [parameter_library],
-        outs = [base_name + ".go"],
-        cmd = "$(location @fire//fire/starlark:generate_code_script) go $< $@ --namespace='{}'".format(go_package),
-        tools = ["@fire//fire/starlark:generate_code_script"],
-        visibility = ["//visibility:public"],
-    )
-
-    # Wrap in go_library
-    go_library(
-        name = name,
-        srcs = [":" + go_file_target],
-        importpath = importpath,
-        **kwargs
-    )
-
-def rust_parameter_library(
-        name,
-        parameter_library,
-        base_name = None):
-    """Generate Rust module from parameter_library.
-
-    Args:
-        name: Name of the Bazel target (use directly in rust_test srcs)
-        parameter_library: Label of the parameter_library target (the YAML file)
-        base_name: Base name for output file (optional, defaults to name with _rs suffix removed)
-
-    Example:
-        parameter_library(
-            name = "vehicle_params",
-            src = "vehicle_params.yaml",
-        )
-
-        rust_parameter_library(
-            name = "vehicle_params_rs",
-            parameter_library = ":vehicle_params",
-        )
-        # Generates: vehicle_params.rs
-        # Include as: #[path = "vehicle_params.rs"] mod vehicle_params;
-    """
-
-    # Derive base_name if not provided
-    if not base_name:
-        # Strip common suffixes
-        base_name = name
-
-    # Create a generated Rust file using the Python script
-    native.genrule(
-        name = name,
-        srcs = [parameter_library],
-        outs = [base_name + ".rs"],
-        cmd = "$(location @fire//fire/starlark:generate_code_script) rust $< $@",
-        tools = ["@fire//fire/starlark:generate_code_script"],
-        visibility = ["//visibility:public"],
     )

--- a/integration_test/BUILD.bazel
+++ b/integration_test/BUILD.bazel
@@ -1,12 +1,9 @@
 """Integration test for fire requirements management system."""
 
-load(
-    "@fire//fire/starlark:parameters.bzl",
-    "cc_parameter_library",
-    "parameter_library",
-    "rust_parameter_library",
-)
+load("@fire//fire/starlark:codegen.bzl", "generate_cc_parameters", "generate_rust_parameters")
+load("@fire//fire/starlark:parameters.bzl", "parameter_library")
 load("@fire//fire/starlark:reports.bzl", "generate_report")
+load("@rules_cc//cc:defs.bzl", "cc_library")
 load("@rules_shell//shell:sh_test.bzl", "sh_test")
 
 exports_files(["test_params.yaml"])
@@ -18,18 +15,24 @@ parameter_library(
     src = "test_params.yaml",
 )
 
-# Generate C++ library with parameters
-# Consumes test_params.json and generates test_params.h
-cc_parameter_library(
-    name = "test_params_cc",
+# Generate C++ header from parameters
+# Consumes test_params (validated YAML) and generates test_params.h
+generate_cc_parameters(
+    name = "test_params_h",
     base_name = "test_params",
     parameter_library = ":test_params",
+)
+
+# Wrap generated header in cc_library
+cc_library(
+    name = "test_params_cc",
+    hdrs = [":test_params_h"],
     visibility = ["//visibility:public"],
 )
 
-# Generate Rust parameters
-# Consumes test_params.json and generates test_params.rs
-rust_parameter_library(
+# Generate Rust module from parameters
+# Consumes test_params (validated YAML) and generates test_params.rs
+generate_rust_parameters(
     name = "test_params_rs",
     base_name = "test_params",
     parameter_library = ":test_params",

--- a/integration_test/MODULE.bazel
+++ b/integration_test/MODULE.bazel
@@ -10,6 +10,13 @@ module(
     version = "0.0.0",
 )
 
+# C++ rules for consuming generated code
+bazel_dep(name = "rules_cc", version = "0.2.16")
+
+# Rust rules for consuming generated code
+bazel_dep(name = "rules_rust", version = "0.68.1")
+bazel_dep(name = "rules_shell", version = "0.6.1")
+
 # Depend on fire project
 bazel_dep(name = "fire", version = "0.1.2")
 
@@ -18,13 +25,6 @@ local_path_override(
     module_name = "fire",
     path = "..",
 )
-
-# C++ rules for consuming generated code
-bazel_dep(name = "rules_cc", version = "0.2.16")
-
-# Rust rules for consuming generated code
-bazel_dep(name = "rules_rust", version = "0.68.1")
-bazel_dep(name = "rules_shell", version = "0.6.1")
 
 # Rust toolchain setup
 rust = use_extension("@rules_rust//rust:extensions.bzl", "rust")

--- a/integration_test/MODULE.bazel.lock
+++ b/integration_test/MODULE.bazel.lock
@@ -9,17 +9,10 @@
     "https://bcr.bazel.build/modules/abseil-cpp/20230802.0/MODULE.bazel": "d253ae36a8bd9ee3c5955384096ccb6baf16a1b1e93e858370da0a3b94f77c16",
     "https://bcr.bazel.build/modules/abseil-cpp/20230802.1/MODULE.bazel": "fa92e2eb41a04df73cdabeec37107316f7e5272650f81d6cc096418fe647b915",
     "https://bcr.bazel.build/modules/abseil-cpp/20240116.1/MODULE.bazel": "37bcdb4440fbb61df6a1c296ae01b327f19e9bb521f9b8e26ec854b6f97309ed",
-    "https://bcr.bazel.build/modules/abseil-cpp/20240116.2/MODULE.bazel": "73939767a4686cd9a520d16af5ab440071ed75cec1a876bf2fcfaf1f71987a16",
-    "https://bcr.bazel.build/modules/abseil-cpp/20250127.1/MODULE.bazel": "c4a89e7ceb9bf1e25cf84a9f830ff6b817b72874088bf5141b314726e46a57c1",
-    "https://bcr.bazel.build/modules/abseil-cpp/20250512.1/MODULE.bazel": "d209fdb6f36ffaf61c509fcc81b19e81b411a999a934a032e10cd009a0226215",
-    "https://bcr.bazel.build/modules/abseil-cpp/20250814.1/MODULE.bazel": "51f2312901470cdab0dbdf3b88c40cd21c62a7ed58a3de45b365ddc5b11bcab2",
-    "https://bcr.bazel.build/modules/abseil-cpp/20250814.1/source.json": "cea3901d7e299da7320700abbaafe57a65d039f10d0d7ea601c4a66938ea4b0c",
-    "https://bcr.bazel.build/modules/apple_support/1.11.1/MODULE.bazel": "1843d7cd8a58369a444fc6000e7304425fba600ff641592161d9f15b179fb896",
-    "https://bcr.bazel.build/modules/apple_support/1.15.1/MODULE.bazel": "a0556fefca0b1bb2de8567b8827518f94db6a6e7e7d632b4c48dc5f865bc7c85",
+    "https://bcr.bazel.build/modules/abseil-cpp/20240116.1/source.json": "9be551b8d4e3ef76875c0d744b5d6a504a27e3ae67bc6b28f46415fd2d2957da",
     "https://bcr.bazel.build/modules/apple_support/1.23.1/MODULE.bazel": "53763fed456a968cf919b3240427cf3a9d5481ec5466abc9d5dc51bc70087442",
     "https://bcr.bazel.build/modules/apple_support/1.24.1/MODULE.bazel": "f46e8ddad60aef170ee92b2f3d00ef66c147ceafea68b6877cb45bd91737f5f8",
     "https://bcr.bazel.build/modules/apple_support/1.24.1/source.json": "cf725267cbacc5f028ef13bb77e7f2c2e0066923a4dab1025e4a0511b1ed258a",
-    "https://bcr.bazel.build/modules/bazel_features/1.1.0/MODULE.bazel": "cfd42ff3b815a5f39554d97182657f8c4b9719568eb7fded2b9135f084bf760b",
     "https://bcr.bazel.build/modules/bazel_features/1.1.1/MODULE.bazel": "27b8c79ef57efe08efccbd9dd6ef70d61b4798320b8d3c134fd571f78963dbcd",
     "https://bcr.bazel.build/modules/bazel_features/1.11.0/MODULE.bazel": "f9382337dd5a474c3b7d334c2f83e50b6eaedc284253334cf823044a26de03e8",
     "https://bcr.bazel.build/modules/bazel_features/1.15.0/MODULE.bazel": "d38ff6e517149dc509406aca0db3ad1efdd890a85e049585b7234d04238e2a4d",
@@ -27,10 +20,8 @@
     "https://bcr.bazel.build/modules/bazel_features/1.18.0/MODULE.bazel": "1be0ae2557ab3a72a57aeb31b29be347bcdc5d2b1eb1e70f39e3851a7e97041a",
     "https://bcr.bazel.build/modules/bazel_features/1.19.0/MODULE.bazel": "59adcdf28230d220f0067b1f435b8537dd033bfff8db21335ef9217919c7fb58",
     "https://bcr.bazel.build/modules/bazel_features/1.21.0/MODULE.bazel": "675642261665d8eea09989aa3b8afb5c37627f1be178382c320d1b46afba5e3b",
-    "https://bcr.bazel.build/modules/bazel_features/1.23.0/MODULE.bazel": "fd1ac84bc4e97a5a0816b7fd7d4d4f6d837b0047cf4cbd81652d616af3a6591a",
     "https://bcr.bazel.build/modules/bazel_features/1.27.0/MODULE.bazel": "621eeee06c4458a9121d1f104efb80f39d34deff4984e778359c60eaf1a8cb65",
     "https://bcr.bazel.build/modules/bazel_features/1.28.0/MODULE.bazel": "4b4200e6cbf8fa335b2c3f43e1d6ef3e240319c33d43d60cc0fbd4b87ece299d",
-    "https://bcr.bazel.build/modules/bazel_features/1.3.0/MODULE.bazel": "cdcafe83ec318cda34e02948e81d790aab8df7a929cec6f6969f13a489ccecd9",
     "https://bcr.bazel.build/modules/bazel_features/1.30.0/MODULE.bazel": "a14b62d05969a293b80257e72e597c2da7f717e1e69fa8b339703ed6731bec87",
     "https://bcr.bazel.build/modules/bazel_features/1.32.0/MODULE.bazel": "095d67022a58cb20f7e20e1aefecfa65257a222c18a938e2914fd257b5f1ccdc",
     "https://bcr.bazel.build/modules/bazel_features/1.32.0/source.json": "2546c766986a6541f0bacd3e8542a1f621e2b14a80ea9e88c6f89f7eedf64ae1",
@@ -47,30 +38,19 @@
     "https://bcr.bazel.build/modules/bazel_skylib/1.6.1/MODULE.bazel": "8fdee2dbaace6c252131c00e1de4b165dc65af02ea278476187765e1a617b917",
     "https://bcr.bazel.build/modules/bazel_skylib/1.7.0/MODULE.bazel": "0db596f4563de7938de764cc8deeabec291f55e8ec15299718b93c4423e9796d",
     "https://bcr.bazel.build/modules/bazel_skylib/1.7.1/MODULE.bazel": "3120d80c5861aa616222ec015332e5f8d3171e062e3e804a2a0253e1be26e59b",
-    "https://bcr.bazel.build/modules/bazel_skylib/1.8.1/MODULE.bazel": "88ade7293becda963e0e3ea33e7d54d3425127e0a326e0d17da085a5f1f03ff6",
     "https://bcr.bazel.build/modules/bazel_skylib/1.8.2/MODULE.bazel": "69ad6927098316848b34a9142bcc975e018ba27f08c4ff403f50c1b6e646ca67",
     "https://bcr.bazel.build/modules/bazel_skylib/1.9.0/MODULE.bazel": "72997b29dfd95c3fa0d0c48322d05590418edef451f8db8db5509c57875fb4b7",
     "https://bcr.bazel.build/modules/bazel_skylib/1.9.0/source.json": "7ad77c1e8c1b84222d9b3f3cae016a76639435744c19330b0b37c0a3c9da7dc0",
     "https://bcr.bazel.build/modules/buildozer/7.1.2/MODULE.bazel": "2e8dd40ede9c454042645fd8d8d0cd1527966aa5c919de86661e62953cd73d84",
     "https://bcr.bazel.build/modules/buildozer/7.1.2/source.json": "c9028a501d2db85793a6996205c8de120944f50a0d570438fcae0457a5f9d1f8",
-    "https://bcr.bazel.build/modules/gazelle/0.32.0/MODULE.bazel": "b499f58a5d0d3537f3cf5b76d8ada18242f64ec474d8391247438bf04f58c7b8",
-    "https://bcr.bazel.build/modules/gazelle/0.33.0/MODULE.bazel": "a13a0f279b462b784fb8dd52a4074526c4a2afe70e114c7d09066097a46b3350",
-    "https://bcr.bazel.build/modules/gazelle/0.34.0/MODULE.bazel": "abdd8ce4d70978933209db92e436deb3a8b737859e9354fb5fd11fb5c2004c8a",
-    "https://bcr.bazel.build/modules/gazelle/0.36.0/MODULE.bazel": "e375d5d6e9a6ca59b0cb38b0540bc9a05b6aa926d322f2de268ad267a2ee74c0",
-    "https://bcr.bazel.build/modules/gazelle/0.36.0/source.json": "0823f097b127e0201ae55d85647c94095edfe27db0431a7ae880dcab08dfaa04",
     "https://bcr.bazel.build/modules/google_benchmark/1.8.2/MODULE.bazel": "a70cf1bba851000ba93b58ae2f6d76490a9feb74192e57ab8e8ff13c34ec50cb",
     "https://bcr.bazel.build/modules/googletest/1.11.0/MODULE.bazel": "3a83f095183f66345ca86aa13c58b59f9f94a2f81999c093d4eeaa2d262d12f4",
     "https://bcr.bazel.build/modules/googletest/1.14.0.bcr.1/MODULE.bazel": "22c31a561553727960057361aa33bf20fb2e98584bc4fec007906e27053f80c6",
+    "https://bcr.bazel.build/modules/googletest/1.14.0.bcr.1/source.json": "41e9e129f80d8c8bf103a7acc337b76e54fad1214ac0a7084bf24f4cd924b8b4",
     "https://bcr.bazel.build/modules/googletest/1.14.0/MODULE.bazel": "cfbcbf3e6eac06ef9d85900f64424708cc08687d1b527f0ef65aa7517af8118f",
-    "https://bcr.bazel.build/modules/googletest/1.15.2/MODULE.bazel": "6de1edc1d26cafb0ea1a6ab3f4d4192d91a312fd2d360b63adaa213cd00b2108",
-    "https://bcr.bazel.build/modules/googletest/1.17.0/MODULE.bazel": "dbec758171594a705933a29fcf69293d2468c49ec1f2ebca65c36f504d72df46",
-    "https://bcr.bazel.build/modules/googletest/1.17.0/source.json": "38e4454b25fc30f15439c0378e57909ab1fd0a443158aa35aec685da727cd713",
     "https://bcr.bazel.build/modules/jsoncpp/1.9.5/MODULE.bazel": "31271aedc59e815656f5736f282bb7509a97c7ecb43e927ac1a37966e0578075",
-    "https://bcr.bazel.build/modules/jsoncpp/1.9.6/MODULE.bazel": "2f8d20d3b7d54143213c4dfc3d98225c42de7d666011528dc8fe91591e2e17b0",
-    "https://bcr.bazel.build/modules/jsoncpp/1.9.6/source.json": "a04756d367a2126c3541682864ecec52f92cdee80a35735a3cb249ce015ca000",
+    "https://bcr.bazel.build/modules/jsoncpp/1.9.5/source.json": "4108ee5085dd2885a341c7fab149429db457b3169b86eb081fa245eadf69169d",
     "https://bcr.bazel.build/modules/libpfm/4.11.0/MODULE.bazel": "45061ff025b301940f1e30d2c16bea596c25b176c8b6b3087e92615adbd52902",
-    "https://bcr.bazel.build/modules/nlohmann_json/3.6.1/MODULE.bazel": "6f7b417dcc794d9add9e556673ad25cb3ba835224290f4f848f8e2db1e1fca74",
-    "https://bcr.bazel.build/modules/nlohmann_json/3.6.1/source.json": "f448c6e8963fdfa7eb831457df83ad63d3d6355018f6574fb017e8169deb43a9",
     "https://bcr.bazel.build/modules/platforms/0.0.10/MODULE.bazel": "8cb8efaf200bdeb2150d93e162c40f388529a25852b332cec879373771e48ed5",
     "https://bcr.bazel.build/modules/platforms/0.0.11/MODULE.bazel": "0daefc49732e227caa8bfa834d65dc52e8cc18a2faf80df25e8caea151a9413f",
     "https://bcr.bazel.build/modules/platforms/0.0.4/MODULE.bazel": "9b328e31ee156f53f3c416a64f8491f7eb731742655a47c9eec4703a71644aee",
@@ -84,53 +64,36 @@
     "https://bcr.bazel.build/modules/protobuf/21.7/MODULE.bazel": "a5a29bb89544f9b97edce05642fac225a808b5b7be74038ea3640fae2f8e66a7",
     "https://bcr.bazel.build/modules/protobuf/27.0/MODULE.bazel": "7873b60be88844a0a1d8f80b9d5d20cfbd8495a689b8763e76c6372998d3f64c",
     "https://bcr.bazel.build/modules/protobuf/27.1/MODULE.bazel": "703a7b614728bb06647f965264967a8ef1c39e09e8f167b3ca0bb1fd80449c0d",
-    "https://bcr.bazel.build/modules/protobuf/29.0-rc2.bcr.1/MODULE.bazel": "52f4126f63a2f0bbf36b99c2a87648f08467a4eaf92ba726bc7d6a500bbf770c",
     "https://bcr.bazel.build/modules/protobuf/29.0-rc2/MODULE.bazel": "6241d35983510143049943fc0d57937937122baf1b287862f9dc8590fc4c37df",
     "https://bcr.bazel.build/modules/protobuf/29.0-rc3/MODULE.bazel": "33c2dfa286578573afc55a7acaea3cada4122b9631007c594bf0729f41c8de92",
     "https://bcr.bazel.build/modules/protobuf/29.0/MODULE.bazel": "319dc8bf4c679ff87e71b1ccfb5a6e90a6dbc4693501d471f48662ac46d04e4e",
-    "https://bcr.bazel.build/modules/protobuf/29.1/MODULE.bazel": "557c3457560ff49e122ed76c0bc3397a64af9574691cb8201b4e46d4ab2ecb95",
+    "https://bcr.bazel.build/modules/protobuf/29.0/source.json": "b857f93c796750eef95f0d61ee378f3420d00ee1dd38627b27193aa482f4f981",
     "https://bcr.bazel.build/modules/protobuf/3.19.0/MODULE.bazel": "6b5fbb433f760a99a22b18b6850ed5784ef0e9928a72668b66e4d7ccd47db9b0",
-    "https://bcr.bazel.build/modules/protobuf/3.19.2/MODULE.bazel": "532ffe5f2186b69fdde039efe6df13ba726ff338c6bc82275ad433013fa10573",
-    "https://bcr.bazel.build/modules/protobuf/3.19.6/MODULE.bazel": "9233edc5e1f2ee276a60de3eaa47ac4132302ef9643238f23128fea53ea12858",
-    "https://bcr.bazel.build/modules/protobuf/32.1/MODULE.bazel": "89cd2866a9cb07fee9ff74c41ceace11554f32e0d849de4e23ac55515cfada4d",
-    "https://bcr.bazel.build/modules/protobuf/32.1/source.json": "bd2664e90875c0cd755d1d9b7a103a4b027893ac8eafa3bba087557ffc244ad4",
     "https://bcr.bazel.build/modules/pybind11_bazel/2.11.1/MODULE.bazel": "88af1c246226d87e65be78ed49ecd1e6f5e98648558c14ce99176da041dc378e",
-    "https://bcr.bazel.build/modules/pybind11_bazel/2.12.0/MODULE.bazel": "e6f4c20442eaa7c90d7190d8dc539d0ab422f95c65a57cc59562170c58ae3d34",
-    "https://bcr.bazel.build/modules/pybind11_bazel/2.12.0/source.json": "6900fdc8a9e95866b8c0d4ad4aba4d4236317b5c1cd04c502df3f0d33afed680",
+    "https://bcr.bazel.build/modules/pybind11_bazel/2.11.1/source.json": "be4789e951dd5301282729fe3d4938995dc4c1a81c2ff150afc9f1b0504c6022",
     "https://bcr.bazel.build/modules/re2/2023-09-01/MODULE.bazel": "cb3d511531b16cfc78a225a9e2136007a48cf8a677e4264baeab57fe78a80206",
-    "https://bcr.bazel.build/modules/re2/2024-07-02.bcr.1/MODULE.bazel": "b4963dda9b31080be1905ef085ecd7dd6cd47c05c79b9cdf83ade83ab2ab271a",
-    "https://bcr.bazel.build/modules/re2/2024-07-02.bcr.1/source.json": "2ff292be6ef3340325ce8a045ecc326e92cbfab47c7cbab4bd85d28971b97ac4",
-    "https://bcr.bazel.build/modules/re2/2024-07-02/MODULE.bazel": "0eadc4395959969297cbcf31a249ff457f2f1d456228c67719480205aa306daa",
+    "https://bcr.bazel.build/modules/re2/2023-09-01/source.json": "e044ce89c2883cd957a2969a43e79f7752f9656f6b20050b62f90ede21ec6eb4",
     "https://bcr.bazel.build/modules/rules_android/0.1.1/MODULE.bazel": "48809ab0091b07ad0182defb787c4c5328bd3a278938415c00a7b69b50c4d3a8",
     "https://bcr.bazel.build/modules/rules_android/0.1.1/source.json": "e6986b41626ee10bdc864937ffb6d6bf275bb5b9c65120e6137d56e6331f089e",
-    "https://bcr.bazel.build/modules/rules_apple/3.16.0/MODULE.bazel": "0d1caf0b8375942ce98ea944be754a18874041e4e0459401d925577624d3a54a",
-    "https://bcr.bazel.build/modules/rules_apple/3.16.0/source.json": "d8b5fe461272018cc07cfafce11fe369c7525330804c37eec5a82f84cd475366",
     "https://bcr.bazel.build/modules/rules_cc/0.0.1/MODULE.bazel": "cb2aa0747f84c6c3a78dad4e2049c154f08ab9d166b1273835a8174940365647",
     "https://bcr.bazel.build/modules/rules_cc/0.0.10/MODULE.bazel": "ec1705118f7eaedd6e118508d3d26deba2a4e76476ada7e0e3965211be012002",
     "https://bcr.bazel.build/modules/rules_cc/0.0.13/MODULE.bazel": "0e8529ed7b323dad0775ff924d2ae5af7640b23553dfcd4d34344c7e7a867191",
     "https://bcr.bazel.build/modules/rules_cc/0.0.14/MODULE.bazel": "5e343a3aac88b8d7af3b1b6d2093b55c347b8eefc2e7d1442f7a02dc8fea48ac",
     "https://bcr.bazel.build/modules/rules_cc/0.0.15/MODULE.bazel": "6704c35f7b4a72502ee81f61bf88706b54f06b3cbe5558ac17e2e14666cd5dcc",
     "https://bcr.bazel.build/modules/rules_cc/0.0.16/MODULE.bazel": "7661303b8fc1b4d7f532e54e9d6565771fea666fbdf839e0a86affcd02defe87",
-    "https://bcr.bazel.build/modules/rules_cc/0.0.17/MODULE.bazel": "2ae1d8f4238ec67d7185d8861cb0a2cdf4bc608697c331b95bf990e69b62e64a",
     "https://bcr.bazel.build/modules/rules_cc/0.0.2/MODULE.bazel": "6915987c90970493ab97393024c156ea8fb9f3bea953b2f3ec05c34f19b5695c",
     "https://bcr.bazel.build/modules/rules_cc/0.0.6/MODULE.bazel": "abf360251023dfe3efcef65ab9d56beefa8394d4176dd29529750e1c57eaa33f",
     "https://bcr.bazel.build/modules/rules_cc/0.0.8/MODULE.bazel": "964c85c82cfeb6f3855e6a07054fdb159aced38e99a5eecf7bce9d53990afa3e",
     "https://bcr.bazel.build/modules/rules_cc/0.0.9/MODULE.bazel": "836e76439f354b89afe6a911a7adf59a6b2518fafb174483ad78a2a2fde7b1c5",
     "https://bcr.bazel.build/modules/rules_cc/0.1.1/MODULE.bazel": "2f0222a6f229f0bf44cd711dc13c858dad98c62d52bd51d8fc3a764a83125513",
     "https://bcr.bazel.build/modules/rules_cc/0.1.5/MODULE.bazel": "88dfc9361e8b5ae1008ac38f7cdfd45ad738e4fa676a3ad67d19204f045a1fd8",
-    "https://bcr.bazel.build/modules/rules_cc/0.2.0/MODULE.bazel": "b5c17f90458caae90d2ccd114c81970062946f49f355610ed89bebf954f5783c",
-    "https://bcr.bazel.build/modules/rules_cc/0.2.13/MODULE.bazel": "eecdd666eda6be16a8d9dc15e44b5c75133405e820f620a234acc4b1fdc5aa37",
     "https://bcr.bazel.build/modules/rules_cc/0.2.16/MODULE.bazel": "9242fa89f950c6ef7702801ab53922e99c69b02310c39fb6e62b2bd30df2a1d4",
     "https://bcr.bazel.build/modules/rules_cc/0.2.16/source.json": "d03d5cde49376d87e14ec14b666c56075e5e3926930327fd5d0484a1ff2ac1cc",
     "https://bcr.bazel.build/modules/rules_cc/0.2.4/MODULE.bazel": "1ff1223dfd24f3ecf8f028446d4a27608aa43c3f41e346d22838a4223980b8cc",
     "https://bcr.bazel.build/modules/rules_cc/0.2.8/MODULE.bazel": "f1df20f0bf22c28192a794f29b501ee2018fa37a3862a1a2132ae2940a23a642",
     "https://bcr.bazel.build/modules/rules_foreign_cc/0.9.0/MODULE.bazel": "c9e8c682bf75b0e7c704166d79b599f93b72cfca5ad7477df596947891feeef6",
     "https://bcr.bazel.build/modules/rules_fuzzing/0.5.2/MODULE.bazel": "40c97d1144356f52905566c55811f13b299453a14ac7769dfba2ac38192337a8",
-    "https://bcr.bazel.build/modules/rules_go/0.41.0/MODULE.bazel": "55861d8e8bb0e62cbd2896f60ff303f62ffcb0eddb74ecb0e5c0cbe36fc292c8",
-    "https://bcr.bazel.build/modules/rules_go/0.42.0/MODULE.bazel": "8cfa875b9aa8c6fce2b2e5925e73c1388173ea3c32a0db4d2b4804b453c14270",
-    "https://bcr.bazel.build/modules/rules_go/0.46.0/MODULE.bazel": "3477df8bdcc49e698b9d25f734c4f3a9f5931ff34ee48a2c662be168f5f2d3fd",
-    "https://bcr.bazel.build/modules/rules_go/0.59.0/MODULE.bazel": "b7e43e7414a3139a7547d1b4909b29085fbe5182b6c58cbe1ed4c6272815aeae",
-    "https://bcr.bazel.build/modules/rules_go/0.59.0/source.json": "1df17bb7865cfc029492c30163cee891d0dd8658ea0d5bfdf252c4b6db5c1ef6",
+    "https://bcr.bazel.build/modules/rules_fuzzing/0.5.2/source.json": "c8b1e2c717646f1702290959a3302a178fb639d987ab61d548105019f11e527e",
     "https://bcr.bazel.build/modules/rules_java/4.0.0/MODULE.bazel": "5a78a7ae82cd1a33cef56dc578c7d2a46ed0dca12643ee45edbb8417899e6f74",
     "https://bcr.bazel.build/modules/rules_java/5.3.5/MODULE.bazel": "a4ec4f2db570171e3e5eb753276ee4b389bae16b96207e9d3230895c99644b86",
     "https://bcr.bazel.build/modules/rules_java/6.0.0/MODULE.bazel": "8a43b7df601a7ec1af61d79345c17b31ea1fedc6711fd4abfd013ea612978e39",
@@ -142,19 +105,16 @@
     "https://bcr.bazel.build/modules/rules_java/7.3.2/MODULE.bazel": "50dece891cfdf1741ea230d001aa9c14398062f2b7c066470accace78e412bc2",
     "https://bcr.bazel.build/modules/rules_java/7.6.1/MODULE.bazel": "2f14b7e8a1aa2f67ae92bc69d1ec0fa8d9f827c4e17ff5e5f02e91caa3b2d0fe",
     "https://bcr.bazel.build/modules/rules_java/8.14.0/MODULE.bazel": "717717ed40cc69994596a45aec6ea78135ea434b8402fb91b009b9151dd65615",
+    "https://bcr.bazel.build/modules/rules_java/8.14.0/source.json": "8a88c4ca9e8759da53cddc88123880565c520503321e2566b4e33d0287a3d4bc",
     "https://bcr.bazel.build/modules/rules_java/8.3.2/MODULE.bazel": "7336d5511ad5af0b8615fdc7477535a2e4e723a357b6713af439fe8cf0195017",
     "https://bcr.bazel.build/modules/rules_java/8.5.1/MODULE.bazel": "d8a9e38cc5228881f7055a6079f6f7821a073df3744d441978e7a43e20226939",
-    "https://bcr.bazel.build/modules/rules_java/8.6.1/MODULE.bazel": "f4808e2ab5b0197f094cabce9f4b006a27766beb6a9975931da07099560ca9c2",
-    "https://bcr.bazel.build/modules/rules_java/9.3.0/MODULE.bazel": "f657c72d65ac449caae9abf2e68e66c0d36f9416848c4c4903d0b3234229e7f2",
-    "https://bcr.bazel.build/modules/rules_java/9.3.0/source.json": "59ae7e662c3c7042b88bbb42ad12483523e234c65ebe4c51611baa43e85cb248",
     "https://bcr.bazel.build/modules/rules_jvm_external/4.4.2/MODULE.bazel": "a56b85e418c83eb1839819f0b515c431010160383306d13ec21959ac412d2fe7",
     "https://bcr.bazel.build/modules/rules_jvm_external/5.1/MODULE.bazel": "33f6f999e03183f7d088c9be518a63467dfd0be94a11d0055fe2d210f89aa909",
     "https://bcr.bazel.build/modules/rules_jvm_external/5.2/MODULE.bazel": "d9351ba35217ad0de03816ef3ed63f89d411349353077348a45348b096615036",
     "https://bcr.bazel.build/modules/rules_jvm_external/5.3/MODULE.bazel": "bf93870767689637164657731849fb887ad086739bd5d360d90007a581d5527d",
     "https://bcr.bazel.build/modules/rules_jvm_external/6.1/MODULE.bazel": "75b5fec090dbd46cf9b7d8ea08cf84a0472d92ba3585b476f44c326eda8059c4",
     "https://bcr.bazel.build/modules/rules_jvm_external/6.3/MODULE.bazel": "c998e060b85f71e00de5ec552019347c8bca255062c990ac02d051bb80a38df0",
-    "https://bcr.bazel.build/modules/rules_jvm_external/6.7/MODULE.bazel": "e717beabc4d091ecb2c803c2d341b88590e9116b8bf7947915eeb33aab4f96dd",
-    "https://bcr.bazel.build/modules/rules_jvm_external/6.7/source.json": "5426f412d0a7fc6b611643376c7e4a82dec991491b9ce5cb1cfdd25fe2e92be4",
+    "https://bcr.bazel.build/modules/rules_jvm_external/6.3/source.json": "6f5f5a5a4419ae4e37c35a5bb0a6ae657ed40b7abc5a5189111b47fcebe43197",
     "https://bcr.bazel.build/modules/rules_kotlin/1.9.0/MODULE.bazel": "ef85697305025e5a61f395d4eaede272a5393cee479ace6686dba707de804d59",
     "https://bcr.bazel.build/modules/rules_kotlin/1.9.6/MODULE.bazel": "d269a01a18ee74d0335450b10f62c9ed81f2321d7958a2934e44272fe82dcef3",
     "https://bcr.bazel.build/modules/rules_kotlin/1.9.6/source.json": "2faa4794364282db7c06600b7e5e34867a564ae91bda7cae7c29c64e9466b7d5",
@@ -167,31 +127,23 @@
     "https://bcr.bazel.build/modules/rules_pkg/1.0.1/source.json": "bd82e5d7b9ce2d31e380dd9f50c111d678c3bdaca190cb76b0e1c71b05e1ba8a",
     "https://bcr.bazel.build/modules/rules_proto/4.0.0/MODULE.bazel": "a7a7b6ce9bee418c1a760b3d84f83a299ad6952f9903c67f19e4edd964894e06",
     "https://bcr.bazel.build/modules/rules_proto/5.3.0-21.7/MODULE.bazel": "e8dff86b0971688790ae75528fe1813f71809b5afd57facb44dad9e8eca631b7",
-    "https://bcr.bazel.build/modules/rules_proto/6.0.0-rc1/MODULE.bazel": "1e5b502e2e1a9e825eef74476a5a1ee524a92297085015a052510b09a1a09483",
     "https://bcr.bazel.build/modules/rules_proto/6.0.2/MODULE.bazel": "ce916b775a62b90b61888052a416ccdda405212b6aaeb39522f7dc53431a5e73",
     "https://bcr.bazel.build/modules/rules_proto/7.0.2/MODULE.bazel": "bf81793bd6d2ad89a37a40693e56c61b0ee30f7a7fdbaf3eabbf5f39de47dea2",
-    "https://bcr.bazel.build/modules/rules_proto/7.1.0/MODULE.bazel": "002d62d9108f75bb807cd56245d45648f38275cb3a99dcd45dfb864c5d74cb96",
-    "https://bcr.bazel.build/modules/rules_proto/7.1.0/source.json": "39f89066c12c24097854e8f57ab8558929f9c8d474d34b2c00ac04630ad8940e",
+    "https://bcr.bazel.build/modules/rules_proto/7.0.2/source.json": "1e5e7260ae32ef4f2b52fd1d0de8d03b606a44c91b694d2f1afb1d3b28a48ce1",
     "https://bcr.bazel.build/modules/rules_python/0.10.2/MODULE.bazel": "cc82bc96f2997baa545ab3ce73f196d040ffb8756fd2d66125a530031cd90e5f",
     "https://bcr.bazel.build/modules/rules_python/0.23.1/MODULE.bazel": "49ffccf0511cb8414de28321f5fcf2a31312b47c40cc21577144b7447f2bf300",
     "https://bcr.bazel.build/modules/rules_python/0.25.0/MODULE.bazel": "72f1506841c920a1afec76975b35312410eea3aa7b63267436bfb1dd91d2d382",
     "https://bcr.bazel.build/modules/rules_python/0.28.0/MODULE.bazel": "cba2573d870babc976664a912539b320cbaa7114cd3e8f053c720171cde331ed",
     "https://bcr.bazel.build/modules/rules_python/0.31.0/MODULE.bazel": "93a43dc47ee570e6ec9f5779b2e64c1476a6ce921c48cc9a1678a91dd5f8fd58",
-    "https://bcr.bazel.build/modules/rules_python/0.33.2/MODULE.bazel": "3e036c4ad8d804a4dad897d333d8dce200d943df4827cb849840055be8d2e937",
     "https://bcr.bazel.build/modules/rules_python/0.4.0/MODULE.bazel": "9208ee05fd48bf09ac60ed269791cf17fb343db56c8226a720fbb1cdf467166c",
     "https://bcr.bazel.build/modules/rules_python/0.40.0/MODULE.bazel": "9d1a3cd88ed7d8e39583d9ffe56ae8a244f67783ae89b60caafc9f5cf318ada7",
-    "https://bcr.bazel.build/modules/rules_python/1.4.1/MODULE.bazel": "8991ad45bdc25018301d6b7e1d3626afc3c8af8aaf4bc04f23d0b99c938b73a6",
     "https://bcr.bazel.build/modules/rules_python/1.7.0/MODULE.bazel": "d01f995ecd137abf30238ad9ce97f8fc3ac57289c8b24bd0bf53324d937a14f8",
     "https://bcr.bazel.build/modules/rules_python/1.7.0/source.json": "028a084b65dcf8f4dc4f82f8778dbe65df133f234b316828a82e060d81bdce32",
     "https://bcr.bazel.build/modules/rules_rust/0.68.1/MODULE.bazel": "8d3332ef4079673385eb81f8bd68b012decc04ac00c9d5a01a40eff90301732c",
     "https://bcr.bazel.build/modules/rules_rust/0.68.1/source.json": "3378e746f81b62457fdfd37391244fa8ff075ba85c05931ee4f3a20ac1efe963",
     "https://bcr.bazel.build/modules/rules_shell/0.2.0/MODULE.bazel": "fda8a652ab3c7d8fee214de05e7a9916d8b28082234e8d2c0094505c5268ed3c",
-    "https://bcr.bazel.build/modules/rules_shell/0.3.0/MODULE.bazel": "de4402cd12f4cc8fda2354fce179fdb068c0b9ca1ec2d2b17b3e21b24c1a937b",
     "https://bcr.bazel.build/modules/rules_shell/0.6.1/MODULE.bazel": "72e76b0eea4e81611ef5452aa82b3da34caca0c8b7b5c0c9584338aa93bae26b",
     "https://bcr.bazel.build/modules/rules_shell/0.6.1/source.json": "20ec05cd5e592055e214b2da8ccb283c7f2a421ea0dc2acbf1aa792e11c03d0c",
-    "https://bcr.bazel.build/modules/rules_swift/1.16.0/MODULE.bazel": "4a09f199545a60d09895e8281362b1ff3bb08bbde69c6fc87aff5b92fcc916ca",
-    "https://bcr.bazel.build/modules/rules_swift/2.1.1/MODULE.bazel": "494900a80f944fc7aa61500c2073d9729dff0b764f0e89b824eb746959bc1046",
-    "https://bcr.bazel.build/modules/rules_swift/2.1.1/source.json": "40fc69dfaac64deddbb75bd99cdac55f4427d9ca0afbe408576a65428427a186",
     "https://bcr.bazel.build/modules/stardoc/0.5.1/MODULE.bazel": "1a05d92974d0c122f5ccf09291442580317cdd859f07a8655f1db9a60374f9f8",
     "https://bcr.bazel.build/modules/stardoc/0.5.3/MODULE.bazel": "c7f6948dae6999bf0db32c1858ae345f112cacf98f174c7a8bb707e41b974f1c",
     "https://bcr.bazel.build/modules/stardoc/0.5.6/MODULE.bazel": "c43dabc564990eeab55e25ed61c07a1aadafe9ece96a4efabb3f8bf9063b71ef",
@@ -199,11 +151,8 @@
     "https://bcr.bazel.build/modules/stardoc/0.7.1/MODULE.bazel": "3548faea4ee5dda5580f9af150e79d0f6aea934fc60c1cc50f4efdd9420759e7",
     "https://bcr.bazel.build/modules/stardoc/0.7.2/MODULE.bazel": "fc152419aa2ea0f51c29583fab1e8c99ddefd5b3778421845606ee628629e0e5",
     "https://bcr.bazel.build/modules/stardoc/0.7.2/source.json": "58b029e5e901d6802967754adf0a9056747e8176f017cfe3607c0851f4d42216",
-    "https://bcr.bazel.build/modules/swift_argument_parser/1.3.1.1/MODULE.bazel": "5e463fbfba7b1701d957555ed45097d7f984211330106ccd1352c6e0af0dcf91",
-    "https://bcr.bazel.build/modules/swift_argument_parser/1.3.1.1/source.json": "32bd87e5f4d7acc57c5b2ff7c325ae3061d5e242c0c4c214ae87e0f1c13e54cb",
     "https://bcr.bazel.build/modules/upb/0.0.0-20220923-a547704/MODULE.bazel": "7298990c00040a0e2f121f6c32544bab27d4452f80d9ce51349b1a28f3005c43",
     "https://bcr.bazel.build/modules/zlib/1.2.11/MODULE.bazel": "07b389abc85fdbca459b69e2ec656ae5622873af3f845e1c9d80fe179f3effa0",
-    "https://bcr.bazel.build/modules/zlib/1.2.12/MODULE.bazel": "3b1a8834ada2a883674be8cbd36ede1b6ec481477ada359cd2d3ddc562340b27",
     "https://bcr.bazel.build/modules/zlib/1.3.1.bcr.5/MODULE.bazel": "eec517b5bbe5492629466e11dae908d043364302283de25581e3eb944326c4ca",
     "https://bcr.bazel.build/modules/zlib/1.3.1.bcr.5/source.json": "22bc55c47af97246cfc093d0acf683a7869377de362b5d1c552c2c2e16b7a806",
     "https://bcr.bazel.build/modules/zlib/1.3.1/MODULE.bazel": "751c9940dcfe869f5f7274e1295422a34623555916eb98c174c1e945594bf198"
@@ -551,170 +500,5 @@
       }
     }
   },
-  "facts": {
-    "@@rules_go+//go:extensions.bzl%go_sdk": {
-      "1.25.0": {
-        "aix_ppc64": [
-          "go1.25.0.aix-ppc64.tar.gz",
-          "e5234a7dac67bc86c528fe9752fc9d63557918627707a733ab4cac1a6faed2d4"
-        ],
-        "darwin_amd64": [
-          "go1.25.0.darwin-amd64.tar.gz",
-          "5bd60e823037062c2307c71e8111809865116714d6f6b410597cf5075dfd80ef"
-        ],
-        "darwin_arm64": [
-          "go1.25.0.darwin-arm64.tar.gz",
-          "544932844156d8172f7a28f77f2ac9c15a23046698b6243f633b0a0b00c0749c"
-        ],
-        "dragonfly_amd64": [
-          "go1.25.0.dragonfly-amd64.tar.gz",
-          "5ed3cf9a810a1483822538674f1336c06b51aa1b94d6d545a1a0319a48177120"
-        ],
-        "freebsd_386": [
-          "go1.25.0.freebsd-386.tar.gz",
-          "abea5d5c6697e6b5c224731f2158fe87c602996a2a233ac0c4730cd57bf8374e"
-        ],
-        "freebsd_amd64": [
-          "go1.25.0.freebsd-amd64.tar.gz",
-          "86e6fe0a29698d7601c4442052dac48bd58d532c51cccb8f1917df648138730b"
-        ],
-        "freebsd_arm": [
-          "go1.25.0.freebsd-arm.tar.gz",
-          "d90b78e41921f72f30e8bbc81d9dec2cff7ff384a33d8d8debb24053e4336bfe"
-        ],
-        "freebsd_arm64": [
-          "go1.25.0.freebsd-arm64.tar.gz",
-          "451d0da1affd886bfb291b7c63a6018527b269505db21ce6e14724f22ab0662e"
-        ],
-        "freebsd_riscv64": [
-          "go1.25.0.freebsd-riscv64.tar.gz",
-          "7b565f76bd8bda46549eeaaefe0e53b251e644c230577290c0f66b1ecdb3cdbe"
-        ],
-        "illumos_amd64": [
-          "go1.25.0.illumos-amd64.tar.gz",
-          "b1e1fdaab1ad25aa1c08d7a36c97d45d74b98b89c3f78c6d2145f77face54a2c"
-        ],
-        "linux_386": [
-          "go1.25.0.linux-386.tar.gz",
-          "8c602dd9d99bc9453b3995d20ce4baf382cc50855900a0ece5de9929df4a993a"
-        ],
-        "linux_amd64": [
-          "go1.25.0.linux-amd64.tar.gz",
-          "2852af0cb20a13139b3448992e69b868e50ed0f8a1e5940ee1de9e19a123b613"
-        ],
-        "linux_arm64": [
-          "go1.25.0.linux-arm64.tar.gz",
-          "05de75d6994a2783699815ee553bd5a9327d8b79991de36e38b66862782f54ae"
-        ],
-        "linux_armv6l": [
-          "go1.25.0.linux-armv6l.tar.gz",
-          "a5a8f8198fcf00e1e485b8ecef9ee020778bf32a408a4e8873371bfce458cd09"
-        ],
-        "linux_loong64": [
-          "go1.25.0.linux-loong64.tar.gz",
-          "cab86b1cf761b1cb3bac86a8877cfc92e7b036fc0d3084123d77013d61432afc"
-        ],
-        "linux_mips": [
-          "go1.25.0.linux-mips.tar.gz",
-          "d66b6fb74c3d91b9829dc95ec10ca1f047ef5e89332152f92e136cf0e2da5be1"
-        ],
-        "linux_mips64": [
-          "go1.25.0.linux-mips64.tar.gz",
-          "4082e4381a8661bc2a839ff94ba3daf4f6cde20f8fb771b5b3d4762dc84198a2"
-        ],
-        "linux_mips64le": [
-          "go1.25.0.linux-mips64le.tar.gz",
-          "70002c299ec7f7175ac2ef673b1b347eecfa54ae11f34416a6053c17f855afcc"
-        ],
-        "linux_mipsle": [
-          "go1.25.0.linux-mipsle.tar.gz",
-          "b00a3a39eff099f6df9f1c7355bf28e4589d0586f42d7d4a394efb763d145a73"
-        ],
-        "linux_ppc64": [
-          "go1.25.0.linux-ppc64.tar.gz",
-          "df166f33bd98160662560a72ff0b4ba731f969a80f088922bddcf566a88c1ec1"
-        ],
-        "linux_ppc64le": [
-          "go1.25.0.linux-ppc64le.tar.gz",
-          "0f18a89e7576cf2c5fa0b487a1635d9bcbf843df5f110e9982c64df52a983ad0"
-        ],
-        "linux_riscv64": [
-          "go1.25.0.linux-riscv64.tar.gz",
-          "c018ff74a2c48d55c8ca9b07c8e24163558ffec8bea08b326d6336905d956b67"
-        ],
-        "linux_s390x": [
-          "go1.25.0.linux-s390x.tar.gz",
-          "34e5a2e19f2292fbaf8783e3a241e6e49689276aef6510a8060ea5ef54eee408"
-        ],
-        "netbsd_386": [
-          "go1.25.0.netbsd-386.tar.gz",
-          "f8586cdb7aa855657609a5c5f6dbf523efa00c2bbd7c76d3936bec80aa6c0aba"
-        ],
-        "netbsd_amd64": [
-          "go1.25.0.netbsd-amd64.tar.gz",
-          "ae8dc1469385b86a157a423bb56304ba45730de8a897615874f57dd096db2c2a"
-        ],
-        "netbsd_arm": [
-          "go1.25.0.netbsd-arm.tar.gz",
-          "1ff7e4cc764425fc9dd6825eaee79d02b3c7cafffbb3691687c8d672ade76cb7"
-        ],
-        "netbsd_arm64": [
-          "go1.25.0.netbsd-arm64.tar.gz",
-          "e1b310739f26724216aa6d7d7208c4031f9ff54c9b5b9a796ddc8bebcb4a5f16"
-        ],
-        "openbsd_386": [
-          "go1.25.0.openbsd-386.tar.gz",
-          "4802a9b20e533da91adb84aab42e94aa56cfe3e5475d0550bed3385b182e69d8"
-        ],
-        "openbsd_amd64": [
-          "go1.25.0.openbsd-amd64.tar.gz",
-          "c016cd984bebe317b19a4f297c4f50def120dc9788490540c89f28e42f1dabe1"
-        ],
-        "openbsd_arm": [
-          "go1.25.0.openbsd-arm.tar.gz",
-          "a1e31d0bf22172ddde42edf5ec811ef81be43433df0948ece52fecb247ccfd8d"
-        ],
-        "openbsd_arm64": [
-          "go1.25.0.openbsd-arm64.tar.gz",
-          "343ea8edd8c218196e15a859c6072d0dd3246fbbb168481ab665eb4c4140458d"
-        ],
-        "openbsd_ppc64": [
-          "go1.25.0.openbsd-ppc64.tar.gz",
-          "694c14da1bcaeb5e3332d49bdc2b6d155067648f8fe1540c5de8f3cf8e157154"
-        ],
-        "openbsd_riscv64": [
-          "go1.25.0.openbsd-riscv64.tar.gz",
-          "aa510ad25cf54c06cd9c70b6d80ded69cb20188ac6e1735655eef29ff7e7885f"
-        ],
-        "plan9_386": [
-          "go1.25.0.plan9-386.tar.gz",
-          "46f8cef02086cf04bf186c5912776b56535178d4cb319cd19c9fdbdd29231986"
-        ],
-        "plan9_amd64": [
-          "go1.25.0.plan9-amd64.tar.gz",
-          "29b34391d84095e44608a228f63f2f88113a37b74a79781353ec043dfbcb427b"
-        ],
-        "plan9_arm": [
-          "go1.25.0.plan9-arm.tar.gz",
-          "0a047107d13ebe7943aaa6d54b1d7bbd2e45e68ce449b52915a818da715799c2"
-        ],
-        "solaris_amd64": [
-          "go1.25.0.solaris-amd64.tar.gz",
-          "9977f9e4351984364a3b2b78f8b88bfd1d339812356d5237678514594b7d3611"
-        ],
-        "windows_386": [
-          "go1.25.0.windows-386.zip",
-          "df9f39db82a803af0db639e3613a36681ab7a42866b1384b3f3a1045663961a7"
-        ],
-        "windows_amd64": [
-          "go1.25.0.windows-amd64.zip",
-          "89efb4f9b30812eee083cc1770fdd2913c14d301064f6454851428f9707d190b"
-        ],
-        "windows_arm64": [
-          "go1.25.0.windows-arm64.zip",
-          "27bab004c72b3d7bd05a69b6ec0fc54a309b4b78cc569dd963d8b3ec28bfdb8c"
-        ]
-      }
-    }
-  }
+  "facts": {}
 }


### PR DESCRIPTION
The problem was that fire spilled its dependencies into downstream consumers. This way, consumers are in their own control of what language support they want and what rules version they need