### PR TITLE
Add PL-e to the default SIL values (#281)

### DIFF
--- a/FORMAT_SPECIFICATION.md
+++ b/FORMAT_SPECIFICATION.md
@@ -71,6 +71,7 @@ Fields must be separated by `|` (space-pipe-space).
 - **ISO 26262 (Automotive):** `ASIL-A`, `ASIL-B`, `ASIL-C`, `ASIL-D`
 - **IEC 61508 (General):** `SIL-1`, `SIL-2`, `SIL-3`, `SIL-4`
 - **DO-178C/DO-254 (Aviation):** `DAL-A`, `DAL-B`, `DAL-C`, `DAL-D`, `DAL-E`
+- **ISO 13849 (Machinery):** `PL-a`, `PL-b`, `PL-c`, `PL-d`, `PL-e`
 - **Quality Management:** `QM`
 - **TODO Placeholder:** `TODO(TICKET-ID)` where TICKET-ID matches `[A-Z]+-[0-9]+`
 

--- a/fire/starlark/config_models_test.py
+++ b/fire/starlark/config_models_test.py
@@ -146,6 +146,7 @@ class TestLoadConfig:
         assert "SIL-1" in sil.values
         assert "DAL-A" in sil.values
         assert "PL-a" in sil.values
+        assert "PL-e" in sil.values
         assert "QM" in sil.values
 
     def test_load_custom_config(self, tmp_path):
@@ -175,5 +176,9 @@ class TestLoadConfig:
         assert cfg.document_types["handbook"].suffix == ".handbook.md"
 
     def test_load_nonexistent_file(self, tmp_path):
-        with pytest.raises(FileNotFoundError):
+        with pytest.raises(OSError):
             load_config(tmp_path / "nonexistent.yaml")
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v"]))

--- a/fire/starlark/default_fire_config.yaml
+++ b/fire/starlark/default_fire_config.yaml
@@ -24,6 +24,7 @@ field_definitions:
       - "PL-b"
       - "PL-c"
       - "PL-d"
+      - "PL-e"
       - "QM"
     allow_todo: true
     description: "Safety Integrity Level (ISO 26262, IEC 61508, DO-178C/DO-254, ISO 13849, QM)"

--- a/fire/starlark/dynamic_requirement_model_test.py
+++ b/fire/starlark/dynamic_requirement_model_test.py
@@ -192,7 +192,11 @@ class TestRegreqEquivalence:
 
 class TestNewSilValues:
     def test_pl_values_accepted(self, models):
-        for pl in ("PL-a", "PL-b", "PL-c", "PL-d"):
+        for pl in ("PL-a", "PL-b", "PL-c", "PL-d", "PL-e"):
             data = {**_VALID_SYSREQ, "sil": pl}
             result = models["sysreq"].model_validate(data)
             assert result.sil == pl
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
### Summary

Adds `PL-e` (ISO 13849 Performance Level) to the default `sil` field values, per #281.

### Implementation Summary

- `default_fire_config.yaml`: add `PL-e` to the `sil` enum. ISO 13849 defines
  Performance Levels a–e, but the config listed only `PL-a`..`PL-d`.
- `FORMAT_SPECIFICATION.md`: add an **ISO 13849 (Machinery)** line listing
  `PL-a`..`PL-e`. The hand-curated SIL section previously omitted the ISO 13849
  levels entirely.
- Tests: assert `PL-e` in the loaded config (`config_models_test`) and that the
  model accepts it (`dynamic_requirement_model_test`).

**Incidental fix (worth flagging):** both `config_models_test.py` and
`dynamic_requirement_model_test.py` were missing the trailing
`pytest.main()` call, so **Bazel never actually executed them** — they reported
green without running a single assertion. Added the call to both. Enabling
`config_models_test` surfaced one stale assertion (`test_load_nonexistent_file`
expected `FileNotFoundError`, but `load_config` raises `OSError`), now corrected.

### Testing

`bazel test //fire/...` (22 pass) and `bazel build --config=typecheck //fire/...`
both pass; pre-commit clean. Verified the two previously-inert test files now
execute their assertions.

### Follow-up (separate)

Five other test files are still missing `pytest.main()` and therefore don't run
under Bazel: `generate_format_spec_test`, `parameter_models_test`,
`version_tracking_test`, `metadata_parsing_test`, `validate_cross_references_test`.
I'll open a separate issue to enable them (may surface further hidden failures),
to keep this PR focused on #281.

Closes #281