### PR TITLE
Fix prefix-match bug in _find_requirement_heading_index

### DIFF
--- a/fire/starlark/validate_cross_references.py
+++ b/fire/starlark/validate_cross_references.py
@@ -85,10 +85,16 @@ def validate_no_bare_todos(content: str, file_path: str) -> list[str]:
 def _find_requirement_heading_index(lines: list[str], req_id: str) -> int | None:
     """Find the line index of the requirement heading.
 
-    Returns the index of the line starting with '## REQ_ID', or None if not found.
+    Matches a line that is exactly ``## <req_id>`` or ``## <req_id> ...``.
+    The trailing-space check prevents prefix collisions: searching for
+    ``REQ-1`` must not match a heading like ``## REQ-12``.
+
+    Returns the index of the matching line, or None if not found.
     """
+    target = f"## {req_id}"
     for i, line in enumerate(lines):
-        if line.startswith(f"## {req_id}"):
+        stripped = line.rstrip()
+        if stripped == target or stripped.startswith(target + " "):
             return i
     return None
 

--- a/fire/starlark/validate_cross_references_test.py
+++ b/fire/starlark/validate_cross_references_test.py
@@ -65,10 +65,26 @@ class TestFindRequirementHeadingIndex:
         lines = ["## REQ-1", "body", "## REQ-1", "more"]
         assert vcr._find_requirement_heading_index(lines, "REQ-1") == 0
 
-    def test_partial_id_match_does_not_count(self):
+    def test_prefix_id_does_not_match_longer_id(self):
+        # Regression test for #268: searching for REQ-1 must not match
+        # a longer ID like REQ-12.
         lines = ["## REQ-12", "body"]
-        # `## REQ-1` matches the start of `## REQ-12`, so this is a known
-        # caveat of the prefix-based matcher — document it explicitly.
+        assert vcr._find_requirement_heading_index(lines, "REQ-1") is None
+
+    def test_skips_prefix_match_and_finds_exact(self):
+        # Even when a longer-ID heading precedes the exact match, the
+        # exact match is what gets returned.
+        lines = ["## REQ-12", "body", "## REQ-1", "more"]
+        assert vcr._find_requirement_heading_index(lines, "REQ-1") == 2
+
+    def test_matches_heading_with_trailing_text(self):
+        # Headings may have a trailing space and additional text;
+        # they should still match.
+        lines = ["## REQ-1 Some description"]
+        assert vcr._find_requirement_heading_index(lines, "REQ-1") == 0
+
+    def test_matches_heading_with_trailing_whitespace(self):
+        lines = ["## REQ-1   "]
         assert vcr._find_requirement_heading_index(lines, "REQ-1") == 0
 
 


### PR DESCRIPTION
Closes #268

## Summary
Tighten `_find_requirement_heading_index` so that a search for `REQ-1` no longer matches a `## REQ-12` heading. Three downstream callers (`validate_requirement_reference`, `validate_requirement_file`, `extract_requirements_from_file`) silently used the wrong metadata when two requirement IDs in the same file shared a prefix.

The matcher now requires the heading to be either exactly `## <req_id>` or `## <req_id> ` (followed by a space).

## Changes
- `validate_cross_references.py`: rewrite `_find_requirement_heading_index` with an exact + space-prefix match.
- `validate_cross_references_test.py`:
  - Replace `test_partial_id_match_does_not_count` (which had documented the wrong behavior as a "known caveat") with three regression tests covering the fix and the supported heading shapes.
  - Drop two pre-existing unused imports flagged by ruff (`pytest`, `FireConfig`).

Stacked on top of #267.

## Test plan
- `bazel test //fire/starlark:all //examples/...` passes (28/28 tests)
- `./fire/starlark/failure_test/run_failure_tests.sh` passes
- New regression tests cover both the prefix collision and the supported heading forms

🤖 Generated with [Claude Code](https://claude.com/claude-code)