### PR TITLE
Add support for unit "1" in normalize_unit_suffix

### DIFF
--- a/fire/starlark/BUILD.bazel
+++ b/fire/starlark/BUILD.bazel
@@ -263,3 +263,32 @@ py_test(
         "@pip//pytest",
     ],
 )
+
+py_library(
+    name = "generate_code_lib",
+    srcs = [
+        "generate_code.py",
+        "generators/cpp.py",
+        "generators/generator_common.py",
+        "generators/go.py",
+        "generators/java.py",
+        "generators/python.py",
+        "generators/rust.py",
+        "generators/template_loader.py",
+    ],
+    data = glob(["templates/*.j2"]),
+    deps = [
+        "@pip//jinja2",
+        "@pip//pyyaml",
+    ],
+)
+
+py_test(
+    name = "generate_code_test",
+    size = "small",
+    srcs = ["generate_code_test.py"],
+    deps = [
+        ":generate_code_lib",
+        "@pip//pytest",
+    ],
+)

--- a/fire/starlark/generate_code.py
+++ b/fire/starlark/generate_code.py
@@ -36,10 +36,10 @@ def normalize_unit_suffix(unit: str) -> str:
     """Convert unit string to valid identifier suffix.
 
     Args:
-        unit: Unit string (e.g., "m/s", "m/s^2", "m^3")
+        unit: Unit string (e.g., "m/s", "m/s^2", "m^3", "1")
 
     Returns:
-        Normalized suffix (e.g., "mps", "mps2", "m3")
+        Normalized suffix (e.g., "mps", "mps2", "m3", "")
 
     Examples:
         "m/s"    -> "mps"    (meters per second)
@@ -48,9 +48,10 @@ def normalize_unit_suffix(unit: str) -> str:
         "m^3"    -> "m3"     (cubic meters)
         "kg/m^3" -> "kgpm3"  (kilograms per cubic meter)
         "m"      -> "m"      (meters)
+        "1"      -> ""       (dimensionless quantity)
         "dimensionless" -> ""
     """
-    if not unit or unit.lower() == "dimensionless":
+    if not unit or unit == "1" or unit.lower() == "dimensionless":
         return ""
 
     suffix = unit.lower()

--- a/fire/starlark/generate_code_test.py
+++ b/fire/starlark/generate_code_test.py
@@ -1,0 +1,59 @@
+"""Tests for fire/starlark/generate_code.py"""
+
+import sys
+
+import pytest
+
+from fire.starlark.generate_code import normalize_unit_suffix
+
+
+class TestNormalizeUnitSuffix:
+    """Tests for normalize_unit_suffix function."""
+
+    def test_empty_string_returns_empty(self):
+        """Empty unit string returns empty suffix."""
+        assert normalize_unit_suffix("") == ""
+
+    def test_dimensionless_returns_empty(self):
+        """'dimensionless' unit returns empty suffix."""
+        assert normalize_unit_suffix("dimensionless") == ""
+
+    def test_unit_one_returns_empty(self):
+        """Unit '1' (dimensionless quantity) returns empty suffix."""
+        assert normalize_unit_suffix("1") == ""
+
+    def test_simple_unit(self):
+        """Simple unit like 'm' returns as-is."""
+        assert normalize_unit_suffix("m") == "m"
+
+    def test_meters_per_second(self):
+        """'m/s' converts to 'mps'."""
+        assert normalize_unit_suffix("m/s") == "mps"
+
+    def test_meters_per_second_squared(self):
+        """'m/s^2' converts to 'mps2'."""
+        assert normalize_unit_suffix("m/s^2") == "mps2"
+
+    def test_radians_per_second(self):
+        """'rad/s' converts to 'radps'."""
+        assert normalize_unit_suffix("rad/s") == "radps"
+
+    def test_cubic_meters(self):
+        """'m^3' converts to 'm3'."""
+        assert normalize_unit_suffix("m^3") == "m3"
+
+    def test_kg_per_cubic_meter(self):
+        """'kg/m^3' converts to 'kgpm3'."""
+        assert normalize_unit_suffix("kg/m^3") == "kgpm3"
+
+    def test_uppercase_dimensionless(self):
+        """'DIMENSIONLESS' (uppercase) returns empty suffix."""
+        assert normalize_unit_suffix("DIMENSIONLESS") == ""
+
+    def test_mixed_case_dimensionless(self):
+        """'Dimensionless' (mixed case) returns empty suffix."""
+        assert normalize_unit_suffix("Dimensionless") == ""
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
## Summary

Add support for unit `"1"` (dimensionless quantity) in `normalize_unit_suffix()`. This prepares for making the `unit` field mandatory in parameter YAML files.

## Implementation Summary

**Changes to `normalize_unit_suffix()`:**
- Treat `"1"` the same as `"dimensionless"` → return empty suffix
- Updated docstring to include `"1"` example
- Maintains backward compatibility

**New Test Suite:**
- Created `generate_code_test.py` with 11 comprehensive test cases
- Tests for unit "1", "dimensionless" (various cases), physical units, compound units
- Added Bazel build targets for the new test

## Why Unit "1"?

In physics/engineering convention, dimensionless quantities have unit = 1:
- Examples: count (4 items), ratio (0.5), boolean (true/false)
- Makes it explicit that a parameter is dimensionless vs. missing unit information
- Prepares for PR #2 which will make `unit` field mandatory

## Testing

```bash
bazel test //fire/starlark:generate_code_test
```

All 11 tests pass ✅

## Next Steps

This is **PR 1 of 3** for mandatory units:
1. ✅ **This PR**: Support unit "1" in code generation
2. Make unit field mandatory + migrate YAML files
3. Update templates to always show unit

🤖 Generated with [Claude Code](https://claude.com/claude-code)