### PR TITLE
Remove C++ function accessor for table parameters (Fixes #175)

### DIFF
--- a/examples/vehicle_params_custom_ns_test.cc
+++ b/examples/vehicle_params_custom_ns_test.cc
@@ -31,18 +31,17 @@ int main() {
             << std::endl;
 
   // Test table parameter with std::array
-  const auto& table = braking_distance_table();
-  assert(table.size() == 6);
-  std::cout << "✓ braking_distance_table().size() = " << table.size()
+  assert(BRAKING_DISTANCE_TABLE.size() == 6);
+  std::cout << "✓ BRAKING_DISTANCE_TABLE.size() = " << BRAKING_DISTANCE_TABLE.size()
             << std::endl;
 
   // Test first row of table
-  assert(table[0].velocity_mps == 10.0);
-  assert(table[0].friction_coefficient == 0.7);
-  assert(table[0].braking_distance_m == 7.1);
-  std::cout << "✓ braking_distance_table()[0] = {" << table[0].velocity_mps << ", "
-            << table[0].friction_coefficient << ", "
-            << table[0].braking_distance_m << "}" << std::endl;
+  assert(BRAKING_DISTANCE_TABLE[0].velocity_mps == 10.0);
+  assert(BRAKING_DISTANCE_TABLE[0].friction_coefficient == 0.7);
+  assert(BRAKING_DISTANCE_TABLE[0].braking_distance_m == 7.1);
+  std::cout << "✓ BRAKING_DISTANCE_TABLE[0] = {" << BRAKING_DISTANCE_TABLE[0].velocity_mps << ", "
+            << BRAKING_DISTANCE_TABLE[0].friction_coefficient << ", "
+            << BRAKING_DISTANCE_TABLE[0].braking_distance_m << "}" << std::endl;
 
   std::cout << "\nAll custom namespace tests passed!" << std::endl;
   return 0;

--- a/examples/vehicle_params_test.cc
+++ b/examples/vehicle_params_test.cc
@@ -30,30 +30,29 @@ int main() {
             << std::endl;
 
   // Test table parameter
-  const auto& table = braking_distance_table();
-  assert(table.size() == 6);
-  std::cout << "✓ braking_distance_table().size() = " << table.size()
+  assert(BRAKING_DISTANCE_TABLE.size() == 6);
+  std::cout << "✓ BRAKING_DISTANCE_TABLE.size() = " << BRAKING_DISTANCE_TABLE.size()
             << std::endl;
 
   // Test first row of table
-  assert(table[0].velocity_mps == 10.0);
-  assert(table[0].friction_coefficient == 0.7);
-  assert(table[0].braking_distance_m == 7.1);
-  std::cout << "✓ braking_distance_table()[0] = {" << table[0].velocity_mps << ", "
-            << table[0].friction_coefficient << ", "
-            << table[0].braking_distance_m << "}" << std::endl;
+  assert(BRAKING_DISTANCE_TABLE[0].velocity_mps == 10.0);
+  assert(BRAKING_DISTANCE_TABLE[0].friction_coefficient == 0.7);
+  assert(BRAKING_DISTANCE_TABLE[0].braking_distance_m == 7.1);
+  std::cout << "✓ BRAKING_DISTANCE_TABLE[0] = {" << BRAKING_DISTANCE_TABLE[0].velocity_mps << ", "
+            << BRAKING_DISTANCE_TABLE[0].friction_coefficient << ", "
+            << BRAKING_DISTANCE_TABLE[0].braking_distance_m << "}" << std::endl;
 
   // Test last row of table
-  assert(table[5].velocity_mps == 30.0);
-  assert(table[5].friction_coefficient == 0.3);
-  assert(table[5].braking_distance_m == 150.0);
-  std::cout << "✓ braking_distance_table()[5] = {" << table[5].velocity_mps << ", "
-            << table[5].friction_coefficient << ", "
-            << table[5].braking_distance_m << "}" << std::endl;
+  assert(BRAKING_DISTANCE_TABLE[5].velocity_mps == 30.0);
+  assert(BRAKING_DISTANCE_TABLE[5].friction_coefficient == 0.3);
+  assert(BRAKING_DISTANCE_TABLE[5].braking_distance_m == 150.0);
+  std::cout << "✓ BRAKING_DISTANCE_TABLE[5] = {" << BRAKING_DISTANCE_TABLE[5].velocity_mps << ", "
+            << BRAKING_DISTANCE_TABLE[5].friction_coefficient << ", "
+            << BRAKING_DISTANCE_TABLE[5].braking_distance_m << "}" << std::endl;
 
   // Test iteration over table with modern range-based for loop
   double total_distance = 0.0;
-  for (const auto& row : table) {
+  for (const auto& row : BRAKING_DISTANCE_TABLE) {
     total_distance += row.braking_distance_m;
   }
   std::cout << "✓ Total braking distance across all entries = "

--- a/fire/starlark/templates/cpp.hpp.j2
+++ b/fire/starlark/templates/cpp.hpp.j2
@@ -39,10 +39,6 @@ constexpr std::array<{{ struct_name }}, {{ size }}> {{ const_name }} = {{ "{" }}
 {% endfor %}
 }};
 
-constexpr const std::array<{{ struct_name }}, {{ size }}>& {{ item.base_name }}() {
-    return {{ const_name }};
-}
-
 {% else %}
 {% set cpp_type = item.type | cpp_type %}
 {% if item.unit_suffix %}


### PR DESCRIPTION
## Summary

Removes the C++ function accessor for table parameters in favor of direct constant access. Tables are now accessed via the constant name (e.g., `BRAKING_DISTANCE_TABLE`) instead of through a function (e.g., `braking_distance_table()`).

## Changes

**Template:**
- Removed function accessor from `cpp.hpp.j2`

**Tests:**
- Updated `vehicle_params_test.cc` to use `BRAKING_DISTANCE_TABLE`
- Updated `vehicle_params_custom_ns_test.cc` to use `BRAKING_DISTANCE_TABLE`

## Before

```cpp
const auto& table = braking_distance_table();
assert(table[0].velocity_mps == 10.0);
```

## After

```cpp
assert(BRAKING_DISTANCE_TABLE[0].velocity_mps == 10.0);
```

## Benefits

- Simpler API with direct access
- Removes unnecessary function indirection
- Consistent with scalar parameter access pattern

## Test Plan

- [x] C++ tests pass: `bazel test //examples:vehicle_params_cc_test`
- [x] Custom namespace tests pass: `bazel test //examples:vehicle_params_cc_custom_ns_test`
- [x] Verified generated headers no longer include function accessor

Fixes #175

🤖 Generated with [Claude Code](https://claude.com/claude-code)