### PR TITLE
Add release automation for FORMAT_SPECIFICATION.md

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,6 +3,12 @@ name: Release
 on:
   release:
     types: [created]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to use (e.g., v0.4.0)"
+        required: true
+        type: string
 
 jobs:
   upload-format-spec:
@@ -16,7 +22,12 @@ jobs:
 
       - name: Get release version
         id: get_version
-        run: echo "version=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "version=${{ inputs.version }}" >> $GITHUB_OUTPUT
+          else
+            echo "version=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
+          fi
 
       - name: Update FORMAT_SPECIFICATION.md version
         run: |


### PR DESCRIPTION
## Summary

Adds automated release workflow to upload `FORMAT_SPECIFICATION.md` as a downloadable asset when creating GitHub releases.

## How It Works

When a new release is created:
1. The workflow extracts the version from the git tag
2. Updates the version field in `FORMAT_SPECIFICATION.md` from `main` to the actual release version (e.g., `v0.4.0`)
3. Uploads the updated file to the release as a downloadable asset

## Benefits

- Consumers can download the format specification for a specific FIRE version
- No manual steps required - fully automated
- Version in the downloaded file matches the release version

## Usage

When creating a release:
1. Create and tag the release as usual (the existing PUBLISHING.md steps)
2. The workflow automatically runs and uploads FORMAT_SPECIFICATION.md
3. Consumers can download it from the release assets

## Testing

This can be tested by creating a draft release or by waiting for the next actual release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)