### PR TITLE
Add markdown→HTML body renderer (Phase 2)

### DIFF
--- a/fire/starlark/BUILD.bazel
+++ b/fire/starlark/BUILD.bazel
@@ -528,3 +528,21 @@ py_test(
         "@pip//pytest",
     ],
 )
+
+# PDF markdown→HTML body renderer (Phase 2)
+py_library(
+    name = "markdown_render",
+    srcs = ["render/markdown_render.py"],
+    visibility = ["//visibility:public"],
+    deps = ["@pip//markdown_it_py"],
+)
+
+py_test(
+    name = "markdown_render_test",
+    size = "small",
+    srcs = ["render/markdown_render_test.py"],
+    deps = [
+        ":markdown_render",
+        "@pip//pytest",
+    ],
+)

--- a/fire/starlark/render/markdown_render.py
+++ b/fire/starlark/render/markdown_render.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python3
+"""Convert a FIRE markdown body fragment to an HTML fragment.
+
+The render model (Phase 1) carries each entry's body as raw markdown. The
+HTML template (Phase 2) embeds that body as HTML, so this module performs the
+markdown→HTML conversion for paragraphs, inline references/links, tables, and
+fenced code blocks.
+"""
+
+from __future__ import annotations
+
+from markdown_it import MarkdownIt
+
+_RENDERER = MarkdownIt("commonmark").enable("table")
+
+
+def render_markdown(text: str) -> str:
+    """Render a markdown *text* fragment to an HTML fragment.
+
+    Returns an empty string for blank input so callers can emit an empty body
+    without a stray ``<p>`` wrapper.
+    """
+    return _RENDERER.render(text).strip()

--- a/fire/starlark/render/markdown_render_test.py
+++ b/fire/starlark/render/markdown_render_test.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+"""Tests for converting FIRE markdown bodies to HTML fragments."""
+
+import pytest
+
+from fire.starlark.render.markdown_render import render_markdown
+
+
+class TestRenderMarkdown:
+    def test_blank_input_renders_empty(self):
+        assert render_markdown("") == ""
+
+    def test_paragraph(self):
+        assert render_markdown("The brake shall engage.") == (
+            "<p>The brake shall engage.</p>"
+        )
+
+    def test_inline_link(self):
+        html = render_markdown("See [REQ-SYS-001](/sys.sysreq.md?version=1).")
+        assert '<a href="/sys.sysreq.md?version=1">REQ-SYS-001</a>' in html
+
+    def test_table(self):
+        html = render_markdown("| A | B |\n| - | - |\n| 1 | 2 |")
+        assert "<table>" in html
+        assert "<th>A</th>" in html
+        assert "<td>1</td>" in html
+
+    def test_fenced_code(self):
+        html = render_markdown("```\nx = 1\n```")
+        assert "<pre><code>" in html
+        assert "x = 1" in html
+
+    def test_bullet_list(self):
+        html = render_markdown("- one\n- two")
+        assert "<ul>" in html
+        assert "<li>one</li>" in html
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v"]))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,7 @@
 jinja2==3.1.6
 markupsafe==3.0.2
+markdown-it-py==3.0.0
+mdurl==0.1.2
 pyyaml==6.0.3
 pydantic==2.12.5
 pydantic-core==2.41.5


### PR DESCRIPTION
### Summary

Adds the markdown→HTML body renderer for the stylesheet-driven PDF export
([design](docs/design/pdf-export-stylesheets.md)). This is the body-rendering
half of Phase 2; the HTML template that embeds these fragments follows in a
separate PR.

### Implementation Summary

- `fire/starlark/render/markdown_render.py`: `render_markdown(text)` converts a
  FIRE entry body from markdown to an HTML fragment using `markdown-it-py`
  (CommonMark + the table plugin). Blank input renders to an empty string so the
  template can emit an empty body without a stray `<p>`.
- Adds `markdown-it-py` (+ `mdurl`) to `requirements.txt`, scoped as a dep of the
  new `markdown_render` library only.
- New `markdown_render` `py_library` and `markdown_render_test` `py_test` targets.

### Testing

Unit tests (`render/markdown_render_test.py`) cover paragraphs, inline links,
tables, fenced code, bullet lists, and the empty-input case. Verified with
`bazel test` and `bazel test --config=typecheck`; pre-commit passes.