### PR TITLE
Add PDF render model (Phase 1)

### DIFF
--- a/fire/starlark/BUILD.bazel
+++ b/fire/starlark/BUILD.bazel
@@ -503,3 +503,28 @@ py_test(
         "@pip//pytest",
     ],
 )
+
+# PDF render model (Phase 1: type-agnostic intermediate, no rule yet)
+py_library(
+    name = "document_model",
+    srcs = ["render/document_model.py"],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":config_models",
+        ":release_report",
+    ],
+)
+
+py_test(
+    name = "document_model_test",
+    size = "small",
+    srcs = [
+        "conftest.py",
+        "render/document_model_test.py",
+    ],
+    deps = [
+        ":config_models",
+        ":document_model",
+        "@pip//pytest",
+    ],
+)

--- a/fire/starlark/render/document_model.py
+++ b/fire/starlark/render/document_model.py
@@ -62,7 +62,7 @@ def build_render_document(
         source_path=file_path,
         doc_type=doc_key,
         display_name=doc_type.display_name,
-        title=_extract_title(content, file_path),
+        title=_extract_title(content, file_path, doc_type.suffix),
         entries=entries,
     )
 
@@ -77,12 +77,18 @@ def _resolve_document_type(
     raise ValueError(f"no document type matches '{file_path}'")
 
 
-def _extract_title(content: str, file_path: str) -> str:
-    """Return the first H1 heading, or the filename stem as a fallback."""
+def _extract_title(content: str, file_path: str, suffix: str) -> str:
+    """Return the first H1 heading, or the filename stem as a fallback.
+
+    The fallback strips the resolved document-type *suffix* rather than
+    splitting on the first dot, so dotted stems (``brake.v1.sysreq.md``)
+    are preserved (``brake.v1``).
+    """
     for line in content.split("\n"):
         if line.startswith("# "):
             return line[2:].strip()
-    return Path(file_path).name.split(".", 1)[0]
+    name = Path(file_path).name
+    return name[: -len(suffix)] if name.endswith(suffix) else name
 
 
 def _build_entry(

--- a/fire/starlark/render/document_model.py
+++ b/fire/starlark/render/document_model.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+"""Build a structured render model from parsed FIRE markdown and config.
+
+The render model is the type-agnostic intermediate consumed by the HTML
+template (Phase 2). It reuses ``parse_requirement_sections`` and
+``FireConfig`` so no new parsing logic is introduced here.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from fire.starlark import release_report
+from fire.starlark.config_models import DocumentTypeDefinition, FireConfig
+
+
+@dataclass(frozen=True)
+class RenderField:
+    """A single metadata field with its display name and formatted values."""
+
+    name: str
+    display_name: str
+    values: tuple[str, ...]
+
+    @property
+    def value(self) -> str:
+        """Return the values joined for single-valued display."""
+        return ", ".join(self.values)
+
+
+@dataclass(frozen=True)
+class RenderEntry:
+    """One ``## ENTRY-ID`` section with ordered fields and body text."""
+
+    entry_id: str
+    fields: tuple[RenderField, ...]
+    body: str
+
+
+@dataclass(frozen=True)
+class RenderDocument:
+    """A whole document: its type, title, and rendered entries."""
+
+    source_path: str
+    doc_type: str
+    display_name: str
+    title: str
+    entries: tuple[RenderEntry, ...]
+
+
+def build_render_document(
+    content: str, file_path: str, config: FireConfig
+) -> RenderDocument:
+    """Construct a :class:`RenderDocument` from markdown *content*."""
+    doc_key, doc_type = _resolve_document_type(file_path, config)
+    sections = release_report.parse_requirement_sections(
+        content, file_path, config.known_fields()
+    )
+    entries = tuple(_build_entry(s, doc_type, config) for s in sections)
+    return RenderDocument(
+        source_path=file_path,
+        doc_type=doc_key,
+        display_name=doc_type.display_name,
+        title=_extract_title(content, file_path),
+        entries=entries,
+    )
+
+
+def _resolve_document_type(
+    file_path: str, config: FireConfig
+) -> tuple[str, DocumentTypeDefinition]:
+    """Return the config key and definition for *file_path*'s suffix."""
+    for key, doc_type in config.document_types.items():
+        if file_path.endswith(doc_type.suffix):
+            return key, doc_type
+    raise ValueError(f"no document type matches '{file_path}'")
+
+
+def _extract_title(content: str, file_path: str) -> str:
+    """Return the first H1 heading, or the filename stem as a fallback."""
+    for line in content.split("\n"):
+        if line.startswith("# "):
+            return line[2:].strip()
+    return Path(file_path).name.split(".", 1)[0]
+
+
+def _build_entry(
+    section: dict, doc_type: DocumentTypeDefinition, config: FireConfig
+) -> RenderEntry:
+    """Build a :class:`RenderEntry` from a parsed *section*."""
+    ordered = doc_type.required_fields + doc_type.optional_fields
+    fields = tuple(
+        field
+        for name in ordered
+        if (field := _build_field(name, section["metadata"], config)) is not None
+    )
+    return RenderEntry(entry_id=section["id"], fields=fields, body=section["body"])
+
+
+def _build_field(name: str, metadata: dict, config: FireConfig) -> RenderField | None:
+    """Build a :class:`RenderField`, or ``None`` when the value is absent."""
+    field_def = config.field_definitions[name]
+    raw = metadata.get(field_def.display_name.lower())
+    if raw is None:
+        return None
+    return RenderField(name, field_def.display_name, _format_values(raw))
+
+
+def _format_values(raw: object) -> tuple[str, ...]:
+    """Normalize a metadata value to a tuple of display strings."""
+    if isinstance(raw, list):
+        return tuple(_format_scalar(v) for v in raw)
+    return (_format_scalar(raw),)
+
+
+def _format_scalar(value: object) -> str:
+    """Format a scalar value, rendering booleans as ``true``/``false``."""
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    return str(value)

--- a/fire/starlark/render/document_model_test.py
+++ b/fire/starlark/render/document_model_test.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""Tests for building the PDF render model from parsed FIRE markdown."""
+
+import pytest
+
+from fire.starlark.render.document_model import build_render_document
+
+_SYSREQ = """\
+# Braking System Requirements
+
+## REQ-BRK-001
+
+Sil: ASIL-D | Sec: true | Version: 1 | Parent: [REQ-SYS-001](/sys.sysreq.md?version=1)
+
+The brake shall engage within 100 ms.
+
+## REQ-BRK-002
+
+Sil: ASIL-B | Sec: false | Version: 2
+
+The brake shall release on command.
+"""
+
+
+@pytest.fixture()
+def document(default_config):
+    return build_render_document(_SYSREQ, "brake.sysreq.md", default_config)
+
+
+class TestDocument:
+    def test_doc_type_from_suffix(self, document):
+        assert document.doc_type == "sysreq"
+
+    def test_display_name(self, document):
+        assert document.display_name == "System Requirement"
+
+    def test_title_from_h1(self, document):
+        assert document.title == "Braking System Requirements"
+
+    def test_title_falls_back_to_stem(self, default_config):
+        doc = build_render_document("## REQ-X\n", "brake.sysreq.md", default_config)
+        assert doc.title == "brake"
+
+    def test_source_path(self, document):
+        assert document.source_path == "brake.sysreq.md"
+
+    def test_unknown_suffix_raises(self, default_config):
+        with pytest.raises(ValueError):
+            build_render_document("# X\n", "notes.txt", default_config)
+
+
+class TestEntries:
+    def test_entry_ids(self, document):
+        assert [e.entry_id for e in document.entries] == ["REQ-BRK-001", "REQ-BRK-002"]
+
+    def test_body_excludes_metadata(self, document):
+        assert document.entries[0].body == "The brake shall engage within 100 ms."
+
+    def test_field_order_follows_config(self, document):
+        names = [f.name for f in document.entries[0].fields]
+        assert names == ["sil", "sec", "version", "parent"]
+
+    def test_optional_field_omitted_when_absent(self, document):
+        names = [f.name for f in document.entries[1].fields]
+        assert names == ["sil", "sec", "version"]
+
+
+class TestFields:
+    def test_display_name_and_value(self, document):
+        sil = document.entries[0].fields[0]
+        assert sil.display_name == "SIL"
+        assert sil.value == "ASIL-D"
+
+    def test_bool_formatting(self, document):
+        sec = document.entries[0].fields[1]
+        assert sec.value == "true"
+
+    def test_int_formatting(self, document):
+        version = document.entries[0].fields[2]
+        assert version.value == "1"
+
+    def test_parent_link_value(self, document):
+        parent = document.entries[0].fields[3]
+        assert parent.values == ("[REQ-SYS-001](/sys.sysreq.md?version=1)",)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/fire/starlark/render/document_model_test.py
+++ b/fire/starlark/render/document_model_test.py
@@ -41,6 +41,10 @@ class TestDocument:
         doc = build_render_document("## REQ-X\n", "brake.sysreq.md", default_config)
         assert doc.title == "brake"
 
+    def test_title_fallback_preserves_dotted_stem(self, default_config):
+        doc = build_render_document("## REQ-X\n", "brake.v1.sysreq.md", default_config)
+        assert doc.title == "brake.v1"
+
     def test_source_path(self, document):
         assert document.source_path == "brake.sysreq.md"
 

--- a/fire/starlark/render/document_model_test.py
+++ b/fire/starlark/render/document_model_test.py
@@ -85,4 +85,4 @@ class TestFields:
 
 
 if __name__ == "__main__":
-    pytest.main([__file__, "-v"])
+    raise SystemExit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
### Summary

Adds the type-agnostic render model that is the first phase of stylesheet-driven PDF export (design: #270).
Introduces `fire/starlark/render/document_model.py` plus unit tests; no Bazel rule and no new runtime dependencies yet.

### Implementation Summary

`build_render_document(content, file_path, config)` turns FIRE markdown into a structured `RenderDocument`:

- Resolves the document type by file suffix via `FireConfig` (raises `ValueError` on an unknown suffix).
- Extracts the document title from the first H1, falling back to the filename stem.
- Reuses `release_report.parse_requirement_sections` for entry/metadata/body parsing (no new parsing logic).
- Emits `RenderEntry`/`RenderField` with fields ordered `required_fields + optional_fields`, absent optionals omitted, and values formatted for display (bool -> `true`/`false`, int -> str, `parent_link` -> tuple of links).

Fields are looked up by `field_def.display_name.lower()`, matching the lowercased keys produced by `metadata_parsing`.
The model is intentionally presentation-agnostic so the Phase 2 Jinja2 template can drive the stable HTML class contract from `fire_config.yaml` with no per-type Python.
Functions are kept small with private helpers; new `document_model` `py_library` and `document_model_test` `py_test` targets are added to `BUILD.bazel`.

### Testing

Unit tests (`render/document_model_test.py`, 14 cases) cover doc-type resolution, the unknown-suffix error, H1/stem title, entry IDs, body extraction, config-driven field ordering, optional-field omission, and value formatting (enum/bool/int/parent_link).
Authored test-first (confirmed failing on missing module, then passing).
Verified with `bazel test //...` (29 pass), `bazel test //... --config=typecheck`, and `prek` (all hooks pass).