### PR TITLE
Fix sed regex in release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -31,7 +31,7 @@ jobs:
 
       - name: Update FORMAT_SPECIFICATION.md version
         run: |
-          sed -i "s/^**Version:** main$/**Version:** ${{ steps.get_version.outputs.version }}/" FORMAT_SPECIFICATION.md
+          sed -i "s/^\*\*Version:\*\* main$/\*\*Version:\*\* ${{ steps.get_version.outputs.version }}/" FORMAT_SPECIFICATION.md
 
       - name: Upload FORMAT_SPECIFICATION.md to release
         env:


### PR DESCRIPTION
## Problem

The release workflow failed with:
```
sed: -e expression #1, char 47: Invalid preceding regular expression
```

## Cause

The `**` (markdown bold formatting) in the sed pattern was being interpreted as regex wildcards instead of literal asterisks.

## Solution

Escape the asterisks with backslashes: `\*\*` so sed treats them as literal characters.

## Testing

After merging, test by running the workflow manually again with a test version.

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>