### PR TITLE
Consolidate parent-link validation in markdown_common

### DIFF
--- a/fire/starlark/BUILD.bazel
+++ b/fire/starlark/BUILD.bazel
@@ -69,6 +69,7 @@ py_library(
 py_library(
     name = "markdown_common",
     srcs = ["markdown_common.py"],
+    deps = [":patterns"],
 )
 
 # Shared regex patterns

--- a/fire/starlark/dynamic_requirement_model.py
+++ b/fire/starlark/dynamic_requirement_model.py
@@ -9,7 +9,6 @@ that FIRE shipped before the configuration system was introduced.
 
 from __future__ import annotations
 
-import re
 from typing import List, Optional, Union
 
 from pydantic import BaseModel, Field, field_validator
@@ -59,25 +58,6 @@ def _build_bool_validator(field_name: str, field_def: FieldDefinition) -> classm
     return field_validator(field_name, mode="before")(classmethod(_validate))
 
 
-def _validate_single_parent(parent_value: str) -> None:
-    """Validate a single parent entry (shared by all parent_link fields)."""
-    if not isinstance(parent_value, str):
-        raise ValueError("each parent entry must be a string")
-    if TODO_PATTERN.fullmatch(parent_value):
-        return
-    match = re.match(markdown_common.MARKDOWN_LINK_PATTERN, parent_value)
-    if not match:
-        raise ValueError(
-            "parent must be a markdown link: [REQ-ID](/path.md?version=N#REQ-ID)"
-        )
-    path = match.group(2)
-    base_path = path.split("#")[0].split("?")[0]
-    if not base_path.startswith("/"):
-        raise ValueError(
-            f"parent path must be repository-relative (start with /): '{path}'"
-        )
-
-
 def _build_parent_link_validator(
     field_name: str, field_def: FieldDefinition
 ) -> classmethod:
@@ -89,7 +69,7 @@ def _build_parent_link_validator(
         if not isinstance(v, list):
             raise ValueError(f"{field_name} must be a list")
         for entry in v:
-            _validate_single_parent(entry)
+            markdown_common.validate_parent_link(entry)
         return v
 
     return field_validator(field_name, mode="before")(classmethod(_validate))

--- a/fire/starlark/markdown_common.py
+++ b/fire/starlark/markdown_common.py
@@ -7,10 +7,42 @@ markdown references used in requirements documents.
 import re
 from typing import Final
 
+from fire.starlark.patterns import TODO_PATTERN
+
 # Regex patterns for markdown reference parsing
 MARKDOWN_LINK_PATTERN: Final = r"\[([^\]]+)\]\(([^\)]+)\)"
 PARAM_REFERENCE_PATTERN: Final = r"\[@([a-zA-Z_][a-zA-Z0-9_]*)\]\(([^)]+)\)"
 REQUIREMENT_REFERENCE_PATTERN: Final = r"\[([A-Z][A-Z0-9_-]+)\]\(([^)]+\.md[^)]*)\)"
+
+
+def validate_parent_link(parent_value: object) -> None:
+    """Validate a single parent-link value.
+
+    A parent link must be either a TODO marker (e.g. ``TODO(KEY-1234)``) or
+    a markdown link of the form ``[REQ-ID](/path.md?version=N#REQ-ID)`` with
+    a repository-relative path (starting with ``/``).
+
+    Args:
+        parent_value: The value to validate.
+
+    Raises:
+        ValueError: If the value is not a valid parent link.
+    """
+    if not isinstance(parent_value, str):
+        raise ValueError("each parent entry must be a string")
+    if TODO_PATTERN.fullmatch(parent_value):
+        return
+    match = re.match(MARKDOWN_LINK_PATTERN, parent_value)
+    if not match:
+        raise ValueError(
+            "parent must be a markdown link: [REQ-ID](/path.md?version=N#REQ-ID)"
+        )
+    path = match.group(2)
+    base_path = path.split("#")[0].split("?")[0]
+    if not base_path.startswith("/"):
+        raise ValueError(
+            f"parent path must be repository-relative (start with /): '{path}'"
+        )
 
 
 def extract_markdown_links(text: str) -> list[tuple[str, str]]:

--- a/fire/starlark/requirement_models.py
+++ b/fire/starlark/requirement_models.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 """Pydantic models for requirement metadata validation."""
 
-import re
 from typing import Literal, Optional, Union, Final, List
 
 from pydantic import BaseModel, Field, field_validator
@@ -98,32 +97,8 @@ class RequirementMetadata(BaseModel):
         if not isinstance(v, list):
             raise ValueError("parent must be a list")
         for parent_value in v:
-            cls._validate_single_parent(parent_value)
+            markdown_common.validate_parent_link(parent_value)
         return v
-
-    @classmethod
-    def _validate_single_parent(cls, parent_value: str) -> None:
-        """Validate a single parent entry."""
-        if not isinstance(parent_value, str):
-            raise ValueError("each parent entry must be a string")
-        if TODO_PATTERN.fullmatch(parent_value):
-            return
-        cls._validate_parent_markdown_link(parent_value)
-
-    @classmethod
-    def _validate_parent_markdown_link(cls, parent_value: str) -> None:
-        """Validate parent is a proper markdown link with repository-relative path."""
-        match = re.match(markdown_common.MARKDOWN_LINK_PATTERN, parent_value)
-        if not match:
-            raise ValueError(
-                "parent must be a markdown link: [REQ-ID](/path.md?version=N#REQ-ID)"
-            )
-        path = match.group(2)
-        base_path = path.split("#")[0].split("?")[0]
-        if not base_path.startswith("/"):
-            raise ValueError(
-                f"parent path must be repository-relative (start with /): '{path}'"
-            )
 
 
 class RegulatoryRequirementMetadata(RequirementMetadata):


### PR DESCRIPTION
Closes #242

## Summary
- Add `validate_parent_link()` to `markdown_common.py` as the single source of truth.
- Replace the duplicated `_validate_single_parent()` in `dynamic_requirement_model.py`.
- Replace the duplicated `_validate_single_parent()` / `_validate_parent_markdown_link()` methods in `requirement_models.py`.
- Add `:patterns` as a dep of `:markdown_common` in `BUILD.bazel`.
- Remove now-unused `import re` from both call sites.

Stacked on top of #256.

## Test plan
- `bazel test //fire/starlark:all` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)