### PR TITLE
Add resolve_reference_links() for link resolution

### DIFF
--- a/fire/starlark/markdown_common.py
+++ b/fire/starlark/markdown_common.py
@@ -124,3 +124,56 @@ def extract_reference_style_links(text: str) -> list[tuple[str, str]]:
         links.append((match.group(1), match.group(1)))
 
     return links
+
+
+def resolve_reference_links(text: str) -> str:
+    """Resolve reference-style links to inline-style links.
+
+    Finds reference-style link definitions and replaces all reference-style
+    links with their corresponding inline links.
+
+    Args:
+        text: Markdown text with reference-style links and definitions
+
+    Returns:
+        Text with reference-style links converted to inline links
+
+    Raises:
+        ValueError: If a reference label is used but not defined
+
+    Example:
+        >>> text = "[See this][1]\\n[1]: http://example.com"
+        >>> resolve_reference_links(text)
+        '[See this](http://example.com)\\n[1]: http://example.com'
+    """
+    definitions = extract_link_definitions(text)
+
+    # Process explicit references: [text][ref]
+    def replace_explicit(match):
+        link_text = match.group(1)
+        ref_label = match.group(2)
+        if ref_label not in definitions:
+            raise ValueError(f"Undefined reference: [{ref_label}]")
+        return f"[{link_text}]({definitions[ref_label]})"
+
+    text = re.sub(r"\[([^\]]+)\]\[([^\]]+)\]", replace_explicit, text)
+
+    # Process implicit references: [text][]
+    def replace_implicit(match):
+        link_text = match.group(1)
+        if link_text not in definitions:
+            raise ValueError(f"Undefined reference: [{link_text}]")
+        return f"[{link_text}]({definitions[link_text]})"
+
+    text = re.sub(r"\[([^\]]+)\]\[\]", replace_implicit, text)
+
+    # Process shortcut references: [text] (not followed by (, [, or :)
+    def replace_shortcut(match):
+        link_text = match.group(1)
+        if link_text not in definitions:
+            raise ValueError(f"Undefined reference: [{link_text}]")
+        return f"[{link_text}]({definitions[link_text]})"
+
+    text = re.sub(r"\[([^\]]+)\](?!\(|\[|:)", replace_shortcut, text)
+
+    return text

--- a/fire/starlark/markdown_common_test.py
+++ b/fire/starlark/markdown_common_test.py
@@ -225,5 +225,56 @@ class TestExtractReferenceStyleLinks:
         assert not any(link_text == "Inline" for link_text, _ in links)
 
 
+class TestResolveReferenceLinks:
+    """Tests for resolve_reference_links function."""
+
+    def test_resolve_explicit_reference(self):
+        text = "[See this][1]\n[1]: http://example.com"
+        result = markdown_common.resolve_reference_links(text)
+        assert "[See this](http://example.com)" in result
+
+    def test_resolve_implicit_reference(self):
+        text = "[REQ-001][]\n[REQ-001]: /path/req.md"
+        result = markdown_common.resolve_reference_links(text)
+        assert "[REQ-001](/path/req.md)" in result
+
+    def test_resolve_shortcut_reference(self):
+        text = "[REQ-001]\n[REQ-001]: /path/req.md"
+        result = markdown_common.resolve_reference_links(text)
+        assert "[REQ-001](/path/req.md)" in result
+
+    def test_resolve_multiple_references(self):
+        text = "[First][1] and [Second][2]\n[1]: url1.md\n[2]: url2.md"
+        result = markdown_common.resolve_reference_links(text)
+        assert "[First](url1.md)" in result
+        assert "[Second](url2.md)" in result
+
+    def test_preserves_inline_links(self):
+        text = "[Inline](url.md) and [Ref][1]\n[1]: ref.md"
+        result = markdown_common.resolve_reference_links(text)
+        assert "[Inline](url.md)" in result
+        assert "[Ref](ref.md)" in result
+
+    def test_preserves_link_definitions(self):
+        text = "[Ref][1]\n[1]: http://example.com"
+        result = markdown_common.resolve_reference_links(text)
+        assert "[1]: http://example.com" in result
+
+    def test_undefined_reference_raises_error(self):
+        text = "[Text][missing]"
+        with pytest.raises(ValueError, match="Undefined reference: \\[missing\\]"):
+            markdown_common.resolve_reference_links(text)
+
+    def test_no_references_returns_unchanged(self):
+        text = "Just plain text with [inline](url.md) links"
+        result = markdown_common.resolve_reference_links(text)
+        assert result == text
+
+    def test_complex_url_with_query_and_anchor(self):
+        text = "[Link][ref]\n[ref]: /path/file.md?version=2#section"
+        result = markdown_common.resolve_reference_links(text)
+        assert "[Link](/path/file.md?version=2#section)" in result
+
+
 if __name__ == "__main__":
     sys.exit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
### Summary

Add `resolve_reference_links()` function to convert reference-style links to inline-style links. This is the core resolution logic that ties together the link definition and link detection functions from previous PRs.

### Implementation Summary

Added new function `resolve_reference_links(text: str) -> str` to `fire/starlark/markdown_common.py` that:
- Extracts all link definitions using `extract_link_definitions()`
- Processes reference-style links in order of specificity:
  1. Explicit references `[text][ref]` → `[text](url)`
  2. Implicit references `[text][]` → `[text](url)`
  3. Shortcut references `[text]` → `[text](url)`
- Uses `re.sub()` with callback functions for clean replacement
- Raises `ValueError` with clear message for undefined references
- Preserves inline links and link definitions in the output

The function is not yet integrated into business logic - it will be activated in a future PR when we integrate with cross-reference validation.

### Testing

Added comprehensive test class `TestResolveReferenceLinks` with 9 test cases:
- Resolution of all three reference formats
- Multiple references in same text
- Preservation of inline links
- Preservation of link definitions
- Undefined reference error handling
- No-op when no references present
- Complex URLs with query parameters and anchors

All tests pass:
- `bazel test //fire/starlark:markdown_common_test` ✓
- All existing tests still pass ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)