### PR TITLE
Use file_io_common for YAML/JSON loading

### DIFF
--- a/fire/starlark/BUILD.bazel
+++ b/fire/starlark/BUILD.bazel
@@ -170,8 +170,8 @@ py_library(
     data = ["default_fire_config.yaml"],
     visibility = ["//visibility:public"],
     deps = [
+        ":file_io_common",
         "@pip//pydantic",
-        "@pip//pyyaml",
     ],
 )
 
@@ -260,11 +260,11 @@ py_library(
     visibility = ["//visibility:public"],
     deps = [
         ":config_models",
+        ":file_io_common",
         ":markdown_common",
         ":path_common",
         ":patterns",
         ":validate_cross_references_lib",
-        "@pip//pyyaml",
     ],
 )
 

--- a/fire/starlark/config_models.py
+++ b/fire/starlark/config_models.py
@@ -11,8 +11,9 @@ from __future__ import annotations
 from pathlib import Path
 from typing import List, Literal, Optional
 
-import yaml
 from pydantic import BaseModel, Field, field_validator, model_validator
+
+from fire.starlark import file_io_common
 
 
 class FieldDefinition(BaseModel):
@@ -107,7 +108,8 @@ def load_config(config_path: str | Path | None = None) -> FireConfig:
     else:
         config_path = Path(config_path)
 
-    with open(config_path) as f:
-        raw = yaml.safe_load(f)
+    raw, error = file_io_common.load_yaml_safe(str(config_path))
+    if error:
+        raise OSError(error)
 
     return FireConfig.model_validate(raw)

--- a/fire/starlark/file_io_common.py
+++ b/fire/starlark/file_io_common.py
@@ -1,9 +1,10 @@
 """Common file I/O utilities for Fire requirements management system.
 
-This module provides safe file reading and YAML loading with consistent
+This module provides safe file reading and YAML/JSON loading with consistent
 error handling.
 """
 
+import json
 from typing import Any
 
 import yaml
@@ -68,6 +69,37 @@ def load_yaml_safe(file_path: str) -> tuple[Any | None, str | None]:
         return None, f"Permission denied: {file_path}"
     except Exception as e:
         return None, f"Error loading YAML from {file_path}: {e}"
+
+
+def load_json_safe(file_path: str) -> tuple[Any | None, str | None]:
+    """Safely load JSON file with consistent error handling.
+
+    Args:
+        file_path: Path to JSON file to load
+
+    Returns:
+        Tuple of (data, error_msg) where:
+        - data: Parsed JSON data if successful, None otherwise
+        - error_msg: Error message if failed, None otherwise
+
+    Example:
+        >>> data, error = load_json_safe("trace.json")
+        >>> if error:
+        ...     print(f"Failed: {error}")
+        ... else:
+        ...     process(data)
+    """
+    try:
+        with open(file_path) as f:
+            return json.load(f), None
+    except FileNotFoundError:
+        return None, f"File not found: {file_path}"
+    except json.JSONDecodeError as e:
+        return None, f"Invalid JSON syntax in {file_path}: {e}"
+    except PermissionError:
+        return None, f"Permission denied: {file_path}"
+    except Exception as e:
+        return None, f"Error loading JSON from {file_path}: {e}"
 
 
 def write_yaml_safe(file_path: str, data: Any) -> str | None:

--- a/fire/starlark/release_report.py
+++ b/fire/starlark/release_report.py
@@ -6,9 +6,12 @@ from __future__ import annotations
 import re
 from typing import Final
 
-import yaml
-
-from fire.starlark import markdown_common, path_common, validate_cross_references
+from fire.starlark import (
+    file_io_common,
+    markdown_common,
+    path_common,
+    validate_cross_references,
+)
 from fire.starlark.config_models import FireConfig, load_config
 from fire.starlark.patterns import PARAM_VERSION_SUFFIX_RE, REQ_ID_PATTERN, TODO_PATTERN
 
@@ -17,17 +20,18 @@ _VALID_TRACE_TYPES: Final = {"impl", "verif"}
 
 def load_yaml_file(path: str) -> object:
     """Load YAML from disk and normalize empty files to an empty list."""
-    with open(path) as handle:
-        data = yaml.safe_load(handle)
+    data, error = file_io_common.load_yaml_safe(path)
+    if error:
+        raise OSError(error)
     return data if data is not None else []
 
 
 def load_json_file(path: str) -> object:
     """Load JSON from disk."""
-    import json
-
-    with open(path) as handle:
-        return json.load(handle)
+    data, error = file_io_common.load_json_safe(path)
+    if error:
+        raise OSError(error)
+    return data
 
 
 def _ensure_list_of_dicts(data: object, source: str) -> list[dict]:


### PR DESCRIPTION
Closes #243

## Summary
- Add `load_json_safe()` to `file_io_common.py` to mirror `load_yaml_safe()`.
- Replace the raw `open()` + `yaml.safe_load()` in `config_models.load_config()` with `file_io_common.load_yaml_safe()`, raising `OSError` on failure.
- Replace the raw `open()` + `yaml.safe_load()` / `json.load()` in `release_report.load_yaml_file()` and `load_json_file()` with the new safe loaders.
- Update `BUILD.bazel` deps: `config_models` and `release_report` now depend on `file_io_common`; drop unused `pyyaml` deps.

Stacked on top of #257.

## Test plan
- `bazel test //fire/starlark:all` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)