### PR TITLE
Add Bazel caching to CI workflows

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -45,6 +45,17 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Cache Bazel
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/bazel
+            ~/.cache/bazelisk
+          key: bazel-${{ matrix.os }}-${{ matrix.bazel-version }}-${{ hashFiles('MODULE.bazel.lock') }}
+          restore-keys: |
+            bazel-${{ matrix.os }}-${{ matrix.bazel-version }}-
+            bazel-${{ matrix.os }}-
+
       - name: Run Bazel tests
         env:
           USE_BAZEL_VERSION: ${{ matrix.bazel-version }}
@@ -61,6 +72,16 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+
+      - name: Cache Bazel
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/bazel
+            ~/.cache/bazelisk
+          key: bazel-typecheck-ubuntu-latest-${{ hashFiles('MODULE.bazel.lock') }}
+          restore-keys: |
+            bazel-typecheck-ubuntu-latest-
 
       - name: Run type checking with ty
         run: bazel build --config=typecheck //...
@@ -85,6 +106,17 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+
+      - name: Cache Bazel
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/bazel
+            ~/.cache/bazelisk
+          key: bazel-integration-py${{ matrix.python-version }}-${{ hashFiles('integration_test/MODULE.bazel.lock') }}
+          restore-keys: |
+            bazel-integration-py${{ matrix.python-version }}-
+            bazel-integration-
 
       - name: Run integration test
         run: |


### PR DESCRIPTION
## Summary

Adds GitHub Actions cache for Bazel builds to reduce download/fetch issues and speed up CI runs.

## Changes

Adds caching steps to three CI jobs:

- **test job**: Caches by OS, Bazel version, and `MODULE.bazel.lock` hash
  - Supports 6 matrix combinations (2 OS × 3 Bazel versions)
  - Cache key: `bazel-{os}-{bazel-version}-{lock-hash}`

- **typecheck job**: Caches by `MODULE.bazel.lock` hash
  - Cache key: `bazel-typecheck-ubuntu-latest-{lock-hash}`

- **integration-test job**: Caches by Python version and `integration_test/MODULE.bazel.lock` hash
  - Supports 4 Python versions (3.10, 3.11, 3.12, 3.13)
  - Cache key: `bazel-integration-py{version}-{lock-hash}`

All caches include hierarchical restore keys for partial cache hits when lock files change.

**Note**: The `failure-tests` job intentionally has no caching as it actively invalidates the cache.

## Benefits

- Faster CI runs (estimated 30-60% time reduction after first run)
- More reliable builds (reduced network dependency)
- Reduced bandwidth usage

Fixes #199

🤖 Generated with [Claude Code](https://claude.com/claude-code)