### PR TITLE
Extract metadata_parsing module

### DIFF
--- a/fire/starlark/BUILD.bazel
+++ b/fire/starlark/BUILD.bazel
@@ -118,6 +118,7 @@ py_binary(
         ":dynamic_requirement_model",
         ":file_io_common",
         ":markdown_common",
+        ":metadata_parsing",
         ":path_common",
         ":pydantic_tools",
         ":requirement_models",
@@ -132,11 +133,12 @@ py_binary(
     visibility = ["//visibility:public"],
     deps = [
         ":config_models",
+        ":file_io_common",
         ":markdown_common",
+        ":metadata_parsing",
         ":path_common",
         ":patterns",
         ":validate_cross_references_lib",
-        "@pip//pyyaml",
     ],
 )
 
@@ -268,9 +270,27 @@ py_library(
         ":config_models",
         ":file_io_common",
         ":markdown_common",
+        ":metadata_parsing",
         ":path_common",
         ":patterns",
         ":validate_cross_references_lib",
+    ],
+)
+
+# Common utilities - inline metadata parsing
+py_library(
+    name = "metadata_parsing",
+    srcs = ["metadata_parsing.py"],
+    deps = [":markdown_common"],
+)
+
+py_test(
+    name = "metadata_parsing_test",
+    size = "small",
+    srcs = ["metadata_parsing_test.py"],
+    deps = [
+        ":metadata_parsing",
+        "@pip//pytest",
     ],
 )
 
