### PR TITLE
Add BCR publish workflow

### DIFF
--- a/.github/workflows/bcr-publish.yaml
+++ b/.github/workflows/bcr-publish.yaml
@@ -1,0 +1,141 @@
+name: Publish to BCR
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag (e.g., v0.5.0)"
+        required: true
+        type: string
+
+jobs:
+  publish-to-bcr:
+    name: Create BCR Pull Request
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout fire repo
+        uses: actions/checkout@v4
+
+      - name: Determine version
+        id: version
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            TAG="${{ inputs.tag }}"
+          else
+            TAG="${{ github.event.release.tag_name }}"
+          fi
+          # Strip v prefix
+          VERSION="${TAG#v}"
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Publishing fire $VERSION (tag: $TAG)"
+
+      - name: Download release tarball and compute integrity
+        id: integrity
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          TAG="${{ steps.version.outputs.tag }}"
+          URL="https://github.com/nesono/fire/releases/download/${TAG}/fire-${VERSION}.tar.gz"
+
+          echo "Downloading $URL ..."
+          curl -fsSL -o "fire-${VERSION}.tar.gz" "$URL"
+
+          # Compute SRI integrity hash (sha256 in base64)
+          HASH=$(sha256sum "fire-${VERSION}.tar.gz" | cut -d' ' -f1 | xxd -r -p | base64 -w0)
+          INTEGRITY="sha256-${HASH}"
+
+          echo "integrity=$INTEGRITY" >> "$GITHUB_OUTPUT"
+          echo "url=$URL" >> "$GITHUB_OUTPUT"
+          echo "Integrity: $INTEGRITY"
+
+      - name: Extract MODULE.bazel from tarball
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          tar xzf "fire-${VERSION}.tar.gz" "fire-${VERSION}/MODULE.bazel" --strip-components=1
+
+          # Remove local_path_override blocks (not valid for BCR)
+          python3 -c "
+          import re
+          with open('MODULE.bazel') as f:
+              content = f.read()
+          # Remove local_path_override(...) blocks
+          content = re.sub(r'local_path_override\([^)]*\)\n*', '', content)
+          # Remove trailing whitespace/newlines
+          content = content.rstrip() + '\n'
+          with open('MODULE.bazel.clean', 'w') as f:
+              f.write(content)
+          "
+
+      - name: Clone BCR fork and create branch
+        env:
+          BCR_PUBLISH_TOKEN: ${{ secrets.BCR_PUBLISH_TOKEN }}
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          BRANCH="fire-${VERSION}"
+
+          git clone "https://x-access-token:${BCR_PUBLISH_TOKEN}@github.com/nesono/bazel-central-registry.git" bcr
+          cd bcr
+          git checkout -b "$BRANCH"
+
+      - name: Add version files to BCR
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          VERSION_DIR="bcr/modules/fire/${VERSION}"
+          mkdir -p "$VERSION_DIR"
+
+          # source.json
+          python3 -c "
+          import json
+          data = {
+              'url': '${{ steps.integrity.outputs.url }}',
+              'integrity': '${{ steps.integrity.outputs.integrity }}',
+              'strip_prefix': 'fire-${VERSION}',
+          }
+          with open('${VERSION_DIR}/source.json', 'w') as f:
+              json.dump(data, f, indent=4)
+              f.write('\n')
+          "
+
+          # MODULE.bazel
+          cp MODULE.bazel.clean "$VERSION_DIR/MODULE.bazel"
+
+          # presubmit.yml
+          cp .bcr/presubmit.yml "$VERSION_DIR/presubmit.yml"
+
+          # Update metadata.json — append the new version
+          python3 -c "
+          import json
+          with open('bcr/modules/fire/metadata.json') as f:
+              meta = json.load(f)
+          if '${VERSION}' not in meta['versions']:
+              meta['versions'].append('${VERSION}')
+          with open('bcr/modules/fire/metadata.json', 'w') as f:
+              json.dump(meta, f, indent=4)
+              f.write('\n')
+          "
+
+      - name: Commit and push
+        env:
+          BCR_PUBLISH_TOKEN: ${{ secrets.BCR_PUBLISH_TOKEN }}
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          cd bcr
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add modules/fire/
+          git commit -m "Add fire ${VERSION}"
+          git push origin "fire-${VERSION}"
+
+      - name: Create pull request on BCR fork
+        env:
+          GH_TOKEN: ${{ secrets.BCR_PUBLISH_TOKEN }}
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          gh pr create \
+            --repo nesono/bazel-central-registry \
+            --base main \
+            --head "fire-${VERSION}" \
+            --title "Add fire ${VERSION}" \
+            --body "Automated BCR entry for [fire ${VERSION}](https://github.com/nesono/fire/releases/tag/v${VERSION})."

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -2,9 +2,6 @@
 
 1. Change the version field in MODULE.bazel, README.md, and integration_test/MODULE.bazel.template
 2. Update the `compatibility_level` in MODULE.bazel, if required
-3. Create a new GitHub release and upload FORMAT_SPECIFICATION.md as a downloadable asset
-4. Go into `bazel-central-registry.git`
-5. Run `bazel run //tools:add_module` and answer all questions
-6. Run `bazel run //tools:update_integrity` if you changed archive contents
-7. Test setup using `bazel run -- //tools:bcr_validation --check=fire@0.2.1`
-8. Run pre-submit tests using `bazel run //tools:setup_presubmit_repos -- --module fire@0.2.1`
+3. Create a new GitHub release — the `release.yaml` workflow uploads the tarball and FORMAT_SPECIFICATION.md automatically
+4. The `bcr-publish.yaml` workflow automatically creates a PR on `nesono/bazel-central-registry` with the new version
+5. Review and merge the BCR PR


### PR DESCRIPTION
## Summary

- Add `.github/workflows/bcr-publish.yaml` that automates publishing to the Bazel Central Registry
- Triggers on release creation or manual dispatch with a tag input
- Creates a branch and PR on `nesono/bazel-central-registry` with the version files (`source.json`, `MODULE.bazel`, `presubmit.yml`) and updated `metadata.json`
- Uses the `BCR_PUBLISH_TOKEN` secret for authentication

Replaces the manual steps 4-7 in PUBLISHING.md.

## Test plan

- [ ] Merge and create a test release to verify the workflow end-to-end
- [ ] Verify the created PR on `nesono/bazel-central-registry` has correct files

🤖 Generated with [Claude Code](https://claude.com/claude-code)