### PR TITLE
Modernize typing imports to Python 3.10+ syntax

### DIFF
--- a/fire/starlark/config_models.py
+++ b/fire/starlark/config_models.py
@@ -9,7 +9,7 @@ Consumers supply a fire_config.yaml; when absent, the built-in default
 from __future__ import annotations
 
 from pathlib import Path
-from typing import List, Literal, Optional
+from typing import Literal
 
 import yaml
 from pydantic import BaseModel, Field, field_validator, model_validator
@@ -23,10 +23,10 @@ class FieldDefinition(BaseModel):
     description: str = ""
 
     # enum-specific
-    values: Optional[List[str]] = None
+    values: list[str] | None = None
 
     # int-specific
-    min_value: Optional[int] = None
+    min_value: int | None = None
 
     # todo support
     allow_todo: bool = False
@@ -53,8 +53,8 @@ class DocumentTypeDefinition(BaseModel):
     suffix: str
     display_name: str
     description: str = ""
-    required_fields: List[str] = Field(default_factory=list)
-    optional_fields: List[str] = Field(default_factory=list)
+    required_fields: list[str] = Field(default_factory=list)
+    optional_fields: list[str] = Field(default_factory=list)
 
     @field_validator("suffix")
     @classmethod

--- a/fire/starlark/dynamic_requirement_model.py
+++ b/fire/starlark/dynamic_requirement_model.py
@@ -10,7 +10,6 @@ that FIRE shipped before the configuration system was introduced.
 from __future__ import annotations
 
 import re
-from typing import List, Optional, Union
 
 from pydantic import BaseModel, Field, field_validator
 
