### PR TITLE
Remove wrapper script and copy contents in the tool itself

### DIFF
--- a/fire/starlark/parameters.bzl
+++ b/fire/starlark/parameters.bzl
@@ -9,29 +9,17 @@ def _validate_parameters_impl(ctx):
     input_file = ctx.file.src
     output = ctx.outputs.out
 
-    # Create a wrapper script that runs validation and copies file on success
-    wrapper_script = ctx.actions.declare_file(ctx.label.name + "_wrapper.sh")
-    ctx.actions.write(
-        output = wrapper_script,
-        content = """#!/bin/bash
-"{script}" "{input}" && cp "{input}" "{output}"
-""".format(
-            script = script.path,
-            input = input_file.path,
-            output = output.path,
-        ),
-        is_executable = True,
-    )
-
     # Get runfiles for the script
     script_runfiles = ctx.attr._script[DefaultInfo].default_runfiles.files.to_list()
+
+    args = [input_file.path, output.path]
 
     # Run validation
     ctx.actions.run(
         inputs = [input_file] + script_runfiles,
         outputs = [output],
-        executable = wrapper_script,
-        tools = [script],
+        arguments = args,
+        executable = script,
         mnemonic = "ValidateParameters",
         progress_message = "Validating parameters in %s" % input_file.basename,
     )

--- a/fire/starlark/validate_parameters.py
+++ b/fire/starlark/validate_parameters.py
@@ -118,6 +118,7 @@ def main():
         description="Validate parameter YAML files against JSON schema"
     )
     parser.add_argument("yaml_file", help="Path to the parameter YAML file")
+    parser.add_argument("output_file", help="Path to the validated YAML file")
 
     args = parser.parse_args()
 
@@ -128,6 +129,11 @@ def main():
         for error in errors:
             print(f"  ERROR: {error}")
         sys.exit(1)
+
+    # copy input to output
+    with open(args.yaml_file) as input_file:
+        with open(args.output_file, "w") as output_file:
+            output_file.write(input_file.read())
 
     sys.exit(0)
 


### PR DESCRIPTION
Removed the wrapper script - it was too much bloat anyways.
We will likely move to aspects for validations in the future - `parameter_library` does not create any output of significance.