### PR TITLE
Add regulatory requirements (.regreq.md) with optional sil/sec (#218)

### DIFF
--- a/FORMAT_SPECIFICATION.md
+++ b/FORMAT_SPECIFICATION.md
@@ -9,9 +9,10 @@ This document specifies the format for all input files used in the FIRE requirem
 
 1. [System Requirements (`.sysreq.md`)](#system-requirements-sysreqmd)
 2. [Software Requirements (`.swreq.md`)](#software-requirements-swreqmd)
-3. [Parameter Files (`.yaml`)](#parameter-files-yaml)
-4. [Cross-References](#cross-references)
-5. [Validation Rules](#validation-rules)
+3. [Regulatory Requirements (`.regreq.md`)](#regulatory-requirements-regreqmd)
+4. [Parameter Files (`.yaml`)](#parameter-files-yaml)
+5. [Cross-References](#cross-references)
+6. [Validation Rules](#validation-rules)
 
 ---
 
@@ -358,6 +359,57 @@ The brake actuator component shall integrate emergency braking commands with sen
 fusion data to optimize braking performance based on detected road conditions and
 obstacle proximity. This requirement derives from both the braking system requirement
 and the sensing system requirement.
+
+---
+```
+
+---
+
+## Regulatory Requirements (`.regreq.md`)
+
+Regulatory requirements are stored in Markdown files with the `.regreq.md`
+extension. These capture regulatory obligations where safety integrity levels
+and security relevance may not apply.
+
+### File Structure
+
+Regulatory requirement files follow the same structure as system requirements.
+
+### Metadata Fields
+
+Regulatory requirements use a reduced metadata format where only `Version` is
+mandatory:
+
+```text
+Version: <version>
+```
+
+The `SIL`, `Sec`, and `Parent` fields are all optional:
+
+```text
+SIL: <sil-value> | Sec: <sec-value> | Version: <version> | Parent: <parent-ref>
+```
+
+### Complete Example
+
+```markdown
+# Data Protection Regulation Requirements
+
+## REQ-GDPR-DATA-RETENTION
+
+Version: 1
+
+The system shall delete personal data after the retention period defined by
+the applicable data protection regulation has expired.
+
+---
+
+## REQ-GDPR-DATA-ACCESS
+
+SIL: QM | Version: 2
+
+The system shall provide a mechanism for data subjects to request access to
+their personal data within 30 days of the request.
 
 ---
 ```

--- a/fire/starlark/requirement_models.py
+++ b/fire/starlark/requirement_models.py
@@ -45,7 +45,7 @@ SilValue = Literal[
 
 
 class RequirementMetadata(BaseModel):
-    """Model for requirement inline metadata."""
+    """Model for requirement inline metadata (sysreq/swreq)."""
 
     id: str = Field(pattern=REQ_ID_PATTERN.pattern)
 
@@ -62,7 +62,9 @@ class RequirementMetadata(BaseModel):
     @field_validator("sil", mode="before")
     @classmethod
     def validate_sil(cls, v: object) -> object:
-        """Accept valid SIL/ASIL/DAL literals or TODO(KEY-1234)."""
+        """Accept valid SIL/ASIL/DAL literals, TODO(KEY-1234), or None."""
+        if v is None:
+            return v
         if isinstance(v, str) and TODO_PATTERN.fullmatch(v):
             return v
         if v not in _VALID_SIL_VALUES:
@@ -78,7 +80,9 @@ class RequirementMetadata(BaseModel):
     @field_validator("sec", mode="before")
     @classmethod
     def validate_sec(cls, v: object) -> object:
-        """Accept strict booleans or TODO(KEY-1234)."""
+        """Accept strict booleans, TODO(KEY-1234), or None."""
+        if v is None:
+            return v
         if isinstance(v, str) and TODO_PATTERN.fullmatch(v):
             return v
         if not isinstance(v, bool):
@@ -120,3 +124,14 @@ class RequirementMetadata(BaseModel):
             raise ValueError(
                 f"parent path must be repository-relative (start with /): '{path}'"
             )
+
+
+class RegulatoryRequirementMetadata(RequirementMetadata):
+    """Model for regulatory requirement metadata (regreq).
+
+    Unlike sysreq/swreq, sil and sec are optional for regulatory requirements.
+    """
+
+    sil: Optional[Union[SilValue, str]] = None
+
+    sec: Optional[Union[bool, str]] = None

--- a/fire/starlark/validate_cross_references.py
+++ b/fire/starlark/validate_cross_references.py
@@ -23,11 +23,23 @@ from pydantic import ValidationError
 
 from fire.starlark import file_io_common, markdown_common, path_common
 from fire.starlark.pydantic_tools import format_validation_errors  # type: ignore
-from fire.starlark.requirement_models import RequirementMetadata
+from fire.starlark.requirement_models import (
+    RequirementMetadata,
+    RegulatoryRequirementMetadata,
+)
+
+_REGREQ_EXTENSION: Final = ".regreq.md"
 
 _BARE_TODO_RE: Final = re.compile(r"TODO(?!\([A-Z]+-[0-9]+\))")
 _METADATA_CONTINUATION_MARKER: Final = "|"
 _METADATA_FIELD_SEPARATOR: Final = "|"
+
+
+def _metadata_model_for_file(file_path: str) -> type[RequirementMetadata]:
+    """Return the Pydantic model class appropriate for the file extension."""
+    if file_path.endswith(_REGREQ_EXTENSION):
+        return RegulatoryRequirementMetadata
+    return RequirementMetadata
 
 
 def validate_no_bare_todos(content: str, file_path: str) -> list[str]:
@@ -179,30 +191,28 @@ def _parse_metadata_fields(metadata_line: str, req_id: str) -> dict:
     return frontmatter
 
 
-def parse_inline_metadata_for_requirement(content, req_id):
+def parse_inline_metadata_for_requirement(
+    content, req_id, model_class=RequirementMetadata
+):
     """Parse inline metadata for a specific requirement ID.
 
     Looks for ## REQ-ID heading followed by a line with pipe-separated fields.
     Format: Key1: value1 | Key2: value2 | Key3: [link](url)
     Returns tuple of (RequirementMetadata | None, ValidationError | None).
     """
-    # Find the requirement heading
     lines = content.split("\n")
     heading_index = _find_requirement_heading_index(lines, req_id)
     if heading_index is None:
         return None, None
 
-    # Extract the metadata line following the heading
     metadata_line = _extract_next_metadata_line(lines, heading_index)
     if not metadata_line:
         return None, None
 
-    # Parse the metadata fields into a dictionary
     frontmatter = _parse_metadata_fields(metadata_line, req_id)
 
-    # Validate with Pydantic
     try:
-        metadata = RequirementMetadata.model_validate(frontmatter)
+        metadata = model_class.model_validate(frontmatter)
         return metadata, None
     except ValidationError as e:
         return None, e
@@ -334,10 +344,10 @@ def validate_requirement_reference(
 
     # Check that filename has valid extension
     filename = os.path.basename(path_without_fragment)
-    if not (filename.endswith(".md") or filename.endswith(".sysreq.md")):
+    if not filename.endswith(".md"):
         return (
             False,
-            f"Requirement file must have .md or .sysreq.md extension: {filename}",
+            f"Requirement file must have .md extension: {filename}",
         )
 
     # Convert to absolute path
@@ -352,8 +362,10 @@ def validate_requirement_reference(
     if error:
         return False, error
 
-    # Parse inline metadata (pipe-separated format)
-    metadata, validation_error = parse_inline_metadata_for_requirement(content, req_id)
+    model_class = _metadata_model_for_file(path_without_fragment)
+    metadata, validation_error = parse_inline_metadata_for_requirement(
+        content, req_id, model_class
+    )
 
     if metadata is None:
         if validation_error:
@@ -405,8 +417,9 @@ def validate_requirement_file(file_path, workspace_root, allowed_deps=None):
     req_id_pattern = r"^## ([A-Z][A-Z0-9_-]+)\s*$"
     for match in re.finditer(req_id_pattern, content, re.MULTILINE):
         req_id = match.group(1)
+        model_class = _metadata_model_for_file(file_path)
         metadata, validation_error = parse_inline_metadata_for_requirement(
-            content, req_id
+            content, req_id, model_class
         )
 
         if metadata is None:

--- a/fire/starlark/validate_requirements_metadata_test.py
+++ b/fire/starlark/validate_requirements_metadata_test.py
@@ -6,7 +6,10 @@ import sys
 import pytest
 from pydantic import ValidationError
 
-from fire.starlark.requirement_models import RequirementMetadata
+from fire.starlark.requirement_models import (
+    RegulatoryRequirementMetadata,
+    RequirementMetadata,
+)
 from fire.starlark.validate_cross_references import (
     parse_inline_metadata_for_requirement,
 )
@@ -797,6 +800,131 @@ Body text.
     # Missing trailing pipe on first Parent line stops continuation
     assert len(metadata.parent) == 1
     assert metadata.parent[0] == "[REQ-A](/p1.md#REQ-A)"
+
+
+# --- Regulatory requirement metadata tests ---
+
+
+def test_regulatory_version_only():
+    """Regulatory requirements need only version."""
+    metadata = RegulatoryRequirementMetadata(id="REQ-REG-001", version=1)
+    assert metadata.version == 1
+    assert metadata.sil is None
+    assert metadata.sec is None
+
+
+def test_regulatory_with_sil():
+    """Regulatory requirements may optionally include sil."""
+    metadata = RegulatoryRequirementMetadata(id="REQ-REG-002", sil="ASIL-B", version=1)
+    assert metadata.sil == "ASIL-B"
+    assert metadata.sec is None
+
+
+def test_regulatory_with_sec():
+    """Regulatory requirements may optionally include sec."""
+    metadata = RegulatoryRequirementMetadata(id="REQ-REG-003", sec=True, version=1)
+    assert metadata.sil is None
+    assert metadata.sec is True
+
+
+def test_regulatory_with_all_fields():
+    """Regulatory requirements accept all fields."""
+    metadata = RegulatoryRequirementMetadata(
+        id="REQ-REG-004", sil="SIL-2", sec=False, version=3
+    )
+    assert metadata.sil == "SIL-2"
+    assert metadata.sec is False
+    assert metadata.version == 3
+
+
+def test_regulatory_version_still_required():
+    """Version is still mandatory for regulatory requirements."""
+    with pytest.raises(ValidationError):
+        RegulatoryRequirementMetadata(id="REQ-REG-005")
+
+
+def test_regulatory_invalid_sil_rejected():
+    """Invalid sil values are still rejected when provided."""
+    with pytest.raises(ValidationError):
+        RegulatoryRequirementMetadata(id="REQ-REG-006", sil="INVALID", version=1)
+
+
+def test_regulatory_invalid_sec_rejected():
+    """Invalid sec values are still rejected when provided."""
+    with pytest.raises(ValidationError):
+        RegulatoryRequirementMetadata(id="REQ-REG-007", sec="true", version=1)
+
+
+def test_regulatory_todo_sil():
+    """TODO(KEY-1234) is accepted for optional sil on regreq."""
+    metadata = RegulatoryRequirementMetadata(
+        id="REQ-REG-009", sil="TODO(JIRA-100)", version=1
+    )
+    assert metadata.sil == "TODO(JIRA-100)"
+
+
+def test_regulatory_parent_optional():
+    """Parent is optional for regulatory requirements."""
+    metadata = RegulatoryRequirementMetadata(
+        id="REQ-REG-008",
+        version=1,
+        parent=["[REQ-A](/path.md#REQ-A)"],
+    )
+    assert len(metadata.parent) == 1
+
+
+def test_parse_regulatory_version_only():
+    """Test parsing regreq metadata with only version."""
+    content = """
+## REQ-REG-001
+Version: 1
+
+Some regulatory text.
+---
+"""
+    metadata, error = parse_inline_metadata_for_requirement(
+        content, "REQ-REG-001", RegulatoryRequirementMetadata
+    )
+    assert error is None
+    assert metadata is not None
+    assert metadata.version == 1
+    assert metadata.sil is None
+    assert metadata.sec is None
+
+
+def test_parse_regulatory_with_sil_and_sec():
+    """Test parsing regreq metadata with optional sil and sec."""
+    content = """
+## REQ-REG-002
+SIL: ASIL-B | Sec: false | Version: 2
+
+Some regulatory text.
+---
+"""
+    metadata, error = parse_inline_metadata_for_requirement(
+        content, "REQ-REG-002", RegulatoryRequirementMetadata
+    )
+    assert error is None
+    assert metadata is not None
+    assert metadata.sil == "ASIL-B"
+    assert metadata.sec is False
+    assert metadata.version == 2
+
+
+def test_parse_sysreq_still_requires_sil_sec():
+    """Parsing with RequirementMetadata still requires sil and sec."""
+    content = """
+## REQ-001
+Version: 1
+
+Some text.
+---
+"""
+    metadata, error = parse_inline_metadata_for_requirement(
+        content, "REQ-001", RequirementMetadata
+    )
+    assert metadata is None
+    assert error is not None
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Add support for `.regreq.md` regulatory requirement files where `SIL` and `Sec` fields are optional. Only `Version` remains mandatory. Closes #218.

## Implementation Summary

- `RegulatoryRequirementMetadata` inherits from `RequirementMetadata`, overriding `sil` and `sec` to `Optional` with `None` default. Validators are inherited and handle `None` via early return.
- `validate_cross_references.py` selects the model class based on file extension via `_metadata_model_for_file()`.
- `parse_inline_metadata_for_requirement()` accepts an optional `model_class` parameter (defaults to `RequirementMetadata` for backward compatibility).
- `FORMAT_SPECIFICATION.md` documents the new `.regreq.md` type.

## Testing

- 12 new unit tests for the model and parsing: version-only, optional sil/sec, validation of invalid values, parsing with model class parameter.
- All 21 existing tests pass unchanged.
- Verified with `--config=typecheck`.