### PR TITLE
Standardize error handling patterns

### DIFF
--- a/fire/starlark/BUILD.bazel
+++ b/fire/starlark/BUILD.bazel
@@ -28,8 +28,8 @@ py_binary(
     main = "generate_code.py",
     visibility = ["//visibility:public"],
     deps = [
+        ":file_io_common",
         "@pip//jinja2",
-        "@pip//pyyaml",
     ],
 )
 
@@ -506,8 +506,8 @@ py_library(
     ],
     data = glob(["templates/*.j2"]),
     deps = [
+        ":file_io_common",
         "@pip//jinja2",
-        "@pip//pyyaml",
     ],
 )
 

--- a/fire/starlark/BUILD.bazel
+++ b/fire/starlark/BUILD.bazel
@@ -314,6 +314,23 @@ py_test(
     ],
 )
 
+# Common utilities - inline metadata parsing
+py_library(
+    name = "metadata_parsing",
+    srcs = ["metadata_parsing.py"],
+    deps = [":markdown_common"],
+)
+
+py_test(
+    name = "metadata_parsing_test",
+    size = "small",
+    srcs = ["metadata_parsing_test.py"],
+    deps = [
+        ":metadata_parsing",
+        "@pip//pytest",
+    ],
+)
+
 # Python library for cross-reference validation
 py_library(
     name = "validate_cross_references_lib",

--- a/fire/starlark/BUILD.bazel
+++ b/fire/starlark/BUILD.bazel
@@ -314,23 +314,6 @@ py_test(
     ],
 )
 
-# Common utilities - inline metadata parsing
-py_library(
-    name = "metadata_parsing",
-    srcs = ["metadata_parsing.py"],
-    deps = [":markdown_common"],
-)
-
-py_test(
-    name = "metadata_parsing_test",
-    size = "small",
-    srcs = ["metadata_parsing_test.py"],
-    deps = [
-        ":metadata_parsing",
-        "@pip//pytest",
-    ],
-)
-
 # Python library for cross-reference validation
 py_library(
     name = "validate_cross_references_lib",

--- a/fire/starlark/file_io_common.py
+++ b/fire/starlark/file_io_common.py
@@ -2,6 +2,16 @@
 
 This module provides safe file reading and YAML/JSON loading with consistent
 error handling.
+
+Error-handling conventions used across ``fire/starlark``:
+
+- **Library functions that touch I/O** return ``(data, error_msg)`` tuples.
+  Callers branch on whether ``error_msg`` is ``None``. This module is the
+  reference implementation.
+- **Library functions that validate inputs** raise ``ValueError`` (or
+  pydantic's ``ValidationError``) with a descriptive message.
+- **CLI entry points** (modules with a ``main()`` function) catch errors,
+  print them to ``stderr``, and exit via ``sys.exit(1)``.
 """
 
 import json
@@ -35,7 +45,7 @@ def read_file_safe(file_path: str) -> tuple[str | None, str | None]:
         return None, f"File not found: {file_path}"
     except PermissionError:
         return None, f"Permission denied: {file_path}"
-    except Exception as e:
+    except OSError as e:
         return None, f"Error reading {file_path}: {e}"
 
 
@@ -67,7 +77,7 @@ def load_yaml_safe(file_path: str) -> tuple[Any | None, str | None]:
         return None, f"Invalid YAML syntax in {file_path}: {e}"
     except PermissionError:
         return None, f"Permission denied: {file_path}"
-    except Exception as e:
+    except OSError as e:
         return None, f"Error loading YAML from {file_path}: {e}"
 
 
@@ -98,7 +108,7 @@ def load_json_safe(file_path: str) -> tuple[Any | None, str | None]:
         return None, f"Invalid JSON syntax in {file_path}: {e}"
     except PermissionError:
         return None, f"Permission denied: {file_path}"
-    except Exception as e:
+    except OSError as e:
         return None, f"Error loading JSON from {file_path}: {e}"
 
 
@@ -125,5 +135,5 @@ def write_yaml_safe(file_path: str, data: Any) -> str | None:
         return f"Permission denied: {file_path}"
     except yaml.YAMLError as e:
         return f"Error serializing YAML to {file_path}: {e}"
-    except Exception as e:
+    except OSError as e:
         return f"Error writing YAML to {file_path}: {e}"

--- a/fire/starlark/generate_code.py
+++ b/fire/starlark/generate_code.py
@@ -25,8 +25,7 @@ import zipfile
 from collections import defaultdict
 from pathlib import Path
 
-import yaml
-
+from fire.starlark import file_io_common
 from fire.starlark.generators.cpp import generate_cpp_files
 from fire.starlark.generators.go import generate_go_files
 from fire.starlark.generators.java import generate_java_files
@@ -170,16 +169,11 @@ def main():
     args = parser.parse_args()
 
     # Load parameter data
-    try:
-        with open(args.input, "r") as f:
-            yaml_data = yaml.safe_load(f)
-        items = yaml_to_items(yaml_data)
-    except FileNotFoundError:
-        print(f"Error: Input file not found: {args.input}", file=sys.stderr)
+    yaml_data, error = file_io_common.load_yaml_safe(args.input)
+    if error:
+        print(f"Error: {error}", file=sys.stderr)
         sys.exit(1)
-    except yaml.YAMLError as e:
-        print(f"Error: Invalid YAML in {args.input}: {e}", file=sys.stderr)
-        sys.exit(1)
+    items = yaml_to_items(yaml_data)
 
     # Generate files based on language
     if args.language == "cpp":


### PR DESCRIPTION
Closes #252

## Summary
- Narrow the catch-all `except Exception` in `file_io_common.py` to `OSError` for all I/O paths (`read_file_safe`, `load_yaml_safe`, `load_json_safe`, `write_yaml_safe`). Programmer errors (`AttributeError`, `KeyError`, etc.) now surface instead of being swallowed.
- Document the project-wide conventions in `file_io_common.py`'s module docstring:
  - I/O library functions return `(data, error_msg)` tuples
  - Validation library functions raise `ValueError` (or pydantic `ValidationError`)
  - CLI entry points catch errors, print to `stderr`, and `sys.exit(1)`
- Migrate `generate_code.py` from raw `open()` + `yaml.safe_load()` to `file_io_common.load_yaml_safe()`. Wire `file_io_common` as a dep of both `generate_code_script` (py_binary) and `generate_code_lib` (py_test target); drop the now-unused `@pip//pyyaml` dep.

Stacked on top of #266.

## Test plan
- `bazel test //fire/starlark:all //examples/...` passes (28/28 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)