### PR TITLE
Extract run_python_script helper for Starlark rules

### DIFF
--- a/fire/starlark/BUILD.bazel
+++ b/fire/starlark/BUILD.bazel
@@ -2,6 +2,7 @@ load("@rules_python//python:defs.bzl", "py_binary", "py_library", "py_test")
 
 exports_files([
     "default_fire_config.yaml",
+    "fire_rule_utils.bzl",
     "format_spec.bzl",
     "parameters.bzl",
     "requirements.bzl",

--- a/fire/starlark/codegen.bzl
+++ b/fire/starlark/codegen.bzl
@@ -8,9 +8,10 @@ This design keeps Fire's dependencies minimal - Fire only needs rules_python for
 validation. Consumers control which language rules they use and which versions.
 """
 
+load("//fire/starlark:fire_rule_utils.bzl", "run_python_script")
+
 def _generate_parameters_impl(ctx):
     """Implementation of parameter code generation rule."""
-    script = ctx.executable._script
     input_file = ctx.file.srcs
     language = ctx.attr.language
 
@@ -44,18 +45,16 @@ def _generate_parameters_impl(ctx):
     if ctx.attr.class_name:
         args.add("--class-name=" + ctx.attr.class_name)
 
-    # Get runfiles for the script
-    script_runfiles = ctx.attr._script[DefaultInfo].default_runfiles.files.to_list()
-
     # Language name for messages (capitalize first letter)
     lang_display = language.capitalize() if language != "cpp" else "C++"
 
-    # Run code generation
-    ctx.actions.run(
-        inputs = [input_file] + script_runfiles,
+    run_python_script(
+        ctx,
+        script = ctx.executable._script,
+        script_target = ctx.attr._script,
+        args = args,
+        extra_inputs = [input_file],
         outputs = [output],
-        executable = script,
-        arguments = [args],
         mnemonic = "Generate" + lang_display.replace("+", "").replace(" ", "") + "Parameters",
         progress_message = "Generating %s parameters from %s" % (lang_display, input_file.basename),
     )

--- a/fire/starlark/fire_rule_utils.bzl
+++ b/fire/starlark/fire_rule_utils.bzl
@@ -1,0 +1,59 @@
+"""Shared helpers for FIRE Bazel rule implementations.
+
+These utilities consolidate the boilerplate around invoking a Python
+``py_binary`` from a custom rule: collecting its runfiles, assembling
+the inputs list, and forwarding execution requirements.
+"""
+
+def run_python_script(
+        ctx,
+        *,
+        script,
+        script_target,
+        args,
+        extra_inputs,
+        outputs,
+        mnemonic,
+        progress_message,
+        use_default_shell_env = False,
+        no_sandbox = False):
+    """Run a Python ``py_binary`` as a Bazel action.
+
+    Args:
+        ctx: The rule context.
+        script: ``File`` for the executable script (typically
+            ``ctx.executable._script``).
+        script_target: The script's ``Target`` (typically ``ctx.attr._script``),
+            used to collect runfiles.
+        args: ``Args`` object (or a plain list) with the script's CLI arguments.
+        extra_inputs: List of additional input ``File`` objects (sources,
+            dependencies, optional config). The script itself and its runfiles
+            are added automatically.
+        outputs: List of output ``File`` objects.
+        mnemonic: Bazel mnemonic for the action.
+        progress_message: Progress message printed during the build.
+        use_default_shell_env: If True, run the action with the host shell
+            environment. Only set this when the script genuinely needs it.
+        no_sandbox: If True, request ``no-sandbox`` execution. Only set this
+            when the script needs to read files outside the Bazel sandbox
+            (e.g. when running outside the execroot).
+    """
+    runfiles = script_target[DefaultInfo].default_runfiles.files.to_list()
+    inputs = list(extra_inputs) + [script] + runfiles
+
+    arguments = args if type(args) == "list" else [args]
+
+    execution_requirements = {}
+    if no_sandbox:
+        execution_requirements["no-sandbox"] = "1"
+
+    ctx.actions.run(
+        inputs = inputs,
+        outputs = outputs,
+        executable = script,
+        arguments = arguments,
+        mnemonic = mnemonic,
+        progress_message = progress_message,
+        use_default_shell_env = use_default_shell_env,
+        execution_requirements = execution_requirements,
+    )

--- a/fire/starlark/format_spec.bzl
+++ b/fire/starlark/format_spec.bzl
@@ -1,8 +1,9 @@
 """Bazel rule for generating FORMAT_SPECIFICATION.md from FIRE config."""
 
+load("//fire/starlark:fire_rule_utils.bzl", "run_python_script")
+
 def _generate_format_specification_impl(ctx):
     """Implementation of the format specification generator rule."""
-    script = ctx.executable._script
     args = ctx.actions.args()
     args.add("--out", ctx.outputs.out.path)
 
@@ -11,13 +12,13 @@ def _generate_format_specification_impl(ctx):
         args.add("--config", ctx.file.config.path)
         config_inputs = [ctx.file.config]
 
-    script_runfiles = ctx.attr._script[DefaultInfo].default_runfiles.files.to_list()
-
-    ctx.actions.run(
-        inputs = config_inputs + [script] + script_runfiles,
+    run_python_script(
+        ctx,
+        script = ctx.executable._script,
+        script_target = ctx.attr._script,
+        args = args,
+        extra_inputs = config_inputs,
         outputs = [ctx.outputs.out],
-        executable = script,
-        arguments = [args],
         mnemonic = "GenerateFormatSpec",
         progress_message = "Generating format specification for %s" % ctx.label.name,
     )

--- a/fire/starlark/parameters.bzl
+++ b/fire/starlark/parameters.bzl
@@ -3,23 +3,20 @@
 Parameters are defined in YAML files and validated at build time.
 """
 
+load("//fire/starlark:fire_rule_utils.bzl", "run_python_script")
+
 def _validate_parameters_impl(ctx):
     """Implementation of parameter validation rule."""
-    script = ctx.executable._script
     input_file = ctx.file.src
     output = ctx.outputs.out
 
-    # Get runfiles for the script
-    script_runfiles = ctx.attr._script[DefaultInfo].default_runfiles.files.to_list()
-
-    args = [input_file.path, output.path]
-
-    # Run validation
-    ctx.actions.run(
-        inputs = [input_file] + script_runfiles,
+    run_python_script(
+        ctx,
+        script = ctx.executable._script,
+        script_target = ctx.attr._script,
+        args = [input_file.path, output.path],
+        extra_inputs = [input_file],
         outputs = [output],
-        arguments = args,
-        executable = script,
         mnemonic = "ValidateParameters",
         progress_message = "Validating parameters in %s" % input_file.basename,
     )

--- a/fire/starlark/reports.bzl
+++ b/fire/starlark/reports.bzl
@@ -1,9 +1,10 @@
 """Bazel rules for release readiness reporting."""
 
+load("//fire/starlark:fire_rule_utils.bzl", "run_python_script")
+
 def _release_report_impl(ctx):
     """Implementation of the release_report rule."""
 
-    script = ctx.executable._script
     args = ctx.actions.args()
     args.add("--out")
     args.add(ctx.outputs.out.path)
@@ -27,18 +28,14 @@ def _release_report_impl(ctx):
     args.add_all(trace_files, before_each = "--source-traces")
 
     config_inputs = [ctx.file.config] if ctx.file.config else []
-    script_runfiles = ctx.attr._script[DefaultInfo].default_runfiles.files.to_list()
 
-    ctx.actions.run(
-        inputs = requirement_files +
-                 param_files +
-                 trace_files +
-                 config_inputs +
-                 [script] +
-                 script_runfiles,
+    run_python_script(
+        ctx,
+        script = ctx.executable._script,
+        script_target = ctx.attr._script,
+        args = args,
+        extra_inputs = requirement_files + param_files + trace_files + config_inputs,
         outputs = [ctx.outputs.out],
-        executable = script,
-        arguments = [args],
         mnemonic = "ReleaseReport",
         progress_message = "Generating release report for %s" % ctx.label.name,
     )

--- a/fire/starlark/requirements.bzl
+++ b/fire/starlark/requirements.bzl
@@ -1,10 +1,9 @@
 """Bazel rules for requirement management."""
 
+load("//fire/starlark:fire_rule_utils.bzl", "run_python_script")
+
 def _validate_requirements_impl(ctx):
     """Implementation of requirement validation rule."""
-    script = ctx.executable._script
-
-    # Output validation marker file
     output = ctx.outputs.out
 
     # Use "." as workspace root - the sandbox will have the right structure
@@ -33,23 +32,21 @@ def _validate_requirements_impl(ctx):
     for src in ctx.files.srcs:
         args.add(src.short_path)
 
-    # Get runfiles for the script
-    script_runfiles = ctx.attr._script[DefaultInfo].default_runfiles.files.to_list()
-
     config_inputs = [ctx.file.config] if ctx.file.config else []
 
-    # Run validation script directly (no shell wrapper needed)
-    ctx.actions.run(
-        inputs = ctx.files.srcs + ctx.files.deps + config_inputs + script_runfiles,
+    run_python_script(
+        ctx,
+        script = ctx.executable._script,
+        script_target = ctx.attr._script,
+        args = args,
+        extra_inputs = ctx.files.srcs + ctx.files.deps + config_inputs,
         outputs = [output],
-        executable = script,
-        arguments = [args],
         mnemonic = "ValidateRequirements",
         progress_message = "Validating cross-references in %s" % ctx.label.name,
+        # no-sandbox + default shell env are needed so the validator can read
+        # workspace-relative file paths during the build.
         use_default_shell_env = True,
-        execution_requirements = {
-            "no-sandbox": "1",  # Disable sandbox so we can access workspace files
-        },
+        no_sandbox = True,
     )
 
     return [DefaultInfo(files = depset([output]))]

--- a/fire/starlark/traceability.bzl
+++ b/fire/starlark/traceability.bzl
@@ -1,10 +1,9 @@
 """Bazel rules for source-to-requirement traceability."""
 
+load("//fire/starlark:fire_rule_utils.bzl", "run_python_script")
+
 def _extract_source_traceability_impl(ctx):
     """Implementation of source traceability extraction rule."""
-    script = ctx.executable._script
-
-    # Output trace JSON file
     output = ctx.outputs.out
 
     # Build arguments list
@@ -27,21 +26,17 @@ def _extract_source_traceability_impl(ctx):
         args.add("--verifies-json")
         args.add(json.encode(ctx.attr.verifies))
 
-    # Get runfiles for the script
-    script_runfiles = ctx.attr._script[DefaultInfo].default_runfiles.files.to_list()
-
-    # Run extraction script
-    ctx.actions.run(
-        inputs = ctx.files.deps + script_runfiles,
+    run_python_script(
+        ctx,
+        script = ctx.executable._script,
+        script_target = ctx.attr._script,
+        args = args,
+        extra_inputs = ctx.files.deps,
         outputs = [output],
-        executable = script,
-        arguments = [args],
         mnemonic = "ExtractSourceTraceability",
         progress_message = "Extracting source traceability for %s" % ctx.label.name,
         use_default_shell_env = True,
-        execution_requirements = {
-            "no-sandbox": "1",
-        },
+        no_sandbox = True,
     )
 
     return [DefaultInfo(files = depset([output]))]


### PR DESCRIPTION
Closes #246

## Summary
Add a shared `run_python_script()` helper in a new `fire/starlark/fire_rule_utils.bzl` and use it from every rule implementation that runs a `py_binary`:
- `format_spec.bzl` — generate format spec
- `parameters.bzl` — validate parameters
- `requirements.bzl` — validate cross-references (carries `no_sandbox=True`, `use_default_shell_env=True`)
- `traceability.bzl` — extract source traceability (same hermeticity caveats)
- `reports.bzl` — release report
- `codegen.bzl` — language code generation

The helper centralizes the runfiles collection and inputs assembly; per-rule flags (`no_sandbox`, `use_default_shell_env`) remain explicit at the call sites so the hermeticity concerns stay visible.

Stacked on top of #262.

## Test plan
- `bazel build //...` succeeds
- `bazel test //fire/starlark:all //examples/...` passes (25/25)

🤖 Generated with [Claude Code](https://claude.com/claude-code)