### PR TITLE
Fix release workflow: use release event tag_name instead of GITHUB_REF

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -26,7 +26,7 @@ jobs:
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             echo "version=${{ inputs.version }}" >> $GITHUB_OUTPUT
           else
-            echo "version=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
+            echo "version=${{ github.event.release.tag_name }}" >> $GITHUB_OUTPUT
           fi
 
       - name: Update FORMAT_SPECIFICATION.md version


### PR DESCRIPTION
## Summary

Fix the release workflow so the version is correctly read from the release event payload.

## Implementation Summary

The `get_version` step was using `${GITHUB_REF#refs/tags/}` shell expansion to extract the tag version, but `GITHUB_REF` was empty in the shell environment for the `release: created` event trigger. This caused all downstream steps to receive an empty version string, and `gh release upload ""` to fail with "release not found".

The fix replaces the shell variable expansion with `${{ github.event.release.tag_name }}`, which is a GitHub Actions expression evaluated before the shell script runs and is reliably populated from the release event payload.

## Testing

- Verified the failing run `22552021920` showed `VERSION=` (empty) confirming the root cause
- The `workflow_dispatch` path is unchanged and still uses `${{ inputs.version }}`
- After merging, trigger the workflow manually with `workflow_dispatch` or re-run against the existing `v0.4.0` release to verify artifacts are uploaded correctly