### PR TITLE
Add markdown→PDF CLI via WeasyPrint (Phase 3)

### DIFF
--- a/fire/starlark/BUILD.bazel
+++ b/fire/starlark/BUILD.bazel
@@ -578,3 +578,37 @@ py_test(
         "@pip//pytest",
     ],
 )
+
+# PDF CLI: markdown → HTML → PDF via WeasyPrint (Phase 3)
+py_library(
+    name = "render_pdf_lib",
+    srcs = ["render/render_pdf.py"],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":config_models",
+        ":document_model",
+        ":html_render",
+    ],
+)
+
+py_binary(
+    name = "render_pdf_script",
+    srcs = ["render/render_pdf.py"],
+    main = "render/render_pdf.py",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":config_models",
+        ":document_model",
+        ":html_render",
+    ],
+)
+
+py_test(
+    name = "render_pdf_test",
+    size = "small",
+    srcs = ["render/render_pdf_test.py"],
+    deps = [
+        ":render_pdf_lib",
+        "@pip//pytest",
+    ],
+)

--- a/fire/starlark/BUILD.bazel
+++ b/fire/starlark/BUILD.bazel
@@ -588,6 +588,7 @@ py_library(
         ":config_models",
         ":document_model",
         ":html_render",
+        "@pip//weasyprint",
     ],
 )
 
@@ -600,6 +601,7 @@ py_binary(
         ":config_models",
         ":document_model",
         ":html_render",
+        "@pip//weasyprint",
     ],
 )
 

