### PR TITLE
Use genquery for failure test target discovery (#210)

### DIFF
--- a/fire/starlark/failure_test/BUILD.bazel
+++ b/fire/starlark/failure_test/BUILD.bazel
@@ -1,0 +1,138 @@
+"""Genquery targets for failure test discovery.
+
+Each target produces a file listing the Bazel labels for one failure test
+category. run_failure_tests.sh builds these targets and reads the files to
+determine which tests belong to each category.
+
+When adding a new failure test target to any sub-package, add it to _SCOPE
+below so genquery can find it.
+"""
+
+# All targets in all failure test packages. genquery scope must enumerate
+# every target that the universe set expands to, and genquery expressions
+# cannot use recursive patterns (//...), so _SCOPE drives both.
+_SCOPE = [
+    # bare_todo
+    "//fire/starlark/failure_test/bare_todo:test_bare_todo",
+    "//fire/starlark/failure_test/bare_todo:test_bare_todo_validation",
+    "//fire/starlark/failure_test/bare_todo:test_todo_bad_format",
+    "//fire/starlark/failure_test/bare_todo:test_todo_bad_format_validation",
+    # dependency_failures
+    "//fire/starlark/failure_test/dependency_failures:test_missing_param_dep",
+    "//fire/starlark/failure_test/dependency_failures:test_missing_param_dep_validation",
+    "//fire/starlark/failure_test/dependency_failures:test_missing_req_dep",
+    "//fire/starlark/failure_test/dependency_failures:test_missing_req_dep_validation",
+    # invalid_metadata
+    "//fire/starlark/failure_test/invalid_metadata:test_invalid_dal",
+    "//fire/starlark/failure_test/invalid_metadata:test_invalid_dal_validation",
+    "//fire/starlark/failure_test/invalid_metadata:test_invalid_sec",
+    "//fire/starlark/failure_test/invalid_metadata:test_invalid_sec_validation",
+    "//fire/starlark/failure_test/invalid_metadata:test_invalid_sil",
+    "//fire/starlark/failure_test/invalid_metadata:test_invalid_sil_validation",
+    "//fire/starlark/failure_test/invalid_metadata:test_invalid_version_negative",
+    "//fire/starlark/failure_test/invalid_metadata:test_invalid_version_negative_validation",
+    "//fire/starlark/failure_test/invalid_metadata:test_invalid_version_zero",
+    "//fire/starlark/failure_test/invalid_metadata:test_invalid_version_zero_validation",
+    # missing_fields
+    "//fire/starlark/failure_test/missing_fields:test_missing_all",
+    "//fire/starlark/failure_test/missing_fields:test_missing_all_validation",
+    "//fire/starlark/failure_test/missing_fields:test_missing_sec",
+    "//fire/starlark/failure_test/missing_fields:test_missing_sec_validation",
+    "//fire/starlark/failure_test/missing_fields:test_missing_sil",
+    "//fire/starlark/failure_test/missing_fields:test_missing_sil_validation",
+    "//fire/starlark/failure_test/missing_fields:test_missing_version",
+    "//fire/starlark/failure_test/missing_fields:test_missing_version_validation",
+    # parameter_version
+    "//fire/starlark/failure_test/parameter_version:test_params",
+    "//fire/starlark/failure_test/parameter_version:test_params_cc",
+    "//fire/starlark/failure_test/parameter_version:test_params_go_lib",
+    "//fire/starlark/failure_test/parameter_version:test_params_go_src",
+    "//fire/starlark/failure_test/parameter_version:test_params_h",
+    "//fire/starlark/failure_test/parameter_version:test_params_java",
+    "//fire/starlark/failure_test/parameter_version:test_params_java_src",
+    "//fire/starlark/failure_test/parameter_version:test_params_py",
+    "//fire/starlark/failure_test/parameter_version:test_params_py_src",
+    "//fire/starlark/failure_test/parameter_version:test_params_rs",
+    "//fire/starlark/failure_test/parameter_version:test_params_rust_src",
+    "//fire/starlark/failure_test/parameter_version:test_params_validation",
+    "//fire/starlark/failure_test/parameter_version:test_version_too_old_cpp",
+    "//fire/starlark/failure_test/parameter_version:test_version_too_old_go",
+    "//fire/starlark/failure_test/parameter_version:test_version_too_old_java",
+    "//fire/starlark/failure_test/parameter_version:test_version_too_old_py",
+    "//fire/starlark/failure_test/parameter_version:test_version_too_old_rust",
+    "//fire/starlark/failure_test/parameter_version:test_version_upgraded_cpp",
+    "//fire/starlark/failure_test/parameter_version:test_version_upgraded_go",
+    "//fire/starlark/failure_test/parameter_version:test_version_upgraded_java",
+    "//fire/starlark/failure_test/parameter_version:test_version_upgraded_py",
+    "//fire/starlark/failure_test/parameter_version:test_version_upgraded_rust",
+    # relative_paths
+    "//fire/starlark/failure_test/relative_paths:base_requirement",
+    "//fire/starlark/failure_test/relative_paths:base_requirement_validation",
+    "//fire/starlark/failure_test/relative_paths:test_non_absolute_param",
+    "//fire/starlark/failure_test/relative_paths:test_non_absolute_param_validation",
+    "//fire/starlark/failure_test/relative_paths:test_non_absolute_parent",
+    "//fire/starlark/failure_test/relative_paths:test_non_absolute_parent_validation",
+    "//fire/starlark/failure_test/relative_paths:test_non_absolute_reference",
+    "//fire/starlark/failure_test/relative_paths:test_non_absolute_reference_validation",
+    "//fire/starlark/failure_test/relative_paths:test_params",
+    "//fire/starlark/failure_test/relative_paths:test_params_validation",
+    # source_traceability
+    "//fire/starlark/failure_test/source_traceability:test_future_version",
+    "//fire/starlark/failure_test/source_traceability:test_missing_version",
+    "//fire/starlark/failure_test/source_traceability:test_outdated_version",
+    # too_many_versions
+    "//fire/starlark/failure_test/too_many_versions:too_many_versions",
+    "//fire/starlark/failure_test/too_many_versions:too_many_versions_validation",
+    # version_mismatch
+    "//fire/starlark/failure_test/version_mismatch:test_param_version_mismatch",
+    "//fire/starlark/failure_test/version_mismatch:test_param_version_mismatch_error",
+    "//fire/starlark/failure_test/version_mismatch:test_param_version_mismatch_error_validation",
+    "//fire/starlark/failure_test/version_mismatch:test_param_version_mismatch_validation",
+    "//fire/starlark/failure_test/version_mismatch:test_params_v2",
+    "//fire/starlark/failure_test/version_mismatch:test_params_v2_validation",
+    "//fire/starlark/failure_test/version_mismatch:test_version_mismatch",
+    "//fire/starlark/failure_test/version_mismatch:test_version_mismatch_validation",
+]
+
+# Build a set() expression from _SCOPE so that genquery expressions can use
+# the same list without recursive patterns (which genquery forbids).
+_UNIVERSE = "set(" + " ".join(_SCOPE) + ")"
+
+_NO_VALIDATION = "except filter(\".*_validation$\", {universe})".format(universe = _UNIVERSE)
+
+_SPECIFIC_TAGS = [
+    "version_too_old",
+    "version_upgraded",
+    "too_many_versions",
+    "missing_version",
+    "outdated_version",
+    "future_version",
+]
+
+[genquery(
+    name = tag + "_targets",
+    expression = "attr(tags, {tag}, {universe}) {no_validation}".format(
+        no_validation = _NO_VALIDATION,
+        tag = tag,
+        universe = _UNIVERSE,
+    ),
+    scope = _SCOPE,
+) for tag in _SPECIFIC_TAGS]
+
+genquery(
+    name = "legacy_failure_targets",
+    expression = (
+        "attr(tags, failure_test, {universe}) {no_validation}".format(
+            no_validation = _NO_VALIDATION,
+            universe = _UNIVERSE,
+        ) +
+        "".join([
+            " except attr(tags, {tag}, {universe})".format(
+                tag = tag,
+                universe = _UNIVERSE,
+            )
+            for tag in _SPECIFIC_TAGS
+        ])
+    ),
+    scope = _SCOPE,
+)

--- a/fire/starlark/failure_test/run_failure_tests.sh
+++ b/fire/starlark/failure_test/run_failure_tests.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 # Run all targets tagged with 'failure_test'
 #
-# This script parses BUILD files to find targets with the 'failure_test' tag
-# and verifies they fail or produce warnings as expected.
+# Target discovery uses genquery (//fire/starlark/failure_test:*_targets).
+# Each category of test is read from a pre-built genquery output file.
 
 set -euo pipefail
 
@@ -17,102 +17,52 @@ SUCCESSES=0
 # Bazel options for CI with repository cache (separate cache for failure tests)
 BAZEL_OPTS="--config=ci --repository_cache=$HOME/.cache/bazel-repo-failure"
 
-# Query Bazel once for all targets with build output format (easy to parse!)
-# Output format: //package:target|tag1 tag2 tag3
-echo "Querying Bazel for failure test targets..."
-PARSED_TARGETS=$(bazel query --output=build '//fire/starlark/failure_test/...' 2>/dev/null | awk '
-  /^[ \t]*[A-Za-z_][A-Za-z0-9_]*\([ \t]*$/ { in_rule=1; name=""; tags=""; pkg=""; next }
+# Build genquery targets to obtain per-category target lists
+GENQUERY_TARGETS=(
+    "//fire/starlark/failure_test:version_too_old_targets"
+    "//fire/starlark/failure_test:version_upgraded_targets"
+    "//fire/starlark/failure_test:too_many_versions_targets"
+    "//fire/starlark/failure_test:missing_version_targets"
+    "//fire/starlark/failure_test:outdated_version_targets"
+    "//fire/starlark/failure_test:future_version_targets"
+    "//fire/starlark/failure_test:legacy_failure_targets"
+)
 
-  in_rule && /^[ \t]*\)[ \t]*$/ {
-    if (name != "" && pkg != "" && tags ~ /failure_test/ && name !~ /_validation$/) {
-      print "//" pkg ":" name "|" tags
-    }
-    in_rule=0
-    next
-  }
+echo "Building genquery target lists..."
+bazel build $BAZEL_OPTS "${GENQUERY_TARGETS[@]}" 2>/dev/null
 
-  in_rule && /^[ \t]*name[ \t]*=/ {
-    s=$0
-    sub(/.*name[ \t]*=[ \t]*"/, "", s)
-    sub(/".*/, "", s)
-    name=s
-    next
-  }
+GENQUERY_DIR="bazel-bin/fire/starlark/failure_test"
 
-  in_rule && /^[ \t]*generator_location[ \t]*=/ {
-    s=$0
-    sub(/.*generator_location[ \t]*=[ \t]*"/, "", s)
-    sub(/\/BUILD.bazel.*/, "", s)
-    pkg=s
-    next
-  }
-
-  in_rule && /^[ \t]*tags[ \t]*=/ {
-    s=$0
-    sub(/.*tags[ \t]*=[ \t]*/, "", s)
-    sub(/,[ \t]*$/, "", s)
-    gsub(/[\[\]"]/, "", s)
-    gsub(/,/, " ", s)
-    gsub(/[ \t]+/, " ", s)
-    sub(/^[ \t]+/, "", s)
-    sub(/[ \t]+$/, "", s)
-    tags=s
-    next
-  }
-')
-
-if [ -z "$PARSED_TARGETS" ]; then
-    echo "No targets with 'failure_test' tag found"
+if [ ! -f "$GENQUERY_DIR/legacy_failure_targets" ]; then
+    echo "Genquery output not found under $GENQUERY_DIR"
     exit 1
 fi
 
-# Extract list of failure test targets
-FAILURE_TARGETS=$(echo "$PARSED_TARGETS" | cut -d'|' -f1)
-
-# Fast tag lookup using parsed BUILD file data (bash 3.2 compatible)
-has_tag() {
+# Run each failure test
+run_failure_test() {
     local target=$1
     local tag=$2
-    local tags=$(echo "$PARSED_TARGETS" | grep "^${target}|" | cut -d'|' -f2)
-    [[ " $tags " == *" $tag "* ]]
-}
 
-# Run each failure test
-for target in $FAILURE_TARGETS; do
     echo "Testing: $target ..."
 
-    # Determine test type based on tags
-    if has_tag "$target" "version_too_old"; then
-        # Version too old tests should fail at compile or runtime
+    if [ "$tag" = "version_too_old" ]; then
         set +e
         output=$(bazel build $BAZEL_OPTS "$target" 2>&1)
         build_exit_code=$?
         set -e
 
         if [ $build_exit_code -ne 0 ]; then
-            # Check for expected error patterns
-            if echo "$output" | grep -qE "static_assert|older than expected|assertion.*failed"; then
-                echo "✅ PASS: Build failed with version too old error"
-                SUCCESSES=$((SUCCESSES + 1))
-            else
-                echo "✅ PASS: Build failed (version too old)"
-                SUCCESSES=$((SUCCESSES + 1))
-            fi
+            echo "✅ PASS: Build failed with version too old error"
+            SUCCESSES=$((SUCCESSES + 1))
         else
-            # Build succeeded, try running to check for runtime error
             set +e
             run_output=$(bazel run $BAZEL_OPTS "$target" 2>&1)
             run_exit_code=$?
             set -e
 
             if [ $run_exit_code -ne 0 ]; then
-                if echo "$run_output" | grep -qE "older than expected|RuntimeError|IllegalArgumentException|panic|ModuleNotFoundError|ImportError|No module named"; then
-                    echo "✅ PASS: Runtime failed with version too old error"
-                    SUCCESSES=$((SUCCESSES + 1))
-                else
-                    echo "✅ PASS: Runtime failed (version too old)"
-                    SUCCESSES=$((SUCCESSES + 1))
-                fi
+                echo "✅ PASS: Runtime failed with version too old error"
+                SUCCESSES=$((SUCCESSES + 1))
             else
                 echo "❌ FAIL: Should have failed with version too old error"
                 echo "Build exit code: $build_exit_code"
@@ -121,9 +71,7 @@ for target in $FAILURE_TARGETS; do
             fi
         fi
 
-    elif has_tag "$target" "version_upgraded"; then
-        # Version upgraded tests should succeed but emit warning
-        # Force full rebuild to see compile-time warnings
+    elif [ "$tag" = "version_upgraded" ]; then
         set +e
         output=$(bazel build $BAZEL_OPTS --action_env=CACHE_BUST=$RANDOM "$target" 2>&1)
         build_exit_code=$?
@@ -135,35 +83,31 @@ for target in $FAILURE_TARGETS; do
             echo "Output excerpt:"
             echo "$output" | head -20
             FAILURES=$((FAILURES + 1))
+        elif echo "$output" | grep -qiE "warning.*deprecated|has been updated to version"; then
+            echo "✅ PASS: Build produced deprecation warning"
+            SUCCESSES=$((SUCCESSES + 1))
         else
-            # Check for compile-time deprecation warning (C++)
-            if echo "$output" | grep -qiE "warning.*deprecated|has been updated to version"; then
-                echo "✅ PASS: Build produced deprecation warning"
-                SUCCESSES=$((SUCCESSES + 1))
-            else
-                # Run and check for runtime warning
-                set +e
-                run_output=$(bazel run $BAZEL_OPTS "$target" 2>&1)
-                run_exit_code=$?
-                set -e
+            set +e
+            run_output=$(bazel run $BAZEL_OPTS "$target" 2>&1)
+            run_exit_code=$?
+            set -e
 
-                if echo "$run_output" | grep -qiE "warning.*updated to version|DeprecationWarning|has been updated"; then
-                    echo "✅ PASS: Runtime produced version upgrade warning"
-                    SUCCESSES=$((SUCCESSES + 1))
-                elif [ $run_exit_code -eq 0 ]; then
-                    echo "❌ FAIL: Should have produced version upgrade warning"
-                    echo "Output excerpt:"
-                    echo "$run_output" | head -20
-                    FAILURES=$((FAILURES + 1))
-                else
-                    echo "❌ FAIL: Runtime should not fail for version upgraded test"
-                    echo "Exit code: $run_exit_code"
-                    FAILURES=$((FAILURES + 1))
-                fi
+            if echo "$run_output" | grep -qiE "warning.*updated to version|DeprecationWarning|has been updated"; then
+                echo "✅ PASS: Runtime produced version upgrade warning"
+                SUCCESSES=$((SUCCESSES + 1))
+            elif [ $run_exit_code -eq 0 ]; then
+                echo "❌ FAIL: Should have produced version upgrade warning"
+                echo "Output excerpt:"
+                echo "$run_output" | head -20
+                FAILURES=$((FAILURES + 1))
+            else
+                echo "❌ FAIL: Runtime should not fail for version upgraded test"
+                echo "Exit code: $run_exit_code"
+                FAILURES=$((FAILURES + 1))
             fi
         fi
 
-    elif has_tag "$target" "too_many_versions"; then
+    elif [ "$tag" = "too_many_versions" ]; then
         set +e
         output=$(bazel build $BAZEL_OPTS --action_env=CACHE_BUST=$RANDOM "$target" 2>&1)
         build_exit_code=$?
@@ -175,38 +119,27 @@ for target in $FAILURE_TARGETS; do
             echo "Output excerpt:"
             echo "$output" | head -20
             FAILURES=$((FAILURES + 1))
-        else
-            # Check for compile-time deprecation warning (C++)
-            if echo "$output" | grep -qiE "exceed two entries"; then
-                echo "✅ PASS: Build produced too many versions error"
-                SUCCESSES=$((SUCCESSES + 1))
-            fi
+        elif echo "$output" | grep -qiE "exceed two entries"; then
+            echo "✅ PASS: Build produced too many versions error"
+            SUCCESSES=$((SUCCESSES + 1))
         fi
 
-    elif has_tag "$target" "missing_version"; then
-        # Missing version suffix tests should fail at build time
+    elif [ "$tag" = "missing_version" ]; then
         set +e
         output=$(bazel build $BAZEL_OPTS "$target" 2>&1)
         build_exit_code=$?
         set -e
 
         if [ $build_exit_code -ne 0 ]; then
-            # Check for expected error pattern
-            if echo "$output" | grep -qE "is missing \?version= suffix"; then
-                echo "✅ PASS: Build failed with missing version suffix error"
-                SUCCESSES=$((SUCCESSES + 1))
-            else
-                echo "✅ PASS: Build failed (missing version)"
-                SUCCESSES=$((SUCCESSES + 1))
-            fi
+            echo "✅ PASS: Build failed with missing version suffix error"
+            SUCCESSES=$((SUCCESSES + 1))
         else
             echo "❌ FAIL: Build should have failed with missing version error"
             echo "Exit code: $build_exit_code"
             FAILURES=$((FAILURES + 1))
         fi
 
-    elif has_tag "$target" "outdated_version"; then
-        # Outdated version tests should succeed but emit warning
+    elif [ "$tag" = "outdated_version" ]; then
         set +e
         output=$(bazel build $BAZEL_OPTS --action_env=CACHE_BUST=$RANDOM "$target" 2>&1)
         build_exit_code=$?
@@ -218,35 +151,25 @@ for target in $FAILURE_TARGETS; do
             echo "Output excerpt:"
             echo "$output" | head -20
             FAILURES=$((FAILURES + 1))
+        elif echo "$output" | grep -qE "WARNING.*OUTDATED|but requirement is at version"; then
+            echo "✅ PASS: Build produced outdated version warning"
+            SUCCESSES=$((SUCCESSES + 1))
         else
-            # Check for outdated version warning
-            if echo "$output" | grep -qE "WARNING.*OUTDATED|but requirement is at version"; then
-                echo "✅ PASS: Build produced outdated version warning"
-                SUCCESSES=$((SUCCESSES + 1))
-            else
-                echo "❌ FAIL: Should have produced outdated version warning"
-                echo "Output excerpt:"
-                echo "$output" | head -20
-                FAILURES=$((FAILURES + 1))
-            fi
+            echo "❌ FAIL: Should have produced outdated version warning"
+            echo "Output excerpt:"
+            echo "$output" | head -20
+            FAILURES=$((FAILURES + 1))
         fi
 
-    elif has_tag "$target" "future_version"; then
-        # Future version tests should fail at build time
+    elif [ "$tag" = "future_version" ]; then
         set +e
         output=$(bazel build $BAZEL_OPTS "$target" 2>&1)
         build_exit_code=$?
         set -e
 
         if [ $build_exit_code -ne 0 ]; then
-            # Check for expected error pattern
-            if echo "$output" | grep -qE "but requirement is only at version"; then
-                echo "✅ PASS: Build failed with future version error"
-                SUCCESSES=$((SUCCESSES + 1))
-            else
-                echo "✅ PASS: Build failed (future version)"
-                SUCCESSES=$((SUCCESSES + 1))
-            fi
+            echo "✅ PASS: Build failed with future version error"
+            SUCCESSES=$((SUCCESSES + 1))
         else
             echo "❌ FAIL: Build should have failed with future version error"
             echo "Exit code: $build_exit_code"
@@ -254,38 +177,30 @@ for target in $FAILURE_TARGETS; do
         fi
 
     else
-        # Legacy tests - check for dependency errors or VERSION MISMATCH
-        # Force full rebuild to see warnings
+        # Legacy tests: dependency errors, VERSION MISMATCH, missing fields, etc.
         set +e
         output=$(bazel build $BAZEL_OPTS --action_env=CACHE_BUST=$RANDOM "$target" 2>&1)
         build_exit_code=$?
         set -e
 
-        # Check for dependency errors (should FAIL)
         if echo "$output" | grep -q "not in declared dependencies"; then
             echo "✅ PASS: Build failed with dependency error"
             SUCCESSES=$((SUCCESSES + 1))
-        # Check for version mismatch warnings (should WARN)
         elif echo "$output" | grep -q "VERSION MISMATCH"; then
             echo "✅ PASS: Build produced version mismatch warning"
             SUCCESSES=$((SUCCESSES + 1))
-        # Check for missing required fields (should FAIL)
         elif echo "$output" | grep -qE "is a required property|has no metadata|Field required"; then
             echo "✅ PASS: Build failed with missing required field error"
             SUCCESSES=$((SUCCESSES + 1))
-        # Check for non-repository-relative paths (should FAIL)
         elif echo "$output" | grep -q "must be repository-relative"; then
             echo "✅ PASS: Build failed with non-repository-relative path error"
             SUCCESSES=$((SUCCESSES + 1))
-        # Check for bare/malformed TODO markers (should FAIL)
         elif echo "$output" | grep -q "Bare or malformed TODO"; then
             echo "✅ PASS: Build failed with bare/malformed TODO error"
             SUCCESSES=$((SUCCESSES + 1))
-        # Check for Pydantic validation errors (should FAIL)
         elif echo "$output" | grep -qE "not a valid boolean|not a valid enumeration member|Input should be one of|not a valid integer|greater than or equal"; then
             echo "✅ PASS: Build failed with Pydantic validation error"
             SUCCESSES=$((SUCCESSES + 1))
-        # Unexpected: build succeeded or failed with wrong error
         else
             echo "❌ FAIL: Build should have failed or produced expected warning"
             echo "Exit code: $build_exit_code"
@@ -295,7 +210,20 @@ for target in $FAILURE_TARGETS; do
         fi
     fi
     echo ""
+}
+
+# Process each category from genquery output files
+for tag in version_too_old version_upgraded too_many_versions missing_version outdated_version future_version; do
+    while IFS= read -r target; do
+        [[ -z "$target" ]] && continue
+        run_failure_test "$target" "$tag"
+    done < "$GENQUERY_DIR/${tag}_targets"
 done
+
+while IFS= read -r target; do
+    [[ -z "$target" ]] && continue
+    run_failure_test "$target" "legacy"
+done < "$GENQUERY_DIR/legacy_failure_targets"
 
 # Summary
 echo "========================================="


### PR DESCRIPTION
## Summary

Replace the `bazel query --output=build | awk` pipeline in `run_failure_tests.sh` with `genquery` targets that pre-compute per-tag target lists at build time. Closes #210.

## Implementation Summary

A new `fire/starlark/failure_test/BUILD.bazel` defines seven `genquery` targets — one per failure test category (`version_too_old`, `version_upgraded`, `too_many_versions`, `missing_version`, `outdated_version`, `future_version`, `legacy`). Two constraints shaped the design:

- `genquery` scope cannot use `//...` recursive patterns (requires explicit target labels)
- `genquery` expressions also forbid `//...` recursive patterns

Both are solved by a single `_SCOPE` list that drives the genquery `scope` attribute directly and is joined into a `set(...)` expression for the query universe — no duplication.

`run_failure_tests.sh` now does one `bazel build` of the genquery targets, then reads the output files to iterate each category. The 40-line awk parser and `has_tag()` function are gone. Script shrinks from 315 to 242 lines.

## Testing

- All 33 failure tests pass locally with the new script
- Pre-commit checks pass