### PR TITLE
Add compile-time version checking for Rust parameters

### DIFF
--- a/fire/starlark/failure_test/parameter_version/test_version_upgraded_rust.rs
+++ b/fire/starlark/failure_test/parameter_version/test_version_upgraded_rust.rs
@@ -8,6 +8,6 @@ use test_params::*;
 fn main() {
     // Parameter is at version 2, but we request version 1
     // This should cause a deprecation warning at compile time
-    let value = test_value::<1>();
-    println!("Value: {}", value);
+    const VALUE: f64 = test_value::<1>();
+    println!("Value: {}", VALUE);
 }

--- a/fire/starlark/generators/rust.py
+++ b/fire/starlark/generators/rust.py
@@ -32,12 +32,13 @@ const fn ${param_name}_outdated() -> &'static [${struct_name}; ${size}] {
     &${const_name}_DATA
 }
 
-#[allow(unreachable_patterns)]
 pub const fn ${param_name}<const EXPECTED_VERSION: i32>() -> &'static [${struct_name}; ${size}] {
-    match EXPECTED_VERSION {
-        ${version_plus}.. => panic!("Parameter ${param_name} version ${version} is older than expected version"),
-        ..=${version_minus} => ${param_name}_outdated(),
-        _ => &${const_name}_DATA,
+    const { assert!(EXPECTED_VERSION <= ${version}, "Parameter ${param_name} version ${version} is older than expected version"); }
+
+    if EXPECTED_VERSION <= ${version_minus} {
+        ${param_name}_outdated()
+    } else {
+        &${const_name}_DATA
     }
 }
 
@@ -69,12 +70,13 @@ const fn ${param_name}_outdated() -> ${rust_type} {
     ${const_name}_VALUE
 }
 
-#[allow(unreachable_patterns)]
 pub const fn ${param_name}<const EXPECTED_VERSION: i32>() -> ${rust_type} {
-    match EXPECTED_VERSION {
-        ${version_plus}.. => panic!("Parameter ${param_name} version ${version} is older than expected version"),
-        ..=${version_minus} => ${param_name}_outdated(),
-        _ => ${const_name}_VALUE,
+    const { assert!(EXPECTED_VERSION <= ${version}, "Parameter ${param_name} version ${version} is older than expected version"); }
+
+    if EXPECTED_VERSION <= ${version_minus} {
+        ${param_name}_outdated()
+    } else {
+        ${const_name}_VALUE
     }
 }
 


### PR DESCRIPTION
Changed Rust parameter version checking from runtime to compile-time validation, making it consistent with C++ behavior.

**Changes:**
- Updated Rust generator to use `if` statements with `panic!` in const fn instead of match patterns
- Modified failure tests to use `const` for parameter values, forcing compile-time evaluation
- Version mismatch now causes compile-time error instead of runtime panic

**Behavior:**
- Version too new (requested > actual): Compile-time error
- Version too old (requested < actual): Compile-time deprecation warning

This ensures parameter version mismatches are caught at build time, improving safety for critical systems.

🤖 Generated with [Claude Code](https://claude.com/claude-code)