--- a/fire/starlark/render/html_render.py
+++ b/fire/starlark/render/html_render.py
@@ -32,10 +32,20 @@ def render_html(
     """Render *document* to a self-contained HTML string.
 
     *stylesheets* are filesystem paths whose contents are cascaded after the
-    FIRE default ``base.css``.
+    FIRE default ``base.css``. *template_name* is a built-in template name or a
+    path to a custom template file.
     """
-    template = _create_environment().get_template(template_name)
+    name, search_dirs = _resolve_template(template_name)
+    template = _create_environment(search_dirs).get_template(name)
     return template.render(document=document, stylesheets=_collect_styles(stylesheets))
+
+
+def _resolve_template(template_name: str) -> tuple[str, list[str]]:
+    """Return the loader name and search dirs for a name or custom path."""
+    path = Path(template_name)
+    if path.is_file():
+        return path.name, [str(path.parent), str(_TEMPLATES_DIR)]
+    return template_name, [str(_TEMPLATES_DIR)]
 
 
 def _collect_styles(extra: Sequence[str]) -> list[str]:
@@ -43,10 +53,10 @@ def _collect_styles(extra: Sequence[str]) -> list[str]:
     return [_BASE_CSS.read_text()] + [Path(p).read_text() for p in extra]
 
 
-def _create_environment() -> Environment:
+def _create_environment(search_dirs: Sequence[str]) -> Environment:
     """Create the Jinja2 environment with the markdown body filter registered."""
     env = Environment(
-        loader=FileSystemLoader(_TEMPLATES_DIR),
+        loader=FileSystemLoader(search_dirs),
         autoescape=select_autoescape(["html", "j2"]),
         trim_blocks=True,
         lstrip_blocks=True,

--- a/fire/starlark/render/html_render_test.py
+++ b/fire/starlark/render/html_render_test.py
@@ -59,6 +59,17 @@ class TestEntryContract:
         )
 
 
+class TestTemplateOverride:
+    def test_custom_template_path_is_used(self, document, tmp_path):
+        custom = tmp_path / "minimal.html.j2"
+        custom.write_text("<h1>{{ document.title }}</h1>\n")
+        html = render_html(document, template_name=str(custom))
+        assert html.strip() == "<h1>Braking System Requirements</h1>"
+
+    def test_builtin_template_name_still_resolves(self, document):
+        assert "fire-entry" in render_html(document, template_name="document.html.j2")
+
+
 class TestStylesheets:
     def test_base_stylesheet_inlined(self, document):
         assert ".fire-entry" in render_html(document)

--- a/fire/starlark/render/render_pdf.py
+++ b/fire/starlark/render/render_pdf.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+"""CLI: render a FIRE markdown document to a styled PDF via WeasyPrint.
+
+The pipeline reuses the render model (Phase 1) and HTML rendering (Phase 2):
+markdown + config → render model → self-contained HTML → PDF. The WeasyPrint
+import is guarded so a missing engine produces an actionable error rather than
+an opaque ``ImportError``; the engine and its fonts are provisioned in the host
+environment (see the README PDF Export prerequisites).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from pathlib import Path
+
+from fire.starlark.config_models import load_config
+from fire.starlark.render.document_model import build_render_document
+from fire.starlark.render.html_render import render_html
+
+_ENGINE_MISSING = (
+    "WeasyPrint is required to render PDFs but could not be imported. Install "
+    "it (`pip install weasyprint`) and provision its native libraries (pango, "
+    "cairo, harfbuzz) and fonts. See the PDF Export section of the README."
+)
+
+
+def build_html(
+    source: str,
+    config: str | None = None,
+    stylesheets: Sequence[str] = (),
+    template: str | None = None,
+) -> str:
+    """Render *source* markdown to a self-contained HTML string."""
+    content = Path(source).read_text()
+    document = build_render_document(content, source, load_config(config))
+    if template is None:
+        return render_html(document, stylesheets=stylesheets)
+    return render_html(document, stylesheets=stylesheets, template_name=template)
+
+
+def write_pdf(html: str, out: str) -> None:
+    """Write *html* to the PDF file *out* using the WeasyPrint engine."""
+    _load_engine().HTML(string=html).write_pdf(out)
+
+
+def _load_engine():
+    """Import WeasyPrint, raising an actionable error when it is missing."""
+    try:
+        import weasyprint
+    except ImportError as exc:
+        raise RuntimeError(_ENGINE_MISSING) from exc
+    return weasyprint
+
+
+def main() -> int:
+    """CLI entrypoint for Bazel."""
+    import argparse
+    import sys
+
+    parser = argparse.ArgumentParser(description="Render a FIRE document to PDF")
+    parser.add_argument("source", help="Markdown document to render")
+    parser.add_argument("--config", default=None, help="Path to fire_config.yaml")
+    parser.add_argument(
+        "--stylesheet",
+        action="append",
+        default=[],
+        dest="stylesheets",
+        help="CSS file cascaded after base.css (repeatable)",
+    )
+    parser.add_argument(
+        "--template", default=None, help="Custom HTML template path or built-in name"
+    )
+    parser.add_argument("--out", required=True, help="Output PDF path")
+    args = parser.parse_args()
+
+    html = build_html(args.source, args.config, args.stylesheets, args.template)
+    try:
+        write_pdf(html, args.out)
+    except RuntimeError as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/fire/starlark/render/render_pdf.py
+++ b/fire/starlark/render/render_pdf.py
@@ -2,10 +2,10 @@
 """CLI: render a FIRE markdown document to a styled PDF via WeasyPrint.
 
 The pipeline reuses the render model (Phase 1) and HTML rendering (Phase 2):
-markdown + config → render model → self-contained HTML → PDF. The WeasyPrint
-import is guarded so a missing engine produces an actionable error rather than
-an opaque ``ImportError``; the engine and its fonts are provisioned in the host
-environment (see the README PDF Export prerequisites).
+markdown + config → render model → self-contained HTML → PDF. WeasyPrint
+itself is a normal pip dependency, but it loads native libraries (pango, cairo,
+harfbuzz) at import time; that load is guarded so a host missing those libraries
+or fonts produces an actionable error rather than an opaque ``OSError``.
 """
 
 from __future__ import annotations
@@ -18,9 +18,9 @@ from fire.starlark.render.document_model import build_render_document
 from fire.starlark.render.html_render import render_html
 
 _ENGINE_MISSING = (
-    "WeasyPrint is required to render PDFs but could not be imported. Install "
-    "it (`pip install weasyprint`) and provision its native libraries (pango, "
-    "cairo, harfbuzz) and fonts. See the PDF Export section of the README."
+    "WeasyPrint could not be initialized. Its native libraries (pango, cairo, "
+    "harfbuzz) and fonts must be available on the host; see the PDF Export "
+    "section of the README for prerequisites."
 )
 
 
@@ -44,10 +44,14 @@ def write_pdf(html: str, out: str) -> None:
 
 
 def _load_engine():
-    """Import WeasyPrint, raising an actionable error when it is missing."""
+    """Import WeasyPrint, raising an actionable error when its libs are missing.
+
+    A missing native library or font surfaces as ``OSError`` from the cffi
+    bindings at import time; ``ImportError`` covers an absent package.
+    """
     try:
         import weasyprint
-    except ImportError as exc:
+    except (ImportError, OSError) as exc:
         raise RuntimeError(_ENGINE_MISSING) from exc
     return weasyprint
 

--- a/fire/starlark/render/render_pdf_test.py
+++ b/fire/starlark/render/render_pdf_test.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+"""Tests for the FIRE markdown→PDF CLI pipeline and engine guard."""
+
+import builtins
+
+import pytest
+
+from fire.starlark.render.render_pdf import build_html, main, write_pdf
+
+_SYSREQ = """\
+# Braking System Requirements
+
+## REQ-BRK-001
+
+Sil: ASIL-D | Sec: true | Version: 1
+
+The brake shall engage within 100 ms.
+"""
+
+
+@pytest.fixture()
+def source(tmp_path):
+    path = tmp_path / "brake.sysreq.md"
+    path.write_text(_SYSREQ)
+    return str(path)
+
+
+def _block_weasyprint(monkeypatch):
+    real_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == "weasyprint":
+            raise ImportError("weasyprint not installed")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+
+
+class TestBuildHtml:
+    def test_default_config_renders_entry(self, source):
+        html = build_html(source)
+        assert '<h2 class="fire-entry__id">REQ-BRK-001</h2>' in html
+
+    def test_body_is_rendered(self, source):
+        assert "<p>The brake shall engage within 100 ms.</p>" in build_html(source)
+
+    def test_stylesheet_is_inlined(self, source, tmp_path):
+        override = tmp_path / "corp.css"
+        override.write_text(".fire-cover__title { color: rebeccapurple; }\n")
+        assert "rebeccapurple" in build_html(source, stylesheets=[str(override)])
+
+    def test_custom_template(self, source, tmp_path):
+        template = tmp_path / "minimal.html.j2"
+        template.write_text("<h1>{{ document.title }}</h1>\n")
+        html = build_html(source, template=str(template))
+        assert html.strip() == "<h1>Braking System Requirements</h1>"
+
+
+class TestEngineGuard:
+    def test_write_pdf_raises_actionable_error(self, monkeypatch, tmp_path):
+        _block_weasyprint(monkeypatch)
+        with pytest.raises(RuntimeError, match="WeasyPrint"):
+            write_pdf("<html></html>", str(tmp_path / "out.pdf"))
+
+    def test_main_reports_missing_engine(self, monkeypatch, capsys, source, tmp_path):
+        _block_weasyprint(monkeypatch)
+        out = str(tmp_path / "out.pdf")
+        monkeypatch.setattr("sys.argv", ["render_pdf", source, "--out", out])
+        assert main() == 1
+        assert "WeasyPrint" in capsys.readouterr().err
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v"]))

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,16 @@ iniconfig==2.3.0
 packaging==25.0
 tomli==2.4.0
 pygments==2.19.2
+weasyprint==69.0
+pydyf==0.12.1
+cffi==2.0.0
+pycparser==3.0
+tinycss2==1.5.1
+tinyhtml5==2.1.0
+cssselect2==0.9.0
+webencodings==0.5.1
+pyphen==0.17.2
+pillow==12.2.0
+fonttools==4.63.0
+brotli==1.2.0
+zopfli==0.4.3


### PR DESCRIPTION
### Summary

Adds the `render_pdf` CLI that converts a FIRE markdown document to a styled PDF
via WeasyPrint, completing Phase 3 of the
[PDF export design](docs/design/pdf-export-stylesheets.md).

### Implementation Summary

- `fire/starlark/render/render_pdf.py`:
  - `build_html(source, config, stylesheets, template)` reuses the render model
    (Phase 1) and HTML rendering (Phase 2) to produce self-contained HTML.
  - `write_pdf(html, out)` renders the PDF via WeasyPrint; the import is **guarded**
    so a missing engine raises an actionable `RuntimeError` (install hint + native
    libs/fonts) rather than an opaque `ImportError`.
  - `main()` CLI: positional `source`, `--config`, `--stylesheet` (repeatable),
    `--template`, `--out`; returns exit code 1 and prints the actionable message
    when the engine is missing.
- `render_html` now resolves `template_name` as either a built-in name or a path
  to a custom template file, backing the `--template` flag.
- New `render_pdf_lib` / `render_pdf_script` / `render_pdf_test` targets, mirroring
  the existing `generate_format_spec_*` pattern.

WeasyPrint is intentionally **not** added as a Bazel dependency here: per the
design it is provisioned from the host environment (the Phase 4 rule runs with
`no_sandbox`/`use_default_shell_env`). The dependency wiring, `document_pdf` rule,
and an integration test asserting a non-empty PDF land in Phase 4.

### Testing

Unit tests (`render/render_pdf_test.py`) cover the HTML pipeline (default config,
body rendering, stylesheet inlining, custom template) and the engine guard (the
missing-engine path is forced deterministically by blocking the `weasyprint`
import, asserting both the `RuntimeError` and the CLI's exit-code-1 + stderr
message). `render/html_render_test.py` adds custom-template-path coverage.
Verified with `bazel test` and `bazel test --config=typecheck`; pre-commit passes.