### PR TITLE
Add deterministic source tarball to release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -33,10 +33,20 @@ jobs:
         run: |
           sed -i "s/^\*\*Version:\*\* main$/\*\*Version:\*\* ${{ steps.get_version.outputs.version }}/" FORMAT_SPECIFICATION.md
 
-      - name: Upload FORMAT_SPECIFICATION.md to release
+      - name: Create deterministic source tarball
+        run: |
+          VERSION=${{ steps.get_version.outputs.version }}
+          # Strip 'v' prefix if present for the archive name
+          VERSION_NUM=${VERSION#v}
+          git archive --format=tar.gz --prefix=fire-${VERSION_NUM}/ HEAD > fire-${VERSION_NUM}.tar.gz
+
+      - name: Upload release artifacts
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
+          VERSION=${{ steps.get_version.outputs.version }}
+          VERSION_NUM=${VERSION#v}
           gh release upload ${{ steps.get_version.outputs.version }} \
             FORMAT_SPECIFICATION.md \
+            fire-${VERSION_NUM}.tar.gz \
             --clobber


### PR DESCRIPTION
## Summary

Adds automatic creation and upload of a deterministic source tarball to the release workflow.

## Problem

Bazel Central Registry requires deterministic source archives. GitHub's automatically generated source archives aren't always deterministic, requiring manual re-upload after each release.

## Solution

Use `git archive` to create a deterministic tarball from the git tree. This command creates reproducible archives based on the git commit.

## Changes

- Added step to create source tarball: `fire-{version}.tar.gz`
- Archive contains source in `fire-{version}/` directory
- Updated upload step to include both FORMAT_SPECIFICATION.md and the tarball
- Version number strips 'v' prefix (e.g., v0.4.0 → fire-0.4.0.tar.gz)

## Benefits

- No more manual tarball re-upload after releases
- Deterministic archives satisfy BCR requirements
- Fully automated release process

## Testing

Can be tested with manual workflow trigger using a test version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)