### PR TITLE
Fix presubmit

### DIFF
--- a/.bcr/presubmit.yml
+++ b/.bcr/presubmit.yml
@@ -5,9 +5,9 @@ bcr_test_module:
     platform: ["debian11", "macos", "ubuntu2204"]
     bazel: [7.x, 8.x, 9.x]
   tasks:
-    run_tests:
+    run_test_module:
       name: "Run test module"
       platform: ${{ platform }}
       bazel: ${{ bazel }}
-      shell_commands:
-        - ./run.sh
+      build_targets:
+        - //...


### PR DESCRIPTION
Adding Bazel 9 and changing testing back to `bazel_targets` from `shell_commands`. It seems the latter is no longer supported. At least no tests were performed and the Bazel Central Registry Gemini Review claimed a style deviation (without getting specific):

> This pull request adds version 0.2.2 for the fire module. The changes are mostly correct and follow the Bazel Central Registry policies by being add-only and including all required files. However, there is one issue in the presubmit.yml file that deviates from the repository's style guide, though an acceptable workaround exists for specific scenarios. This issue should be addressed.