### PR TITLE
Rename parameter_library argument from srcs to src

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test")
 # Step 1: Validate parameters from YAML file
 parameter_library(
     name = "vehicle_params",
-    srcs = "vehicle_params.yaml",
+    src = "vehicle_params.yaml",
 )
 
 # Step 2: Generate C++ header directory
@@ -283,7 +283,7 @@ load("//fire/starlark:parameters.bzl", "parameter_library")
 # Validate and create parameter library from YAML file
 parameter_library(
     name = "vehicle_params",
-    srcs = "vehicle_params.yaml",
+    src = "vehicle_params.yaml",
 )
 
 # Generate C++ headers (directory of per-param-version .h files)

--- a/examples/BUILD.bazel
+++ b/examples/BUILD.bazel
@@ -11,7 +11,7 @@ load("//fire/starlark:requirements.bzl", "requirement_library")
 # Validate and create parameter library from YAML file
 parameter_library(
     name = "vehicle_params",
-    srcs = "vehicle_params.yaml",
+    src = "vehicle_params.yaml",
 )
 
 # Generate C++ headers (directory: vehicle_params_cc/)

--- a/fire/starlark/failure_test/parameter_version/BUILD.bazel
+++ b/fire/starlark/failure_test/parameter_version/BUILD.bazel
@@ -18,7 +18,7 @@ load("//fire/starlark:parameters.bzl", "parameter_library")
 # Generate parameter library from test YAML
 parameter_library(
     name = "test_params",
-    srcs = "test_params.yaml",
+    src = "test_params.yaml",
 )
 
 # Generate C++ code (directory of per-param-version .h files)

--- a/fire/starlark/failure_test/relative_paths/BUILD.bazel
+++ b/fire/starlark/failure_test/relative_paths/BUILD.bazel
@@ -17,7 +17,7 @@ requirement_library(
 # Test parameter library
 parameter_library(
     name = "test_params",
-    srcs = "test_params.yaml",
+    src = "test_params.yaml",
 )
 
 # Non-absolute parent path - should FAIL

--- a/fire/starlark/failure_test/too_many_versions/BUILD.bazel
+++ b/fire/starlark/failure_test/too_many_versions/BUILD.bazel
@@ -7,7 +7,7 @@ load("//fire/starlark:parameters.bzl", "parameter_library")
 
 parameter_library(
     name = "too_many_versions",
-    srcs = "test_params.yaml",
+    src = "test_params.yaml",
     tags = [
         "failure_test",
         "manual",

--- a/fire/starlark/failure_test/version_mismatch/BUILD.bazel
+++ b/fire/starlark/failure_test/version_mismatch/BUILD.bazel
@@ -24,7 +24,7 @@ requirement_library(
 # Parameter version mismatch test - should produce WARNING
 parameter_library(
     name = "test_params_v2",
-    srcs = "test_params_v2.yaml",
+    src = "test_params_v2.yaml",
 )
 
 requirement_library(

--- a/fire/starlark/parameters.bzl
+++ b/fire/starlark/parameters.bzl
@@ -6,7 +6,7 @@ Parameters are defined in YAML files and validated at build time.
 def _validate_parameters_impl(ctx):
     """Implementation of parameter validation rule."""
     script = ctx.executable._script
-    input_file = ctx.file.srcs
+    input_file = ctx.file.src
     output = ctx.outputs.out
 
     # Get runfiles for the script
@@ -32,7 +32,7 @@ _validate_parameters = rule(
         "out": attr.output(
             mandatory = True,
         ),
-        "srcs": attr.label(
+        "src": attr.label(
             allow_single_file = [".yaml", ".yml"],
             mandatory = True,
             doc = "Parameter YAML file to validate",
@@ -48,7 +48,7 @@ _validate_parameters = rule(
 
 def parameter_library(
         name,
-        srcs,
+        src,
         visibility = None,
         tags = None):
     """Define and validate a parameter library from a YAML file.
@@ -58,7 +58,7 @@ def parameter_library(
 
     Args:
         name: Name of the library
-        srcs: Path to the parameter YAML file (e.g., "vehicle_params.yaml")
+        src: Path to the parameter YAML file (e.g., "vehicle_params.yaml")
         visibility: Visibility of the target
         tags: Optional tags (e.g., ["manual", "failure_test"])
 
@@ -77,7 +77,7 @@ def parameter_library(
         # Validate parameters
         parameter_library(
             name = "vehicle_params",
-            srcs = "vehicle_params.yaml",
+            src = "vehicle_params.yaml",
         )
     """
 
@@ -85,7 +85,7 @@ def parameter_library(
     validation_name = name + "_validation"
     _validate_parameters(
         name = validation_name,
-        srcs = srcs,
+        src = src,
         out = name + "_validated.yaml",
         tags = tags if tags else [],
     )

--- a/integration_test/BUILD.bazel
+++ b/integration_test/BUILD.bazel
@@ -13,7 +13,7 @@ exports_files(["test_params.yaml"])
 # Validates test_params.yaml and makes it available for code generation
 parameter_library(
     name = "test_params",
-    srcs = "test_params.yaml",
+    src = "test_params.yaml",
 )
 
 # Generate C++ headers from parameters (directory: test_params_cc/)


### PR DESCRIPTION
## Summary

Renames the `parameter_library` rule argument from `srcs` (plural) to `src` (singular) since it only accepts a single YAML file.

This corrects a naming mistake and makes the API clearer.

## Changes

**parameters.bzl:**
- Renamed `srcs` parameter to `src` in `_validate_parameters` rule
- Renamed `srcs` parameter to `src` in `parameter_library` macro
- Updated documentation and examples

**All BUILD files:**
- Updated all `parameter_library()` calls from `srcs=` to `src=`

## Breaking Change

⚠️ This is a **breaking change** with no backward compatibility.

Users must update their BUILD files:

**Before:**
```python
parameter_library(
    name = "vehicle_params",
    srcs = "vehicle_params.yaml",  # ❌ plural
)
```

**After:**
```python
parameter_library(
    name = "vehicle_params",
    src = "vehicle_params.yaml",  # ✅ singular
)
```

## Test Plan

- [x] All example builds pass: `bazel build //examples:vehicle_params`
- [x] All tests pass: `bazel test //examples:vehicle_params_py_test`
- [x] All failure tests updated and working
- [x] Pre-commit hooks pass (buildifier verified)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Fixes #173