### PR TITLE
Consolidate regex patterns for markdown links (Fixes #144)

### DIFF
--- a/fire/starlark/BUILD.bazel
+++ b/fire/starlark/BUILD.bazel
@@ -136,7 +136,10 @@ py_library(
         "requirement_models.py",
     ],
     visibility = ["//visibility:public"],
-    deps = ["@pip//pydantic"],
+    deps = [
+        ":markdown_common",
+        "@pip//pydantic",
+    ],
 )
 
 # Python library for cross-reference validation

--- a/fire/starlark/requirement_models.py
+++ b/fire/starlark/requirement_models.py
@@ -6,6 +6,8 @@ from typing import Literal, Optional, Union, Final
 
 from pydantic import BaseModel, Field, field_validator
 
+from fire.starlark import markdown_common
+
 _TODO_PATTERN: Final = re.compile(r"^TODO\([A-Z]+-[0-9]+\)$")
 
 _VALID_SIL_VALUES: Final = {
@@ -95,7 +97,7 @@ class RequirementMetadata(BaseModel):
             return v
 
         # Check markdown link format: [TEXT](URL)
-        match = re.match(r"\[([^\]]+)\]\(([^\)]+)\)", v)
+        match = re.match(markdown_common.MARKDOWN_LINK_PATTERN, v)
         if not match:
             raise ValueError(
                 "parent must be a markdown link: [REQ-ID](/path.md?version=N#REQ-ID)"


### PR DESCRIPTION
## Summary
- Replaced the last remaining inline regex pattern in `requirement_models.py` with `markdown_common.MARKDOWN_LINK_PATTERN`
- Added `markdown_common` dependency to the `requirement_models` library in BUILD.bazel
- All markdown link regex patterns are now centralized in `markdown_common.py` (completed as part of #143)

## Test coverage
All existing tests pass including requirement metadata validation tests. No new tests needed as this maintains identical behavior while using shared constants.

Closes #144

🤖 Generated with [Claude Code](https://claude.com/claude-code)