### PR TITLE
Document CSS customization and add stylesheet example (Phase 5)

### DIFF
--- a/README.md
+++ b/README.md
@@ -385,6 +385,43 @@ bazel build //path/to:braking_pdf
 open bazel-bin/path/to/braking.pdf
 ```
 
+### Customizing the styling
+
+The template emits a stable set of HTML classes and `data-` attributes that your
+stylesheets target, so new document types and fields are styled in CSS with no
+Python changes:
+
+```html
+<section class="fire-entry" data-doc-type="sysreq">
+  <h2 class="fire-entry__id">REQ-BRK-001</h2>
+  <dl class="fire-fields">
+    <div class="fire-field fire-field--sil" data-value="ASIL-D">
+      <dt>SIL</dt>
+      <dd>ASIL-D</dd>
+    </div>
+  </dl>
+  <div class="fire-entry__body">…</div>
+</section>
+```
+
+Each stylesheet in `stylesheets` cascades after the built-in `base.css`, so you
+override only what you need:
+
+```css
+.fire-entry[data-doc-type="sysreq"] .fire-entry__id {
+  color: #003366;
+}
+.fire-field--sil[data-value="ASIL-D"] dd {
+  color: #b00020;
+  font-weight: 700;
+}
+```
+
+The default stylesheet and template ship at
+`@fire//fire/starlark:render/styles/base.css` and
+`@fire//fire/starlark:render/templates/document.html.j2`; copy them as a starting
+point and pass your versions via `stylesheets` or `template`.
+
 ### Prerequisites
 
 Rendering uses [WeasyPrint](https://weasyprint.org/), which loads native

--- a/fire/starlark/render/styles/base.css
+++ b/fire/starlark/render/styles/base.css
@@ -76,6 +76,7 @@ body {
   display: flex;
   gap: 1.5mm;
   align-items: baseline;
+  white-space: nowrap;
 }
 
 .fire-field dt {

--- a/integration_test/BUILD.bazel
+++ b/integration_test/BUILD.bazel
@@ -94,6 +94,7 @@ document_pdf(
     name = "integration_pdf",
     srcs = ["braking.sysreq.md"],
     out = "braking.pdf",
+    stylesheets = ["branding.css"],
 )
 
 # Release readiness report

--- a/integration_test/branding.css
+++ b/integration_test/branding.css
@@ -1,0 +1,9 @@
+/* Example branding stylesheet cascaded over the FIRE base.css. */
+
+.fire-cover__title {
+  color: #003366;
+}
+
+.fire-entry__id {
+  color: #00553b;
+}


### PR DESCRIPTION
### Summary

Completes Phase 5 of the [PDF export design](docs/design/pdf-export-stylesheets.md):
documents the CSS customization contract and adds a worked stylesheet example.
(The README "PDF Export" section, prerequisites, and the macOS limitation
landed with #275.)

### Implementation Summary

- `README.md`: new "Customizing the styling" subsection documenting the stable
  HTML class contract (`fire-entry`/`fire-field` classes, `data-doc-type`,
  `data-value`) and how user stylesheets cascade over the built-in `base.css`,
  with the export paths of the default `base.css` and template.
- `integration_test/branding.css` + `integration_pdf` target: an example
  branding stylesheet wired through `document_pdf`, exercising the stylesheet
  cascade end-to-end (the action now passes `--stylesheet branding.css`).
- `base.css`: keep field values on one line (`white-space: nowrap` on
  `.fire-field`) so badges like `ASIL-D` no longer wrap mid-token.

### Testing

- Verified the integration target still analyzes and `bazel aquery` shows the
  stylesheet in the action: `render_pdf_script braking.sysreq.md --out … --stylesheet branding.css`.
- Re-rendered the sample through the pipeline to confirm `ASIL-D` stays on one
  line and tables render correctly.
- pre-commit (markdownlint, prettier, buildifier, …) clean.