### PR TITLE
Add document_pdf Bazel rule and integration test (Phase 4)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -121,6 +121,13 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Install WeasyPrint native libraries and fonts
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libpango-1.0-0 libpangocairo-1.0-0 libpangoft2-1.0-0 \
+            libgdk-pixbuf-2.0-0 libharfbuzz0b libffi-dev fonts-dejavu-core
+
       - name: Cache Bazel
         uses: actions/cache@v4
         with:

--- a/README.md
+++ b/README.md
@@ -360,3 +360,52 @@ generate_format_specification(
     out = "FORMAT_SPECIFICATION.md",
 )
 ```
+
+## PDF Export
+
+Render a FIRE markdown document to a styled PDF with the `document_pdf` rule.
+Styling is controlled entirely through CSS: a default `base.css` ships with
+FIRE and your stylesheets cascade after it (no Python required).
+
+```starlark
+load("@fire//fire/starlark:pdf.bzl", "document_pdf")
+
+document_pdf(
+    name = "braking_pdf",
+    srcs = ["braking.sysreq.md"],
+    stylesheets = ["//branding:corporate.css"],  # optional, cascaded over base.css
+    # config = ":fire_config.yaml",               # optional, defaults to built-in
+    # template = "//branding:doc.html.j2",         # optional template override
+    out = "braking.pdf",
+)
+```
+
+```bash
+bazel build //path/to:braking_pdf
+open bazel-bin/path/to/braking.pdf
+```
+
+### Prerequisites
+
+Rendering uses [WeasyPrint](https://weasyprint.org/), which loads native
+libraries (pango, cairo, harfbuzz) and fonts from the host. The Python package
+is provided by Bazel, but the native libraries and fonts must be installed
+separately. On Debian/Ubuntu:
+
+```bash
+sudo apt-get install -y libpango-1.0-0 libpangocairo-1.0-0 libpangoft2-1.0-0 \
+  libgdk-pixbuf-2.0-0 libharfbuzz0b libffi-dev fonts-dejavu-core
+```
+
+On macOS: `brew install pango` (and a font package such as
+`font-dejavu`). When the libraries or fonts are missing, the build fails with
+an actionable message rather than producing a partial PDF.
+
+### Known limitation: PDF rendering via Bazel on macOS
+
+Building a `document_pdf` target with `bazel` on macOS currently fails to find
+the Homebrew native libraries even when they are installed. macOS System
+Integrity Protection strips `DYLD_*` variables from the build action's
+environment, so the dynamic loader cannot locate `/opt/homebrew/lib`. Render on
+Linux (this is what CI uses); macOS rendering through Bazel is not yet
+supported.

--- a/fire/starlark/BUILD.bazel
+++ b/fire/starlark/BUILD.bazel
@@ -5,11 +5,14 @@ exports_files([
     "fire_rule_utils.bzl",
     "format_spec.bzl",
     "parameters.bzl",
+    "pdf.bzl",
     "requirements.bzl",
     "reports.bzl",
     "traceability.bzl",
     "generate_code.py",
     "validate_cross_references.py",
+    "render/styles/base.css",
+    "render/templates/document.html.j2",
 ])
 
 py_binary(

--- a/fire/starlark/pdf.bzl
+++ b/fire/starlark/pdf.bzl
@@ -1,0 +1,92 @@
+"""Bazel rule for rendering a FIRE markdown document to a styled PDF.
+
+The action runs the ``render_pdf`` binary with ``no_sandbox`` and the host
+shell environment (the same escape hatch as the other FIRE rules) because
+WeasyPrint loads native libraries (pango, cairo, harfbuzz) and fonts that must
+be provisioned on the host; see the README PDF Export prerequisites.
+"""
+
+load("//fire/starlark:fire_rule_utils.bzl", "run_python_script")
+
+def _document_pdf_impl(ctx):
+    """Render a single FIRE markdown document to a PDF artifact."""
+    srcs = ctx.files.srcs
+    if len(srcs) != 1:
+        fail(
+            "document_pdf renders a single document (multi-file merge is " +
+            "deferred); got %d sources" % len(srcs),
+        )
+    source = srcs[0]
+
+    args = ctx.actions.args()
+    args.add(source.short_path)
+    args.add("--out", ctx.outputs.out.path)
+
+    extra_inputs = list(srcs)
+    if ctx.file.config:
+        args.add("--config", ctx.file.config.short_path)
+        extra_inputs.append(ctx.file.config)
+    for sheet in ctx.files.stylesheets:
+        args.add("--stylesheet", sheet.short_path)
+    extra_inputs += ctx.files.stylesheets
+    if ctx.file.template:
+        args.add("--template", ctx.file.template.short_path)
+        extra_inputs.append(ctx.file.template)
+
+    run_python_script(
+        ctx,
+        script = ctx.executable._script,
+        script_target = ctx.attr._script,
+        args = args,
+        extra_inputs = extra_inputs,
+        outputs = [ctx.outputs.out],
+        mnemonic = "DocumentPdf",
+        progress_message = "Rendering PDF for %s" % ctx.label.name,
+        use_default_shell_env = True,
+        no_sandbox = True,
+    )
+
+    return [DefaultInfo(files = depset([ctx.outputs.out]))]
+
+document_pdf = rule(
+    implementation = _document_pdf_impl,
+    attrs = {
+        "config": attr.label(
+            allow_single_file = [".yaml", ".yml"],
+            doc = "Optional fire_config.yaml; defaults to the embedded config",
+        ),
+        "out": attr.output(
+            mandatory = True,
+            doc = "Generated PDF artifact",
+        ),
+        "srcs": attr.label_list(
+            allow_files = [".md"],
+            mandatory = True,
+            doc = "Markdown document to render (a single document in v1)",
+        ),
+        "stylesheets": attr.label_list(
+            allow_files = [".css"],
+            default = [],
+            doc = "CSS files cascaded after the FIRE base.css, in order",
+        ),
+        "template": attr.label(
+            allow_single_file = [".j2", ".html"],
+            doc = "Optional HTML template overriding the default",
+        ),
+        "_script": attr.label(
+            default = Label("//fire/starlark:render_pdf_script"),
+            executable = True,
+            cfg = "exec",
+        ),
+    },
+    doc = """Renders a FIRE markdown document to a styled PDF via WeasyPrint.
+
+    Example:
+        document_pdf(
+            name = "braking_pdf",
+            srcs = ["braking.sysreq.md"],
+            stylesheets = ["//branding:corporate.css"],
+            out = "braking.pdf",
+        )
+    """,
+)

--- a/integration_test/BUILD.bazel
+++ b/integration_test/BUILD.bazel
@@ -2,6 +2,7 @@
 
 load("@fire//fire/starlark:codegen.bzl", "generate_cc_parameters", "generate_rust_parameters")
 load("@fire//fire/starlark:parameters.bzl", "parameter_library")
+load("@fire//fire/starlark:pdf.bzl", "document_pdf")
 load("@fire//fire/starlark:reports.bzl", "release_readiness_test", "release_report")
 load("@fire//fire/starlark:traceability.bzl", "source_traceability")
 load("@rules_cc//cc:defs.bzl", "cc_library")
@@ -86,6 +87,13 @@ source_traceability(
             "REQ-INT-004?version=1",
         ],
     },
+)
+
+# Render a styled PDF deliverable (end-to-end document_pdf rule)
+document_pdf(
+    name = "integration_pdf",
+    srcs = ["braking.sysreq.md"],
+    out = "braking.pdf",
 )
 
 # Release readiness report

--- a/integration_test/braking.sysreq.md
+++ b/integration_test/braking.sysreq.md
@@ -1,0 +1,20 @@
+# Braking System Requirements
+
+## REQ-BRK-001
+
+SIL: ASIL-D | Sec: True | Version: 1
+
+**Brake Engagement Latency**
+
+The braking system SHALL engage within 100 ms of a brake command.
+
+| Condition | Limit  |
+| --------- | ------ |
+| Dry road  | 100 ms |
+| Wet road  | 150 ms |
+
+## REQ-BRK-002
+
+SIL: ASIL-B | Sec: False | Version: 2
+
+The braking system SHALL release on command.

--- a/integration_test/run.sh
+++ b/integration_test/run.sh
@@ -98,6 +98,26 @@ else
 fi
 echo ""
 
+echo "Rendering PDF deliverable (document_pdf)..."
+PDF_BUILD_LOG=$(mktemp)
+if bazel build $BAZEL_OPTS //:integration_pdf 2>"$PDF_BUILD_LOG"; then
+    PDF_OUT="bazel-bin/braking.pdf"
+    if [ -s "$PDF_OUT" ] && head -c 4 "$PDF_OUT" | grep -q "%PDF"; then
+        echo "PDF deliverable generated successfully ($(wc -c <"$PDF_OUT") bytes)"
+    else
+        echo "ERROR: PDF deliverable was not produced or is empty"
+        exit 1
+    fi
+elif grep -q "WeasyPrint could not" "$PDF_BUILD_LOG"; then
+    echo "WARNING: skipping PDF assertion - WeasyPrint native libraries/fonts"
+    echo "         are not available on this host (see README PDF Export)."
+else
+    cat "$PDF_BUILD_LOG"
+    echo "ERROR: PDF build failed"
+    exit 1
+fi
+echo ""
+
 echo "Running release readiness test..."
 bazel test $BAZEL_OPTS //:integration_release_readiness --test_output=all
 echo ""


### PR DESCRIPTION
### Summary

Adds the `document_pdf` Bazel rule and an end-to-end integration test that
renders a styled PDF, completing Phase 4 of the
[PDF export design](docs/design/pdf-export-stylesheets.md).

### Implementation Summary

- `fire/starlark/pdf.bzl`: `document_pdf` rule — renders a FIRE markdown
  document to a PDF artifact via the `render_pdf` binary. Attributes: `srcs`
  (single document in v1), optional `config`, ordered `stylesheets`, optional
  `template`, and the `out` PDF. The action runs with `no_sandbox` +
  `use_default_shell_env` (the same escape hatch as the other FIRE rules)
  because WeasyPrint loads native libraries (pango/cairo/harfbuzz) and fonts
  from the host.
- `fire/starlark/BUILD.bazel`: exports `pdf.bzl` plus the default `base.css`
  and `document.html.j2` so consumers can reference or override them.
- `integration_test/`: renders `braking.sysreq.md` via `document_pdf` and
  asserts a non-empty `%PDF` artifact in `run.sh`. The assertion is skipped
  with a warning when WeasyPrint's native libraries are unavailable (e.g. local
  macOS), so `run.sh` stays runnable off-CI.
- `.github/workflows/ci.yaml`: the (ubuntu) integration job now installs the
  WeasyPrint native libraries and DejaVu fonts before running `run.sh`.

### Testing

- Verified the rule analyzes in the consumer workspace (`bazel build --nobuild
  //:integration_pdf`) and that the constructed action is correct via `bazel
  aquery`: `render_pdf_script braking.sysreq.md --out …/braking.pdf`, mnemonic
  `DocumentPdf`, with the sources, default config, base.css, template, and
  weasyprint in its inputs.
- Confirmed the `run.sh` skip-path triggers on a host without the native libs
  (this branch's CI integration job installs them so the real assertion runs).
- Existing render unit tests still pass (`bazel test //fire/starlark:...`);
  pre-commit (incl. buildifier) clean.

Real end-to-end rendering on macOS via `bazel` is blocked by SIP stripping
`DYLD_*` from the action env (the libs exist but the loader can't see them);
the integration matrix is ubuntu-only, where pango is on the default linker
path. A sample PDF rendered through this exact pipeline was shared earlier.