@@ -284,6 +304,7 @@ py_library(
         ":dynamic_requirement_model",
         ":file_io_common",
         ":markdown_common",
+        ":metadata_parsing",
         ":path_common",
         ":pydantic_tools",
         ":requirement_models",

--- a/fire/starlark/metadata_parsing.py
+++ b/fire/starlark/metadata_parsing.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+"""Parse pipe-separated inline metadata blocks found in requirement files.
+
+Requirement files use a compact one-line (or continuation-line) metadata
+format directly under a ``## REQ-ID`` heading::
+
+    Sil: ASIL-D | Sec: false | Version: 1 | Parent: [REQ-XYZ](/path.md?version=1)
+
+This module isolates the parsing logic so it can be shared by both the
+cross-reference validator and the release-report generator without
+crossing module-private boundaries.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Final
+
+from fire.starlark import markdown_common
+
+_METADATA_CONTINUATION_MARKER: Final = "|"
+_METADATA_FIELD_SEPARATOR: Final = "|"
+_DEFAULT_KNOWN_FIELDS: Final = ("sil", "sec", "version", "parent")
+
+
+def is_metadata_line(line: str, known_fields: list[str]) -> bool:
+    """Return True if *line* looks like an inline metadata line."""
+    if _METADATA_FIELD_SEPARATOR in line:
+        return True
+    if ":" in line and not line.startswith("#"):
+        parts = line.split(":", 1)
+        key = parts[0].strip().lower()
+        return len(parts) == 2 and key in known_fields
+    return False
+
+
+def _should_stop_collection(line: str, collected_lines: list[str]) -> bool:
+    """Return True when metadata collection should stop on *line*."""
+    if not line:
+        return bool(collected_lines)
+    if collected_lines and not collected_lines[-1].endswith(
+        _METADATA_CONTINUATION_MARKER
+    ):
+        return True
+    return False
+
+
+def _join_metadata_lines(lines: list[str]) -> str:
+    """Join metadata lines and strip the final trailing pipe."""
+    joined = " ".join(lines).rstrip()
+    if joined.endswith(_METADATA_CONTINUATION_MARKER):
+        joined = joined[:-1].rstrip()
+    return joined
+
+
+def extract_next_metadata_line(
+    lines: list[str],
+    start_index: int,
+    known_fields: list[str] | None = None,
+) -> str | None:
+    """Extract metadata lines after *start_index*, supporting continuations."""
+    if known_fields is None:
+        known_fields = list(_DEFAULT_KNOWN_FIELDS)
+    collected_lines: list[str] = []
+
+    for j in range(start_index + 1, len(lines)):
+        next_line = lines[j].strip()
+
+        if not next_line and not collected_lines:
+            continue
+
+        if _should_stop_collection(next_line, collected_lines):
+            break
+
+        if not is_metadata_line(next_line, known_fields):
+            break
+
+        collected_lines.append(next_line)
+        if not next_line.endswith(_METADATA_CONTINUATION_MARKER):
+            break
+
+    return _join_metadata_lines(collected_lines) if collected_lines else None
+
+
+def _parse_field_value(value: str) -> int | bool | str:
+    """Parse a single metadata field value to its appropriate Python type."""
+    if value.startswith("[") and "](" in value:
+        match = re.match(markdown_common.MARKDOWN_LINK_PATTERN, value)
+        if match:
+            return value
+
+    if value.isdigit():
+        return int(value)
+
+    if value.lower() == "true":
+        return True
+    if value.lower() == "false":
+        return False
+
+    return value
+
+
+def parse_metadata_fields(metadata_line: str, req_id: str) -> dict:
+    """Parse a pipe-separated metadata line into a frontmatter dictionary.
+
+    Keys are normalized to lowercase. Values are typed via ``_parse_field_value``.
+    Multiple ``Parent`` fields are aggregated into a list under ``parent``.
+    """
+    frontmatter: dict = {"id": req_id}
+    parent_values: list = []
+
+    for field in metadata_line.split(_METADATA_FIELD_SEPARATOR):
+        field = field.strip()
+        if not field or ":" not in field:
+            continue
+
+        parts = field.split(":", 1)
+        key = parts[0].strip().lower()
+        value = parts[1].strip() if len(parts) > 1 else ""
+
+        if key == "parent":
+            parent_values.append(_parse_field_value(value))
+        else:
+            frontmatter[key] = _parse_field_value(value)
+
+    if parent_values:
+        frontmatter["parent"] = parent_values
+
+    return frontmatter

--- a/fire/starlark/metadata_parsing_test.py
+++ b/fire/starlark/metadata_parsing_test.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+"""Tests for inline metadata parsing."""
+
+from fire.starlark.metadata_parsing import (
+    extract_next_metadata_line,
+    is_metadata_line,
+    parse_metadata_fields,
+)
+
+_KNOWN_FIELDS = ["sil", "sec", "version", "parent"]
+
+
+class TestIsMetadataLine:
+    def test_pipe_separated_line(self):
+        assert is_metadata_line("Sil: ASIL-D | Sec: false", _KNOWN_FIELDS)
+
+    def test_single_known_field(self):
+        assert is_metadata_line("Version: 1", _KNOWN_FIELDS)
+
+    def test_heading_is_not_metadata(self):
+        assert not is_metadata_line("# Heading: foo", _KNOWN_FIELDS)
+
+    def test_unknown_field_without_pipe(self):
+        assert not is_metadata_line("Author: Jane", _KNOWN_FIELDS)
+
+    def test_blank_line(self):
+        assert not is_metadata_line("", _KNOWN_FIELDS)
+
+
+class TestExtractNextMetadataLine:
+    def test_single_metadata_line_after_heading(self):
+        lines = [
+            "## REQ-1",
+            "Sil: ASIL-D | Sec: false | Version: 1",
+            "",
+            "Body",
+        ]
+        assert (
+            extract_next_metadata_line(lines, 0)
+            == "Sil: ASIL-D | Sec: false | Version: 1"
+        )
+
+    def test_continuation_via_trailing_pipe(self):
+        lines = [
+            "## REQ-1",
+            "Sil: ASIL-D |",
+            "Sec: false | Version: 1",
+            "",
+        ]
+        assert (
+            extract_next_metadata_line(lines, 0)
+            == "Sil: ASIL-D | Sec: false | Version: 1"
+        )
+
+    def test_no_metadata_line_returns_none(self):
+        lines = ["## REQ-1", "Body without metadata"]
+        assert extract_next_metadata_line(lines, 0) is None
+
+    def test_default_known_fields(self):
+        lines = ["## REQ-1", "Version: 2"]
+        assert extract_next_metadata_line(lines, 0) == "Version: 2"
+
+    def test_custom_known_fields(self):
+        lines = ["## REQ-1", "Author: Jane"]
+        assert (
+            extract_next_metadata_line(lines, 0, known_fields=["author"])
+            == "Author: Jane"
+        )
+
+
+class TestParseMetadataFields:
+    def test_parses_basic_fields(self):
+        result = parse_metadata_fields("Sil: ASIL-D | Version: 1", "REQ-1")
+        assert result == {"id": "REQ-1", "sil": "ASIL-D", "version": 1}
+
+    def test_parses_boolean_lowercase(self):
+        result = parse_metadata_fields("Sec: false", "REQ-1")
+        assert result == {"id": "REQ-1", "sec": False}
+
+    def test_aggregates_parent_into_list(self):
+        result = parse_metadata_fields(
+            "Parent: [REQ-A](/a.md) | Parent: [REQ-B](/b.md)",
+            "REQ-1",
+        )
+        assert result["parent"] == ["[REQ-A](/a.md)", "[REQ-B](/b.md)"]
+
+    def test_single_parent_still_in_list(self):
+        result = parse_metadata_fields("Parent: [REQ-A](/a.md)", "REQ-1")
+        assert result["parent"] == ["[REQ-A](/a.md)"]
+
+    def test_empty_fields_are_skipped(self):
+        result = parse_metadata_fields("Sil: ASIL-D | | Version: 1", "REQ-1")
+        assert result == {"id": "REQ-1", "sil": "ASIL-D", "version": 1}
+
+    def test_int_string_remains_string_if_not_pure_digits(self):
+        result = parse_metadata_fields("Sil: ASIL-1", "REQ-1")
+        assert result == {"id": "REQ-1", "sil": "ASIL-1"}

--- a/fire/starlark/release_report.py
+++ b/fire/starlark/release_report.py
@@ -108,9 +108,7 @@ def parse_requirement_sections(
         )
         metadata = {}
         if metadata_line:
-            metadata = metadata_parsing.parse_metadata_fields(
-                metadata_line, req_id
-            )
+            metadata = metadata_parsing.parse_metadata_fields(metadata_line, req_id)
 
         body_start = 1
         if metadata_line:

--- a/fire/starlark/release_report.py
+++ b/fire/starlark/release_report.py
@@ -9,6 +9,7 @@ from typing import Final
 from fire.starlark import (
     file_io_common,
     markdown_common,
+    metadata_parsing,
     path_common,
     validate_cross_references,
 )
@@ -102,12 +103,12 @@ def parse_requirement_sections(
         end = indices[idx + 1][0] if idx + 1 < len(indices) else len(lines)
         section_lines = lines[start:end]
 
-        metadata_line = validate_cross_references._extract_next_metadata_line(
+        metadata_line = metadata_parsing.extract_next_metadata_line(
             section_lines, 0, known_fields
         )
         metadata = {}
         if metadata_line:
-            metadata = validate_cross_references._parse_metadata_fields(
+            metadata = metadata_parsing.parse_metadata_fields(
                 metadata_line, req_id
             )
 

--- a/fire/starlark/validate_cross_references.py
+++ b/fire/starlark/validate_cross_references.py
@@ -93,8 +93,6 @@ def _find_requirement_heading_index(lines: list[str], req_id: str) -> int | None
     return None
 
 
-
-
 def _requirement_suffixes(config: FireConfig | None = None) -> tuple[str, ...]:
     """Return known requirement file suffixes from config or the hardcoded default."""
     if config is not None:

--- a/fire/starlark/validate_cross_references.py
+++ b/fire/starlark/validate_cross_references.py
@@ -22,7 +22,12 @@ from typing import Final
 
 from pydantic import BaseModel, ValidationError
 
-from fire.starlark import file_io_common, markdown_common, path_common
+from fire.starlark import (
+    file_io_common,
+    markdown_common,
+    metadata_parsing,
+    path_common,
+)
 from fire.starlark.config_models import FireConfig, load_config
 from fire.starlark.dynamic_requirement_model import (
     build_models_from_config,
@@ -38,8 +43,6 @@ _REGREQ_EXTENSION: Final = ".regreq.md"
 _REQUIREMENT_SUFFIXES: Final = (".sysreq.md", ".swreq.md", ".regreq.md")
 
 _BARE_TODO_RE: Final = re.compile(r"TODO(?!\([A-Z]+-[0-9]+\))")
-_METADATA_CONTINUATION_MARKER: Final = "|"
-_METADATA_FIELD_SEPARATOR: Final = "|"
 
 
 def _metadata_model_for_file(
@@ -90,130 +93,6 @@ def _find_requirement_heading_index(lines: list[str], req_id: str) -> int | None
     return None
 
 
-def _is_metadata_line(line: str, known_fields: list[str]) -> bool:
-    """Check if a line looks like metadata."""
-    if _METADATA_FIELD_SEPARATOR in line:
-        return True
-    if ":" in line and not line.startswith("#"):
-        parts = line.split(":", 1)
-        key = parts[0].strip().lower()
-        return len(parts) == 2 and key in known_fields
-    return False
-
-
-def _should_stop_collection(line: str, collected_lines: list[str]) -> bool:
-    """Check if we should stop collecting metadata lines."""
-    if not line:
-        return bool(collected_lines)
-    if collected_lines and not collected_lines[-1].endswith(
-        _METADATA_CONTINUATION_MARKER
-    ):
-        return True
-    return False
-
-
-def _join_metadata_lines(lines: list[str]) -> str:
-    """Join metadata lines and strip final trailing pipe."""
-    joined = " ".join(lines).rstrip()
-    if joined.endswith(_METADATA_CONTINUATION_MARKER):
-        joined = joined[:-1].rstrip()
-    return joined
-
-
-def _extract_next_metadata_line(
-    lines: list[str],
-    start_index: int,
-    known_fields: list[str] | None = None,
-) -> str | None:
-    """Extract metadata lines after start_index, supporting multi-line continuation."""
-    if known_fields is None:
-        known_fields = ["sil", "sec", "version", "parent"]
-    collected_lines = []
-
-    for j in range(start_index + 1, len(lines)):
-        next_line = lines[j].strip()
-
-        if not next_line and not collected_lines:
-            continue
-
-        if _should_stop_collection(next_line, collected_lines):
-            break
-
-        if not _is_metadata_line(next_line, known_fields):
-            break
-
-        collected_lines.append(next_line)
-        if not next_line.endswith(_METADATA_CONTINUATION_MARKER):
-            break
-
-    return _join_metadata_lines(collected_lines) if collected_lines else None
-
-
-def _parse_field_value(value: str) -> int | bool | str:
-    """Parse a single metadata field value to its appropriate type.
-
-    Handles:
-    - Markdown links (returned as-is)
-    - Integers (converted to int)
-    - Booleans (true/false converted to bool)
-    - Strings (returned as-is)
-    """
-    # Markdown links stay as strings
-    if value.startswith("[") and "](" in value:
-        # Validate it matches the expected link pattern
-        match = re.match(markdown_common.MARKDOWN_LINK_PATTERN, value)
-        if match:
-            return value
-
-    # Parse integers
-    if value.isdigit():
-        return int(value)
-
-    # Parse booleans
-    if value.lower() == "true":
-        return True
-    if value.lower() == "false":
-        return False
-
-    # Default: return as string
-    return value
-
-
-def _parse_metadata_fields(metadata_line: str, req_id: str) -> dict:
-    """Parse pipe-separated metadata fields into a frontmatter dictionary.
-
-    Splits the line and parses each 'key: value' pair.
-    Keys are normalized to lowercase. Values are typed using _parse_field_value.
-
-    Special handling for Parent field:
-    - Multiple Parent fields are aggregated into a list
-    - Stored as frontmatter["parent"] = [value1, value2, ...]
-    - Always stored as list for consistency, even if single parent
-    """
-    frontmatter = {"id": req_id}
-    parent_values = []
-
-    for field in metadata_line.split(_METADATA_FIELD_SEPARATOR):
-        field = field.strip()
-        if not field or ":" not in field:
-            continue
-
-        # Split by first ':' to get key and value
-        parts = field.split(":", 1)
-        key = parts[0].strip().lower()
-        value = parts[1].strip() if len(parts) > 1 else ""
-
-        # Special handling for parent field - aggregate into list
-        if key == "parent":
-            parent_values.append(_parse_field_value(value))
-        else:
-            frontmatter[key] = _parse_field_value(value)
-
-    # Store parent as list if any parent values were found
-    if parent_values:
-        frontmatter["parent"] = parent_values
-
-    return frontmatter
 
 
 def _requirement_suffixes(config: FireConfig | None = None) -> tuple[str, ...]:
@@ -240,11 +119,13 @@ def parse_inline_metadata_for_requirement(
     if heading_index is None:
         return None, None
 
-    metadata_line = _extract_next_metadata_line(lines, heading_index, known_fields)
+    metadata_line = metadata_parsing.extract_next_metadata_line(
+        lines, heading_index, known_fields
+    )
     if not metadata_line:
         return None, None
 
-    frontmatter = _parse_metadata_fields(metadata_line, req_id)
+    frontmatter = metadata_parsing.parse_metadata_fields(metadata_line, req_id)
 
     try:
         metadata = model_class.model_validate(frontmatter)


### PR DESCRIPTION
Closes #244

## Summary
- Create `fire/starlark/metadata_parsing.py` with public functions: `is_metadata_line`, `extract_next_metadata_line`, `parse_metadata_fields`.
- Remove the private versions (`_is_metadata_line`, `_extract_next_metadata_line`, `_parse_metadata_fields`, `_parse_field_value`, etc.) and the private `_METADATA_*` constants from `validate_cross_references.py`.
- Switch both `validate_cross_references.py` and `release_report.py` to call into the new module instead of importing private symbols across module boundaries.
- Add unit tests in `metadata_parsing_test.py`.
- Wire `BUILD.bazel`: new `metadata_parsing` library + test target, deps added to dependents.

Stacked on top of #259.

## Test plan
- `bazel test //fire/starlark:all` passes (15/15)
- `bazel test //fire/starlark:metadata_parsing_test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)