### PR TITLE
Author BCR release commits as a CLA-signed identity

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -169,8 +169,10 @@ jobs:
         run: |
           VERSION="${{ steps.version.outputs.version }}"
           cd bcr
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
+          # Author must be a CLA-signed identity, not the Actions bot, or the
+          # BCR PR's cla/google check fails.
+          git config user.name "Jochen Issing"
+          git config user.email "github@nesono.com"
           git add modules/fire/
           git commit -m "Add fire ${VERSION}"
           git push origin "fire-${VERSION}"


### PR DESCRIPTION
### Summary

Fixes the BCR PR's failing `cla/google` check by committing the BCR entry under
a CLA-signed identity instead of the GitHub Actions bot.

### Implementation Summary

The `publish-to-bcr` job's "Commit and push" step set
`git config user.name/email` to `github-actions[bot]`. That bot email is not
associated with a CLA-signed GitHub account, so the automated PR on
`bazel-central-registry` failed Google's `cla/google` check. Set the author and
committer to `github@nesono.com` (Jochen Issing).

### Testing

`pre-commit` passes. Verified live on the open fire 0.6.0 BCR PR (#9663 on
bazelbuild/bazel-central-registry): re-authoring the existing commit under
`github@nesono.com` flipped `cla/google` from fail to pass.