### PR TITLE
Surface WeasyPrint's underlying error in the engine guard

### DIFF
--- a/fire/starlark/render/render_pdf.py
+++ b/fire/starlark/render/render_pdf.py
@@ -52,7 +52,7 @@ def _load_engine():
     try:
         import weasyprint
     except (ImportError, OSError) as exc:
-        raise RuntimeError(_ENGINE_MISSING) from exc
+        raise RuntimeError(f"{_ENGINE_MISSING}\n\nUnderlying error: {exc}") from exc
     return weasyprint
 
 

--- a/fire/starlark/render/render_pdf_test.py
+++ b/fire/starlark/render/render_pdf_test.py
@@ -59,7 +59,13 @@ class TestBuildHtml:
 class TestEngineGuard:
     def test_write_pdf_raises_actionable_error(self, monkeypatch, tmp_path):
         _block_weasyprint(monkeypatch)
-        with pytest.raises(RuntimeError, match="WeasyPrint"):
+        with pytest.raises(RuntimeError) as excinfo:
+            write_pdf("<html></html>", str(tmp_path / "out.pdf"))
+        assert "WeasyPrint" in str(excinfo.value)
+
+    def test_write_pdf_surfaces_underlying_error(self, monkeypatch, tmp_path):
+        _block_weasyprint(monkeypatch)
+        with pytest.raises(RuntimeError, match="weasyprint not installed"):
             write_pdf("<html></html>", str(tmp_path / "out.pdf"))
 
     def test_main_reports_missing_engine(self, monkeypatch, capsys, source, tmp_path):
@@ -67,7 +73,9 @@ class TestEngineGuard:
         out = str(tmp_path / "out.pdf")
         monkeypatch.setattr("sys.argv", ["render_pdf", source, "--out", out])
         assert main() == 1
-        assert "WeasyPrint" in capsys.readouterr().err
+        err = capsys.readouterr().err
+        assert "WeasyPrint" in err
+        assert "weasyprint not installed" in err
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Summary

The PDF engine guard masked WeasyPrint's real failure reason. It now appends the
original error to the actionable message.

### Implementation Summary

`_load_engine` caught WeasyPrint's `ImportError`/`OSError` and raised a generic
`RuntimeError(_ENGINE_MISSING)`; `main()` printed only that string, so the chained
cause (e.g. *which* native library failed to `dlopen`) was dropped. The guard now
raises `RuntimeError(f"{_ENGINE_MISSING}\n\nUnderlying error: {exc}")`, surfacing
the specific reason while keeping the install guidance.

Before:

```
WeasyPrint could not be initialized. Its native libraries ... see the README.
```

After:

```
WeasyPrint could not be initialized. Its native libraries ... see the README.

Underlying error: cannot load library 'libgobject-2.0-0': dlopen(libgobject-2.0-0, 0x0002): tried: ... (no such file) ...
```

### Testing

- Added `test_write_pdf_surfaces_underlying_error` and extended
  `test_main_reports_missing_engine` to assert the underlying error text is
  present.
- `bazel test //fire/starlark:render_pdf_test` (with and without
  `--config=typecheck`) passes; verified live via `bazel run` that the real
  `dlopen` failure now appears in the output.