### PR TITLE
Add HTML template rendering and base.css (Phase 2)

### DIFF
--- a/fire/starlark/BUILD.bazel
+++ b/fire/starlark/BUILD.bazel
@@ -546,3 +546,35 @@ py_test(
         "@pip//pytest",
     ],
 )
+
+# PDF render model → HTML via the default template + base.css (Phase 2)
+py_library(
+    name = "html_render",
+    srcs = ["render/html_render.py"],
+    data = glob([
+        "render/templates/*.html.j2",
+        "render/styles/*.css",
+    ]),
+    visibility = ["//visibility:public"],
+    deps = [
+        ":document_model",
+        ":markdown_render",
+        "@pip//jinja2",
+        "@pip//markupsafe",
+    ],
+)
+
+py_test(
+    name = "html_render_test",
+    size = "small",
+    srcs = [
+        "conftest.py",
+        "render/html_render_test.py",
+    ],
+    deps = [
+        ":config_models",
+        ":document_model",
+        ":html_render",
+        "@pip//pytest",
+    ],
+)

--- a/fire/starlark/render/html_render.py
+++ b/fire/starlark/render/html_render.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+"""Render the PDF render model to HTML using a Jinja2 template.
+
+The template defines the stable HTML class contract documented in the PDF
+export design: ``fire-entry``/``fire-field`` classes plus ``data-doc-type`` and
+``data-value`` hooks that user stylesheets target. The FIRE-shipped ``base.css``
+is inlined first and any user stylesheets are inlined after it, so the CSS
+cascade lets users override the defaults without a full rewrite.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from pathlib import Path
+
+from jinja2 import Environment, FileSystemLoader, select_autoescape
+from markupsafe import Markup
+
+from fire.starlark.render.document_model import RenderDocument
+from fire.starlark.render.markdown_render import render_markdown
+
+_TEMPLATES_DIR = Path(__file__).parent / "templates"
+_BASE_CSS = Path(__file__).parent / "styles" / "base.css"
+_DEFAULT_TEMPLATE = "document.html.j2"
+
+
+def render_html(
+    document: RenderDocument,
+    stylesheets: Sequence[str] = (),
+    template_name: str = _DEFAULT_TEMPLATE,
+) -> str:
+    """Render *document* to a self-contained HTML string.
+
+    *stylesheets* are filesystem paths whose contents are cascaded after the
+    FIRE default ``base.css``.
+    """
+    template = _create_environment().get_template(template_name)
+    return template.render(document=document, stylesheets=_collect_styles(stylesheets))
+
+
+def _collect_styles(extra: Sequence[str]) -> list[str]:
+    """Return the base stylesheet followed by each user stylesheet's content."""
+    return [_BASE_CSS.read_text()] + [Path(p).read_text() for p in extra]
+
+
+def _create_environment() -> Environment:
+    """Create the Jinja2 environment with the markdown body filter registered."""
+    env = Environment(
+        loader=FileSystemLoader(_TEMPLATES_DIR),
+        autoescape=select_autoescape(["html", "j2"]),
+        trim_blocks=True,
+        lstrip_blocks=True,
+    )
+    env.filters["markdown"] = lambda text: Markup(render_markdown(text))
+    return env

--- a/fire/starlark/render/html_render_test.py
+++ b/fire/starlark/render/html_render_test.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+"""Tests for rendering the PDF render model to HTML via the default template."""
+
+import pytest
+
+from fire.starlark.render.document_model import build_render_document
+from fire.starlark.render.html_render import render_html
+
+_SYSREQ = """\
+# Braking System Requirements
+
+## REQ-BRK-001
+
+Sil: ASIL-D | Sec: true | Version: 1
+
+The brake shall engage within 100 ms.
+"""
+
+
+@pytest.fixture()
+def document(default_config):
+    return build_render_document(_SYSREQ, "brake.sysreq.md", default_config)
+
+
+class TestStructure:
+    def test_doctype_declaration(self, document):
+        assert render_html(document).lstrip().startswith("<!DOCTYPE html>")
+
+    def test_title_in_head(self, document):
+        assert "<title>Braking System Requirements</title>" in render_html(document)
+
+    def test_cover_shows_display_name(self, document):
+        assert "System Requirement" in render_html(document)
+
+
+class TestEntryContract:
+    def test_entry_section_carries_doc_type(self, document):
+        html = render_html(document)
+        assert '<section class="fire-entry" data-doc-type="sysreq">' in html
+
+    def test_entry_id_heading(self, document):
+        assert '<h2 class="fire-entry__id">REQ-BRK-001</h2>' in render_html(document)
+
+    def test_field_class_and_data_value(self, document):
+        html = render_html(document)
+        assert 'class="fire-field fire-field--sil"' in html
+        assert 'data-value="ASIL-D"' in html
+
+    def test_field_term_and_definition(self, document):
+        html = render_html(document)
+        assert "<dt>SIL</dt>" in html
+        assert "<dd>ASIL-D</dd>" in html
+
+    def test_body_rendered_as_html(self, document):
+        html = render_html(document)
+        assert (
+            '<div class="fire-entry__body"><p>The brake shall engage'
+            " within 100 ms.</p></div>" in html
+        )
+
+
+class TestStylesheets:
+    def test_base_stylesheet_inlined(self, document):
+        assert ".fire-entry" in render_html(document)
+
+    def test_user_stylesheet_cascades_after_base(self, document, tmp_path):
+        override = tmp_path / "corporate.css"
+        override.write_text(".fire-cover__title { color: rebeccapurple; }\n")
+        html = render_html(document, stylesheets=[str(override)])
+        assert "rebeccapurple" in html
+        assert html.index(".fire-entry") < html.index("rebeccapurple")
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v"]))

