### PR TITLE
Remove FORMAT_SPECIFICATION.md from release artifacts

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,8 +11,8 @@ on:
         type: string
 
 jobs:
-  upload-format-spec:
-    name: Upload Format Specification
+  upload-tarball:
+    name: Upload Source Tarball
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -29,10 +29,6 @@ jobs:
             echo "version=${{ github.event.release.tag_name }}" >> $GITHUB_OUTPUT
           fi
 
-      - name: Update FORMAT_SPECIFICATION.md version
-        run: |
-          sed -i "s/^\*\*Version:\*\* main$/\*\*Version:\*\* ${{ steps.get_version.outputs.version }}/" FORMAT_SPECIFICATION.md
-
       - name: Create deterministic source tarball
         run: |
           VERSION=${{ steps.get_version.outputs.version }}
@@ -47,6 +43,5 @@ jobs:
           VERSION=${{ steps.get_version.outputs.version }}
           VERSION_NUM=${VERSION#v}
           gh release upload ${{ steps.get_version.outputs.version }} \
-            FORMAT_SPECIFICATION.md \
             fire-${VERSION_NUM}.tar.gz \
             --clobber

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -2,6 +2,6 @@
 
 1. Change the version field in MODULE.bazel, README.md, and integration_test/MODULE.bazel.template
 2. Update the `compatibility_level` in MODULE.bazel, if required
-3. Create a new GitHub release — the `release.yaml` workflow uploads the tarball and FORMAT_SPECIFICATION.md automatically
+3. Create a new GitHub release — the `release.yaml` workflow uploads the source tarball automatically
 4. The `bcr-publish.yaml` workflow automatically creates a PR on `nesono/bazel-central-registry` with the new version
 5. Review and merge the BCR PR


### PR DESCRIPTION
## Summary

Closes #228

- Remove FORMAT_SPECIFICATION.md upload from `release.yaml` workflow
- Remove the version-stamping step that was only needed for the published spec
- Update PUBLISHING.md to reflect the change
- Rename job from `upload-format-spec` to `upload-tarball`

The format specification is now generated at consumption time via
`generate_format_specification()`, so publishing it as a static release
asset is no longer needed.

## Test plan

- [ ] Verify next release only uploads the source tarball

🤖 Generated with [Claude Code](https://claude.com/claude-code)