### PR TITLE
Support multiple h1 in reqs

### DIFF
--- a/examples/brake_actuator/doc/brake_actuator.swreq.md
+++ b/examples/brake_actuator/doc/brake_actuator.swreq.md
@@ -16,6 +16,8 @@ The brake actuator component shall subscribe to brake force commands at a rate o
 
 # Software Requirements: Second H1 (optional, but doesn't fail)
 
+Some more text, which should not fail the FIRE checker.
+
 ## REQ_BA_CONVERT_FORCE
 
 SIL: ASIL-D | Sec: false | Version: 1 | Parent: [REQ-BRK-001](/examples/requirements/braking_requirements.sysreq.md?version=2#REQ-BRK-001)


### PR DESCRIPTION
We want to be able to add multiple H1s in one requirements file, in particular after the requirements separator. This can be used to have some reader targeted additional information, that is not parsed and enforced.

Note that markdown linters will complain about this. You will likely need to silence them actively to make this work in your case.