### PR TITLE
Add release report integration test

### DIFF
--- a/integration_test/BUILD.bazel
+++ b/integration_test/BUILD.bazel
@@ -2,6 +2,8 @@
 
 load("@fire//fire/starlark:codegen.bzl", "generate_cc_parameters", "generate_rust_parameters")
 load("@fire//fire/starlark:parameters.bzl", "parameter_library")
+load("@fire//fire/starlark:reports.bzl", "release_readiness_test", "release_report")
+load("@fire//fire/starlark:traceability.bzl", "source_traceability")
 load("@rules_cc//cc:defs.bzl", "cc_library")
 load("@rules_rust//rust:defs.bzl", "rust_library")
 load("@rules_shell//shell:sh_test.bzl", "sh_test")
@@ -55,4 +57,48 @@ sh_test(
 sh_test(
     name = "test_update_rate",
     srcs = ["test_dummy.sh"],
+)
+
+# Source traceability for integration tests
+source_traceability(
+    name = "integration_trace",
+    verifies = {
+        ":test_braking": ["REQ-INT-002?version=1"],
+        ":test_speed_limit": ["REQ-INT-001?version=1"],
+        ":test_update_rate": [
+            "REQ-INT-003?version=1",
+            "REQ-INT-004?version=1",
+        ],
+    },
+    deps = ["//requirements:integration_requirements"],
+    implements = {
+        "consumer/test.cpp": [
+            "REQ-INT-001?version=1",
+            "REQ-INT-002?version=1",
+            "REQ-INT-003?version=1",
+            "REQ-INT-004?version=1",
+        ],
+        "consumer/test.rs": [
+            "REQ-INT-001?version=1",
+            "REQ-INT-002?version=1",
+            "REQ-INT-003?version=1",
+            "REQ-INT-004?version=1",
+        ],
+    },
+)
+
+# Release readiness report
+release_report(
+    name = "integration_release_report",
+    out = "RELEASE_REPORT.md",
+    params = [":test_params"],
+    product = "Fire Integration Test",
+    requirements = ["//requirements:integration_requirements"],
+    source_traces = [":integration_trace"],
+)
+
+# Validate release readiness
+release_readiness_test(
+    name = "integration_release_readiness",
+    report = ":integration_release_report",
 )

--- a/integration_test/run.sh
+++ b/integration_test/run.sh
@@ -44,6 +44,26 @@ echo "Running all Bazel tests..."
 bazel test //... --test_output=errors
 echo ""
 
+echo "Building release report..."
+bazel build //:integration_release_report
+echo ""
+
+echo "Verifying release report..."
+if [ -f bazel-bin/RELEASE_REPORT.md ]; then
+    echo "✓ Release report generated successfully"
+    echo ""
+    echo "Report summary:"
+    head -20 bazel-bin/RELEASE_REPORT.md
+else
+    echo "✗ Release report not found"
+    exit 1
+fi
+echo ""
+
+echo "Running release readiness test..."
+bazel test //:integration_release_readiness --test_output=all
+echo ""
+
 echo "Integration tests completed successfully!"
 
 exit 0


### PR DESCRIPTION
## Summary

Adds comprehensive integration test for `release_report` and `release_readiness_test` to validate end-to-end functionality of the release readiness reporting system.

## Changes

### New Targets in `integration_test/BUILD.bazel`

1. **`source_traceability` target** (`integration_trace`)
   - Maps implementation files to requirements:
     - `consumer/test.cpp` and `consumer/test.rs` implement all 4 integration requirements
   - Maps verification tests to requirements:
     - `:test_speed_limit` verifies REQ-INT-001
     - `:test_braking` verifies REQ-INT-002
     - `:test_update_rate` verifies REQ-INT-003 and REQ-INT-004

2. **`release_report` target** (`integration_release_report`)
   - Product: "Fire Integration Test"
   - Inputs: integration requirements, test parameters, and source traces
   - Output: `RELEASE_REPORT.md`

3. **`release_readiness_test` target** (`integration_release_readiness`)
   - Validates the release report
   - Fails build if not ready for release
   - Demonstrates CI/CD integration

### Updated `run.sh`

- Builds the release report
- Displays report summary (first 20 lines)
- Runs the release readiness test
- Shows full test output

## Test Results

The integration test demonstrates a **"READY FOR RELEASE"** scenario:

```
✅ RELEASE READINESS CHECK PASSED

The product is ready for release!
```

**Report contents:**
- ✓ 18 versioned references (all consistent)
- ✓ All requirements have implementation traces
- ✓ All requirements have verification traces
- ✓ No TODOs
- ✓ No stale references
- Includes Mermaid traceability graph

## Why This Matters

This integration test validates that Fire consumers can:
1. Define source traceability for their requirements
2. Generate comprehensive release reports
3. Validate release readiness in CI/CD pipelines
4. Get clear pass/fail signals for release decisions

The test runs as part of `./run.sh` and demonstrates real-world usage of the release reporting system.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)