--- a/fire/starlark/render/styles/base.css
+++ b/fire/starlark/render/styles/base.css
@@ -1,0 +1,123 @@
+/*
+ * FIRE default PDF stylesheet.
+ *
+ * Targets the stable HTML class contract emitted by document.html.j2.
+ * User stylesheets are cascaded after this file, so any rule here can be
+ * overridden without restating the whole sheet.
+ */
+
+@page {
+  size: A4;
+  margin: 20mm 18mm;
+
+  @top-center {
+    content: string(doc-title);
+    font: 9pt/1.2 sans-serif;
+    color: #666;
+  }
+
+  @bottom-right {
+    content: "Page " counter(page) " of " counter(pages);
+    font: 9pt/1.2 sans-serif;
+    color: #666;
+  }
+}
+
+html {
+  font: 10.5pt/1.45 sans-serif;
+  color: #1a1a1a;
+}
+
+body {
+  margin: 0;
+}
+
+.fire-cover {
+  page-break-after: always;
+  padding-top: 60mm;
+  text-align: center;
+}
+
+.fire-cover__title {
+  string-set: doc-title content();
+  font-size: 28pt;
+  font-weight: 700;
+  margin: 0 0 8mm;
+}
+
+.fire-cover__type {
+  font-size: 13pt;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #555;
+}
+
+.fire-entry {
+  page-break-inside: avoid;
+  margin-bottom: 8mm;
+  padding-bottom: 4mm;
+  border-bottom: 0.4pt solid #ddd;
+}
+
+.fire-entry__id {
+  font-size: 13pt;
+  color: #003366;
+  margin: 0 0 2mm;
+}
+
+.fire-fields {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 2mm 6mm;
+  margin: 0 0 3mm;
+}
+
+.fire-field {
+  display: flex;
+  gap: 1.5mm;
+  align-items: baseline;
+}
+
+.fire-field dt {
+  font-weight: 600;
+  color: #555;
+}
+
+.fire-field dd {
+  margin: 0;
+}
+
+.fire-field[data-value="ASIL-D"] dd,
+.fire-field[data-value="ASIL-C"] dd {
+  color: #b00020;
+  font-weight: 700;
+}
+
+.fire-entry__body {
+  margin-top: 2mm;
+}
+
+.fire-entry__body table {
+  border-collapse: collapse;
+  width: 100%;
+  margin: 3mm 0;
+}
+
+.fire-entry__body th,
+.fire-entry__body td {
+  border: 0.4pt solid #bbb;
+  padding: 1.5mm 2.5mm;
+  text-align: left;
+}
+
+.fire-entry__body th {
+  background: #f0f3f7;
+}
+
+.fire-entry__body pre {
+  background: #f5f5f5;
+  border: 0.4pt solid #ddd;
+  padding: 2.5mm;
+  overflow-x: auto;
+  font-size: 9pt;
+}

--- a/fire/starlark/render/templates/document.html.j2
+++ b/fire/starlark/render/templates/document.html.j2
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>{{ document.title }}</title>
+    {% for css in stylesheets %}
+    <style>
+{{ css | safe }}
+    </style>
+    {% endfor %}
+  </head>
+  <body>
+    <header class="fire-cover">
+      <h1 class="fire-cover__title">{{ document.title }}</h1>
+      <p class="fire-cover__type">{{ document.display_name }}</p>
+    </header>
+    <main class="fire-entries">
+      {% for entry in document.entries %}
+      <section class="fire-entry" data-doc-type="{{ document.doc_type }}">
+        <h2 class="fire-entry__id">{{ entry.entry_id }}</h2>
+        {% if entry.fields %}
+        <dl class="fire-fields">
+          {% for field in entry.fields %}
+          <div class="fire-field fire-field--{{ field.name }}" data-value="{{ field.value }}">
+            <dt>{{ field.display_name }}</dt>
+            <dd>{{ field.value }}</dd>
+          </div>
+          {% endfor %}
+        </dl>
+        {% endif %}
+        <div class="fire-entry__body">{{ entry.body | markdown }}</div>
+      </section>
+      {% endfor %}
+    </main>
+  </body>
+</html>


### PR DESCRIPTION
### Summary

Renders the PDF render model to self-contained HTML and ships the default
`base.css`, completing Phase 2 of the [PDF export design](docs/design/pdf-export-stylesheets.md).

> Stacked on #272 (markdown→HTML renderer). Review/merge that one first; this
> PR targets `phase-II-markdown-render` so its diff stays focused.

### Implementation Summary

- `fire/starlark/render/html_render.py`: `render_html(document, stylesheets=())`
  builds a Jinja2 environment (a `markdown` filter converts entry bodies) and
  renders the default template. `base.css` is inlined first, then each user
  stylesheet, so the CSS cascade lets users override defaults without a rewrite.
- `templates/document.html.j2`: defines the stable class contract — cover page,
  `fire-entry` sections with `data-doc-type`, `fire-field fire-field--<name>`
  with `data-value`, and a markdown-rendered `fire-entry__body`.
- `styles/base.css`: A4 paged-media defaults (running header/footer + page
  counters), cover page, field/badge styling, and table/code styling, all
  targeting the class contract.
- New `html_render` `py_library` (with `data` globbing the template + CSS) and
  `html_render_test` `py_test`.

### Testing

Unit tests (`render/html_render_test.py`) assert the document structure, every
class-contract hook, markdown body conversion, base-stylesheet inlining, and
that a user stylesheet cascades after the base. Verified with `bazel test` and
`bazel test --config=typecheck`; pre-commit passes.