@@ -98,28 +97,28 @@ def _build_parent_link_validator(
 def _annotation_for_field(field_def: FieldDefinition, *, required: bool) -> type:
     """Return the Python type annotation for a field definition."""
     if field_def.type == "enum":
-        base = Union[str, str]  # enum values are strings; TODO is also a string
+        base = str  # enum values are strings; TODO is also a string
         if field_def.allow_todo:
             base = str
         else:
             base = str
     elif field_def.type == "bool":
         if field_def.allow_todo:
-            base = Union[bool, str]
+            base = bool | str
         else:
             base = bool
     elif field_def.type == "int":
         base = int
     elif field_def.type == "parent_link":
         if field_def.allow_multiple:
-            base = Optional[List[str]]
+            base = list[str] | None
         else:
-            base = Optional[List[str]]
+            base = list[str] | None
     else:
         base = str
 
     if not required and field_def.type != "parent_link":
-        base = Optional[base]
+        base = base | None
 
     return base
 

--- a/fire/starlark/parameter_models.py
+++ b/fire/starlark/parameter_models.py
@@ -5,8 +5,10 @@ This module defines the Pydantic models that replace the JSON schema
 for validating parameter YAML files.
 """
 
+from __future__ import annotations
+
 from collections import defaultdict
-from typing import Any, Dict, List, Literal, Union
+from typing import Any, Literal
 
 from pydantic import (
     BaseModel,
@@ -46,7 +48,7 @@ def infer_type_from_value(value: Any) -> str:
         raise ValueError(f"Cannot infer type from {type(value).__name__}")
 
 
-def infer_parameter_type(data: Dict[str, Any]) -> str:
+def infer_parameter_type(data: dict[str, Any]) -> str:
     """Infer parameter type for a parameter.
 
     Args:
@@ -138,23 +140,19 @@ class TableParameter(AllParamBase):
     """Table parameter with columns and rows."""
 
     type: Literal["table"]
-    columns: List[Column] = Field(min_length=1)
-    rows: List[List[Any]] = Field(min_length=1)
+    columns: list[Column] = Field(min_length=1)
+    rows: list[list[Any]] = Field(min_length=1)
 
     model_config = {"extra": "forbid"}
 
 
 # Union of all parameter types (type field injected by ParameterFile validator)
-Parameter = Union[
-    I64Parameter,
-    F64Parameter,
-    StringParameter,
-    BoolParameter,
-    TableParameter,
-]
+Parameter = (
+    I64Parameter | F64Parameter | StringParameter | BoolParameter | TableParameter
+)
 
 
-def _reject_explicit_type_fieds_in_columns(param_name: str, columns: List[Any]):
+def _reject_explicit_type_fieds_in_columns(param_name: str, columns: list[Any]):
     """Asserting no explicit types are set in table columns."""
     for i, col in enumerate(columns):
         if isinstance(col, dict) and "type" in col:
@@ -167,7 +165,7 @@ def _reject_explicit_type_fieds_in_columns(param_name: str, columns: List[Any]):
 
 
 def _reject_inconsistent_types_in_table(
-    param_name: str, rows: List[Any], columns: List[Any]
+    param_name: str, rows: list[Any], columns: list[Any]
 ):
     """Assert all values in the table are of a consistent type per column."""
     # Infer types from first row and inject into columns
@@ -189,10 +187,10 @@ def _reject_inconsistent_types_in_table(
                 )
 
 
-class ParameterFile(RootModel[Dict[str, Parameter]]):
+class ParameterFile(RootModel[dict[str, Parameter]]):
     """Root model for parameter YAML files."""
 
-    root: Dict[str, Parameter] = Field(min_length=1)
+    root: dict[str, Parameter] = Field(min_length=1)
 
     @model_validator(mode="before")
     @classmethod
@@ -233,7 +231,7 @@ class ParameterFile(RootModel[Dict[str, Parameter]]):
     @model_validator(mode="after")
     def validate_version_suffixes(self):
         """Validate that all parameter keys use _vN suffix and versions are consecutive."""
-        groups: Dict[str, Dict[int, str]] = defaultdict(dict)
+        groups: dict[str, dict[int, str]] = defaultdict(dict)
 
         for key in self.root:
             m = PARAM_VERSION_SUFFIX_RE.match(key)

--- a/fire/starlark/requirement_models.py
+++ b/fire/starlark/requirement_models.py
@@ -1,8 +1,10 @@
 #!/usr/bin/env python3
 """Pydantic models for requirement metadata validation."""
 
+from __future__ import annotations
+
 import re
-from typing import Literal, Optional, Union, Final, List
+from typing import Final, Literal
 
 from pydantic import BaseModel, Field, field_validator
 
@@ -49,13 +51,13 @@ class RequirementMetadata(BaseModel):
 
     id: str = Field(pattern=REQ_ID_PATTERN.pattern)
 
-    sil: Union[SilValue, str]
+    sil: SilValue | str
 
-    sec: Union[bool, str]
+    sec: bool | str
 
     version: int = Field(ge=1, strict=True)
 
-    parent: Optional[List[str]] = None
+    parent: list[str] | None = None
 
     model_config = {"extra": "forbid"}
 
@@ -91,7 +93,7 @@ class RequirementMetadata(BaseModel):
 
     @field_validator("parent")
     @classmethod
-    def validate_parent_format(cls, v: Optional[List[str]]) -> Optional[List[str]]:
+    def validate_parent_format(cls, v: list[str] | None) -> list[str] | None:
         """Validate parent is a list of markdown links, TODO(KEY-1234), or None."""
         if v is None:
             return v
@@ -132,6 +134,6 @@ class RegulatoryRequirementMetadata(RequirementMetadata):
     Unlike sysreq/swreq, sil and sec are optional for regulatory requirements.
     """
 
-    sil: Optional[Union[SilValue, str]] = None
+    sil: SilValue | str | None = None
 
-    sec: Optional[Union[bool, str]] = None
+    sec: bool | str | None = None


### PR DESCRIPTION
## Summary
- Replace \`List\`, \`Dict\`, \`Optional\`, \`Union\` from \`typing\` with built-in equivalents
- Add \`from __future__ import annotations\` where missing
- Files updated: \`config_models.py\`, \`dynamic_requirement_model.py\`, \`requirement_models.py\`, \`parameter_models.py\`
- Minimum Python version is 3.10, so modern syntax is safe

## Test plan
- [ ] All existing tests pass (\`bazel test //...\`)
- [ ] Integration tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)