### PR TITLE
Share test fixtures via conftest.py

### DIFF
--- a/fire/starlark/BUILD.bazel
+++ b/fire/starlark/BUILD.bazel
@@ -202,7 +202,10 @@ py_library(
 py_test(
     name = "dynamic_requirement_model_test",
     size = "small",
-    srcs = ["dynamic_requirement_model_test.py"],
+    srcs = [
+        "conftest.py",
+        "dynamic_requirement_model_test.py",
+    ],
     deps = [
         ":config_models",
         ":dynamic_requirement_model",
@@ -231,7 +234,10 @@ py_binary(
 py_test(
     name = "generate_format_spec_test",
     size = "small",
-    srcs = ["generate_format_spec_test.py"],
+    srcs = [
+        "conftest.py",
+        "generate_format_spec_test.py",
+    ],
     deps = [
         ":config_models",
         ":generate_format_spec_lib",

--- a/fire/starlark/conftest.py
+++ b/fire/starlark/conftest.py
@@ -1,0 +1,11 @@
+"""Shared pytest fixtures for fire/starlark tests."""
+
+import pytest
+
+from fire.starlark.config_models import load_config
+
+
+@pytest.fixture()
+def default_config():
+    """Return the built-in default FIRE config."""
+    return load_config()

--- a/fire/starlark/dynamic_requirement_model_test.py
+++ b/fire/starlark/dynamic_requirement_model_test.py
@@ -4,7 +4,6 @@
 import pytest
 from pydantic import ValidationError
 
-from fire.starlark.config_models import load_config
 from fire.starlark.dynamic_requirement_model import (
     build_models_from_config,
     model_for_suffix,
@@ -16,13 +15,8 @@ from fire.starlark.requirement_models import (
 
 
 @pytest.fixture()
-def config():
-    return load_config()
-
-
-@pytest.fixture()
-def models(config):
-    return build_models_from_config(config)
+def models(default_config):
+    return build_models_from_config(default_config)
 
 
 # ---------------------------------------------------------------------------
@@ -31,21 +25,21 @@ def models(config):
 
 
 class TestBuildModels:
-    def test_builds_all_document_types(self, config, models):
-        assert set(models.keys()) == set(config.document_types.keys())
+    def test_builds_all_document_types(self, default_config, models):
+        assert set(models.keys()) == set(default_config.document_types.keys())
 
-    def test_model_for_suffix_sysreq(self, config, models):
-        m = model_for_suffix(config, models, "some/path/req.sysreq.md")
+    def test_model_for_suffix_sysreq(self, default_config, models):
+        m = model_for_suffix(default_config, models, "some/path/req.sysreq.md")
         assert m is not None
         assert "sysreq" in m.__name__.lower()
 
-    def test_model_for_suffix_regreq(self, config, models):
-        m = model_for_suffix(config, models, "regulations.regreq.md")
+    def test_model_for_suffix_regreq(self, default_config, models):
+        m = model_for_suffix(default_config, models, "regulations.regreq.md")
         assert m is not None
         assert "regreq" in m.__name__.lower()
 
-    def test_model_for_suffix_unknown(self, config, models):
-        assert model_for_suffix(config, models, "notes.txt") is None
+    def test_model_for_suffix_unknown(self, default_config, models):
+        assert model_for_suffix(default_config, models, "notes.txt") is None
 
 
 # ---------------------------------------------------------------------------

--- a/fire/starlark/generate_format_spec_test.py
+++ b/fire/starlark/generate_format_spec_test.py
@@ -1,15 +1,8 @@
 #!/usr/bin/env python3
 """Tests for the format specification generator."""
 
-import pytest
-
-from fire.starlark.config_models import FireConfig, load_config
+from fire.starlark.config_models import FireConfig
 from fire.starlark.generate_format_spec import generate_format_spec
-
-
-@pytest.fixture()
-def default_config():
-    return load_config()
 
 
 class TestGenerateFormatSpec:


### PR DESCRIPTION
Closes #251

## Summary
- Add `fire/starlark/conftest.py` with a shared `default_config` fixture.
- Remove the duplicate `default_config()` fixture from `generate_format_spec_test.py`.
- Replace the local `config()` fixture in `dynamic_requirement_model_test.py` with `default_config` from conftest; rename references inside the file accordingly.
- Update `BUILD.bazel` to include `conftest.py` in the `srcs` of both test targets so pytest finds it under Bazel.

Stacked on top of #258.

## Test plan
- `bazel test //fire/starlark:dynamic_requirement_model_test //fire/starlark:generate_format_spec_test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)