### PR TITLE
Ensure paths are relative to repo root

### DIFF
--- a/fire/starlark/failure_test/dependency_failures/missing_param_dep.md
+++ b/fire/starlark/failure_test/dependency_failures/missing_param_dep.md
@@ -4,6 +4,6 @@
 
 SIL: ASIL-A | Sec: Public | Version: 1
 
-This requirement references [@test_parameter](fire/starlark/failure_test/dependency_failures/test_params.bzl#test_parameter) but the dependency is NOT declared in BUILD.
+This requirement references [@test_parameter](/fire/starlark/failure_test/dependency_failures/test_params.bzl#test_parameter) but the dependency is NOT declared in BUILD.
 
 This should FAIL validation.

--- a/fire/starlark/failure_test/dependency_failures/missing_req_dep.md
+++ b/fire/starlark/failure_test/dependency_failures/missing_req_dep.md
@@ -4,6 +4,6 @@
 
 SIL: ASIL-A | Sec: Public | Version: 1
 
-This requirement references [REQ-BASE-001](fire/starlark/failure_test/dependency_failures/base_requirement.md?version=1#REQ-BASE-001) but the dependency is NOT declared in BUILD.
+This requirement references [REQ-BASE-001](/fire/starlark/failure_test/dependency_failures/base_requirement.md?version=1#REQ-BASE-001) but the dependency is NOT declared in BUILD.
 
 This should FAIL validation.

--- a/fire/starlark/failure_test/relative_paths/BUILD.bazel
+++ b/fire/starlark/failure_test/relative_paths/BUILD.bazel
@@ -1,0 +1,54 @@
+"""Tests for non-repository-relative paths in references.
+
+These tests verify that validation fails when references use non-repository-relative
+paths (paths that don't start with /).
+They are tagged as 'manual' and 'failure_test' so they don't run in normal test runs.
+"""
+
+load("//fire/starlark:parameters.bzl", "parameter_library")
+load("//fire/starlark:requirements.bzl", "requirement_library")
+
+# Base requirement (valid)
+requirement_library(
+    name = "base_requirement",
+    srcs = ["base_requirement.md"],
+)
+
+# Test parameter library
+parameter_library(
+    name = "test_params",
+    src = "test_params.yaml",
+)
+
+# Non-absolute parent path - should FAIL
+requirement_library(
+    name = "test_non_absolute_parent",
+    srcs = ["non_absolute_parent.md"],
+    tags = [
+        "failure_test",  # Expected to fail
+        "manual",  # Don't run in normal test runs
+    ],
+    deps = [":base_requirement"],
+)
+
+# Non-absolute requirement reference - should FAIL
+requirement_library(
+    name = "test_non_absolute_reference",
+    srcs = ["non_absolute_reference.md"],
+    tags = [
+        "failure_test",  # Expected to fail
+        "manual",  # Don't run in normal test runs
+    ],
+    deps = [":base_requirement"],
+)
+
+# Non-absolute parameter reference - should FAIL
+requirement_library(
+    name = "test_non_absolute_param",
+    srcs = ["non_absolute_param.md"],
+    tags = [
+        "failure_test",  # Expected to fail
+        "manual",  # Don't run in normal test runs
+    ],
+    deps = [":test_params"],
+)

--- a/fire/starlark/failure_test/relative_paths/base_requirement.md
+++ b/fire/starlark/failure_test/relative_paths/base_requirement.md
@@ -1,0 +1,7 @@
+# Base Requirement
+
+## REQ-RELATIVE-BASE
+
+SIL: ASIL-A | Sec: Public | Version: 1
+
+This is a base requirement that will be referenced with a non-repository-relative path.

--- a/fire/starlark/failure_test/relative_paths/non_absolute_param.md
+++ b/fire/starlark/failure_test/relative_paths/non_absolute_param.md
@@ -1,0 +1,9 @@
+# Test Non-Absolute Parameter Path
+
+## REQ-NON-ABSOLUTE-PARAM
+
+SIL: ASIL-A | Sec: Public | Version: 1
+
+This requirement references [@test_param](fire/starlark/failure_test/relative_paths/test_params.yaml?version=1#test_param) with a non-repository-relative path (missing leading /).
+
+This should FAIL validation.

--- a/fire/starlark/failure_test/relative_paths/non_absolute_parent.md
+++ b/fire/starlark/failure_test/relative_paths/non_absolute_parent.md
@@ -1,0 +1,9 @@
+# Test Non-Absolute Parent Path
+
+## REQ-NON-ABSOLUTE-PARENT
+
+SIL: ASIL-A | Sec: Public | Version: 1 | Parent: [REQ-RELATIVE-BASE](fire/starlark/failure_test/relative_paths/base_requirement.md?version=1#REQ-RELATIVE-BASE)
+
+This requirement has a parent reference with a non-repository-relative path (missing leading /).
+
+This should FAIL validation.

--- a/fire/starlark/failure_test/relative_paths/non_absolute_reference.md
+++ b/fire/starlark/failure_test/relative_paths/non_absolute_reference.md
@@ -1,0 +1,9 @@
+# Test Non-Absolute Reference Path
+
+## REQ-NON-ABSOLUTE-REF
+
+SIL: ASIL-A | Sec: Public | Version: 1
+
+This requirement references [REQ-RELATIVE-BASE](fire/starlark/failure_test/relative_paths/base_requirement.md?version=1#REQ-RELATIVE-BASE) with a non-repository-relative path (missing leading /).
+
+This should FAIL validation.

--- a/fire/starlark/failure_test/relative_paths/test_params.yaml
+++ b/fire/starlark/failure_test/relative_paths/test_params.yaml
@@ -1,0 +1,6 @@
+parameters:
+  test_param:
+    type: f64
+    value: 42.0
+    description: Test parameter
+    version: 1

--- a/fire/starlark/failure_test/run_failure_tests.sh
+++ b/fire/starlark/failure_test/run_failure_tests.sh
@@ -136,6 +136,10 @@ for target in $FAILURE_TARGETS; do
         elif echo "$output" | grep -qE "does not contain '(sil|sec|version)' field|has no metadata"; then
             echo "✅ PASS: Build failed with missing required field error"
             SUCCESSES=$((SUCCESSES + 1))
+        # Check for non-repository-relative paths (should FAIL)
+        elif echo "$output" | grep -q "must be repository-relative"; then
+            echo "✅ PASS: Build failed with non-repository-relative path error"
+            SUCCESSES=$((SUCCESSES + 1))
         # Unexpected: build succeeded or failed with wrong error
         else
             echo "❌ FAIL: Build should have failed or produced expected warning"

--- a/fire/starlark/failure_test/version_mismatch/test_param_version_mismatch.md
+++ b/fire/starlark/failure_test/version_mismatch/test_param_version_mismatch.md
@@ -4,6 +4,6 @@
 
 SIL: ASIL-A | Sec: Public | Version: 1
 
-This requirement references [@test_param](fire/starlark/failure_test/version_mismatch/test_params_v2.yaml?version=1#test_param) with version=1, but test_params_v2.yaml is at version=2.
+This requirement references [@test_param](/fire/starlark/failure_test/version_mismatch/test_params_v2.yaml?version=1#test_param) with version=1, but test_params_v2.yaml is at version=2.
 
 This should generate a PARAMETER VERSION MISMATCH warning.

--- a/fire/starlark/failure_test/version_mismatch/test_param_version_mismatch_error.md
+++ b/fire/starlark/failure_test/version_mismatch/test_param_version_mismatch_error.md
@@ -5,7 +5,7 @@
 SIL: ASIL-A | Sec: Public | Version: 1
 
 This requirement references
-[@test_param](fire/starlark/failure_test/version_mismatch/test_params_v2.yaml?version=3#test_param)
+[@test_param](/fire/starlark/failure_test/version_mismatch/test_params_v2.yaml?version=3#test_param)
 with version=3, but test_params_v2.yaml is at version=2 - this needs to create
 an error.
 

--- a/fire/starlark/failure_test/version_mismatch/test_version_mismatch.md
+++ b/fire/starlark/failure_test/version_mismatch/test_version_mismatch.md
@@ -4,6 +4,6 @@
 
 SIL: ASIL-A | Sec: Public | Version: 1
 
-This requirement references [REQ-VERSION-BASE](fire/starlark/failure_test/version_mismatch/base_requirement_v2.md?version=1#REQ-VERSION-BASE) with version=1, but base_requirement_v2.md is at version=2.
+This requirement references [REQ-VERSION-BASE](/fire/starlark/failure_test/version_mismatch/base_requirement_v2.md?version=1#REQ-VERSION-BASE) with version=1, but base_requirement_v2.md is at version=2.
 
 This should generate a VERSION MISMATCH warning.

--- a/fire/starlark/validate_cross_references.py
+++ b/fire/starlark/validate_cross_references.py
@@ -172,6 +172,13 @@ def validate_parameter_reference(
         file_path = param_path
         anchor = param_name
 
+    # Check that path is repository-relative (starts with /)
+    if not file_path.startswith("/"):
+        return (
+            False,
+            f"Parameter reference path must be repository-relative (start with /): '{param_path}'",
+        )
+
     # Strip leading slash for repository-relative paths (e.g., /examples/foo.yaml -> examples/foo.yaml)
     # Markdown uses /path for repository-relative, but os.path.join treats it as absolute
     if file_path.startswith("/"):
@@ -247,6 +254,19 @@ def validate_requirement_reference(
     req_id, req_path, workspace_root, ref_version=None, source_file=None
 ):
     """Validate that a requirement reference exists and check version if specified."""
+    # Check that path is repository-relative (starts with /)
+    # Extract the path part before checking (handle fragments and query params)
+    path_to_check = req_path.split("#")[0] if "#" in req_path else req_path
+    path_to_check = (
+        path_to_check.split("?")[0] if "?" in path_to_check else path_to_check
+    )
+
+    if not path_to_check.startswith("/"):
+        return (
+            False,
+            f"Requirement reference path must be repository-relative (start with /): '{req_path}'",
+        )
+
     # Strip leading slash for repository-relative paths (e.g., /examples/foo.md -> examples/foo.md)
     # Markdown uses /path for repository-relative, but os.path.join treats it as absolute
     if req_path.startswith("/"):
@@ -395,6 +415,28 @@ def validate_requirement_file(file_path, workspace_root, allowed_deps=None):
             errors.append(
                 f"{file_path}: Requirement '{req_id}' does not contain 'version' field"
             )
+
+        # Check parent field path is repository-relative (if parent exists)
+        if "parent" in frontmatter:
+            parent_value = frontmatter["parent"]
+            # Parent is in format [REQ-ID](/path/to/file.md?version=N#REQ-ID)
+            parent_match = re.match(r"\[([^\]]+)\]\(([^\)]+)\)", parent_value)
+            if parent_match:
+                parent_path = parent_match.group(2)
+                # Extract the path part (before # and ?)
+                path_to_check = (
+                    parent_path.split("#")[0] if "#" in parent_path else parent_path
+                )
+                path_to_check = (
+                    path_to_check.split("?")[0]
+                    if "?" in path_to_check
+                    else path_to_check
+                )
+
+                if not path_to_check.startswith("/"):
+                    errors.append(
+                        f"{file_path}: Requirement '{req_id}' parent path must be repository-relative (start with /): '{parent_path}'"
+                    )
 
     # Extract references from markdown body
     param_refs, req_refs, test_refs = extract_markdown_references(content)

--- a/integration_test/requirements/REQ-INT-001.md
+++ b/integration_test/requirements/REQ-INT-001.md
@@ -6,7 +6,7 @@ SIL: ASIL-B | Sec: Public | Version: 1
 
 **Maximum Speed Constraint**
 
-The system SHALL NOT exceed the maximum speed defined by [@max_speed](test_params.yaml?version=1#max_speed).
+The system SHALL NOT exceed the maximum speed defined by [@max_speed](/test_params.yaml?version=1#max_speed).
 
 This requirement ensures safe operation within design limits.
 

--- a/integration_test/requirements/REQ-INT-002.md
+++ b/integration_test/requirements/REQ-INT-002.md
@@ -6,11 +6,11 @@ SIL: ASIL-C | Sec: Public | Version: 1
 
 **Minimum Braking Distance**
 
-The system SHALL maintain a minimum braking distance of [@min_braking_distance](test_params.yaml?version=1#min_braking_distance) when operating at maximum speed [REQ-INT-001](requirements/REQ-INT-001.md?version=1#REQ-INT-001).
+The system SHALL maintain a minimum braking distance of [@min_braking_distance](/test_params.yaml?version=1#min_braking_distance) when operating at maximum speed [REQ-INT-001](/requirements/REQ-INT-001.md?version=1#REQ-INT-001).
 
 ### Rationale
 
-This requirement is derived from [REQ-INT-001](requirements/REQ-INT-001.md?version=1#REQ-INT-001) to ensure safe stopping distance.
+This requirement is derived from [REQ-INT-001](/requirements/REQ-INT-001.md?version=1#REQ-INT-001) to ensure safe stopping distance.
 
 ### Verification
 

--- a/integration_test/requirements/REQ-INT-003.md
+++ b/integration_test/requirements/REQ-INT-003.md
@@ -6,7 +6,7 @@ SIL: ASIL-D | Sec: Public | Version: 1
 
 **System Update Rate**
 
-The system SHALL process sensor data and update control outputs at [@update_rate](test_params.yaml?version=1#update_rate) Hz.
+The system SHALL process sensor data and update control outputs at [@update_rate](/test_params.yaml?version=1#update_rate) Hz.
 
 ### Verification
 


### PR DESCRIPTION
This ensures proper parsing on GitHub as well and aligns with Bazel's principles.