### PR TITLE
Unify requirement_library and parameter_library macros

### DIFF
--- a/fire/starlark/parameters.bzl
+++ b/fire/starlark/parameters.bzl
@@ -46,11 +46,7 @@ _validate_parameters = rule(
     doc = "Validates a parameter YAML file",
 )
 
-def parameter_library(
-        name,
-        src,
-        visibility = None,
-        tags = None):
+def parameter_library(name, src, tags = [], visibility = None):
     """Define and validate a parameter library from a YAML file.
 
     This macro validates the YAML file at build time
@@ -59,8 +55,8 @@ def parameter_library(
     Args:
         name: Name of the library
         src: Path to the parameter YAML file (e.g., "vehicle_params.yaml")
+        tags: Tags for this target (e.g., ["manual", "failure_test"])
         visibility: Visibility of the target
-        tags: Optional tags (e.g., ["manual", "failure_test"])
 
     Example:
         # Define parameters in a YAML file (vehicle_params.yaml):
@@ -87,13 +83,13 @@ def parameter_library(
         name = validation_name,
         src = src,
         out = name + "_validated.yaml",
-        tags = tags if tags else [],
+        tags = tags,
     )
 
     # Main target is a filegroup containing the validated YAML
     native.filegroup(
         name = name,
         srcs = [":" + validation_name],
-        visibility = visibility if visibility else ["//visibility:public"],
-        tags = tags if tags else [],
+        tags = tags,
+        visibility = visibility,
     )

--- a/integration_test/BUILD.bazel
+++ b/integration_test/BUILD.bazel
@@ -15,6 +15,7 @@ exports_files(["test_params.yaml"])
 parameter_library(
     name = "test_params",
     src = "test_params.yaml",
+    visibility = ["//visibility:public"],
 )
 
 # Generate C++ headers from parameters (directory: test_params_cc/)


### PR DESCRIPTION
Closes #248

## Summary
Align `parameter_library` with the simpler shape used by `requirement_library`:
- `tags` default is now `[]` (was `None`); pass through directly without `if tags else []`.
- `visibility` default is now `None` (was `["//visibility:public"]`); pass through directly.
- Argument order normalized to `(name, src, tags, visibility)`.

### Behavior change

`parameter_library` no longer defaults to public visibility. Consumers that rely on cross-package access must now set `visibility = ["//visibility:public"]` explicitly. All in-tree usages live in the same Bazel package as their consumers, so this change does not affect FIRE itself.

Stacked on top of #261.

## Test plan
- `bazel test //fire/starlark:all //examples/...` passes (25/25)

🤖 Generated with [Claude Code](https://claude.com/claude-code)