### PR TITLE
Enable inert test files and fix surfaced failures (#284)

### DIFF
--- a/fire/starlark/generate_format_spec_test.py
+++ b/fire/starlark/generate_format_spec_test.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python3
 """Tests for the format specification generator."""
 
+import pytest
+
 from fire.starlark.config_models import FireConfig
 from fire.starlark.generate_format_spec import generate_format_spec
 
@@ -52,17 +54,17 @@ class TestGenerateFormatSpec:
 
     def test_sysreq_shows_required_sil(self, default_config):
         output = generate_format_spec(default_config)
-        # sysreq section should show SIL as required
-        sysreq_start = output.index("System Requirement")
-        # Find the next document type section to bound our search
-        swreq_start = output.index("Software Requirement")
+        # sysreq section should show SIL as required. Anchor on the "## "
+        # section heading, not the Table of Contents entry.
+        sysreq_start = output.index("## System Requirement")
+        swreq_start = output.index("## Software Requirement")
         sysreq_section = output[sysreq_start:swreq_start]
         assert "**Required:** Yes" in sysreq_section
 
     def test_regreq_shows_optional_sil(self, default_config):
         output = generate_format_spec(default_config)
         # regreq section should show SIL as optional
-        regreq_start = output.index("Regulatory Requirement")
+        regreq_start = output.index("## Regulatory Requirement")
         regreq_section = output[regreq_start:]
         # Find the SIL field in the regreq section
         sil_pos = regreq_section.index("`SIL` Field")
@@ -97,3 +99,7 @@ class TestGenerateFormatSpec:
         assert "Handbook Entry" in output
         assert ".handbook.md" in output
         assert "Product handbook entries" in output
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v"]))

--- a/fire/starlark/metadata_parsing_test.py
+++ b/fire/starlark/metadata_parsing_test.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python3
 """Tests for inline metadata parsing."""
 
+import pytest
+
 from fire.starlark.metadata_parsing import (
     extract_next_metadata_line,
     is_metadata_line,
@@ -95,3 +97,7 @@ class TestParseMetadataFields:
     def test_int_string_remains_string_if_not_pure_digits(self):
         result = parse_metadata_fields("Sil: ASIL-1", "REQ-1")
         assert result == {"id": "REQ-1", "sil": "ASIL-1"}
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v"]))

--- a/fire/starlark/parameter_models_test.py
+++ b/fire/starlark/parameter_models_test.py
@@ -102,9 +102,12 @@ class TestF64Parameter:
         p = F64Parameter(type="f64", value=1.5, unit="m/s", description="speed")
         assert p.value == 1.5
 
-    def test_int_rejected_due_to_strict(self):
-        with pytest.raises(ValidationError):
-            F64Parameter(type="f64", value=1, unit="m/s", description="speed")
+    def test_int_accepted_and_coerced(self):
+        # pydantic strict mode accepts int for a float field, coercing to float
+        # (unlike strict int, which rejects float — see test_float_rejected).
+        p = F64Parameter(type="f64", value=1, unit="m/s", description="speed")
+        assert p.value == 1.0
+        assert isinstance(p.value, float)
 
 
 class TestStringParameter:
@@ -317,3 +320,7 @@ class TestParameterFile:
         assert isinstance(table, TableParameter)
         assert table.columns[0].type == "i64"
         assert table.columns[1].type == "f64"
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v"]))

--- a/fire/starlark/validate_cross_references_test.py
+++ b/fire/starlark/validate_cross_references_test.py
@@ -3,6 +3,8 @@
 
 import textwrap
 
+import pytest
+
 from fire.starlark import validate_cross_references as vcr
 from fire.starlark.dynamic_requirement_model import build_models_from_config
 from fire.starlark.requirement_models import (
@@ -202,3 +204,7 @@ class TestExtractMarkdownReferences:
         param_refs, req_refs = vcr.extract_markdown_references(body)
         assert param_refs == []
         assert req_refs == []
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v"]))

--- a/fire/starlark/version_tracking_test.py
+++ b/fire/starlark/version_tracking_test.py
@@ -89,3 +89,7 @@ class TestMergeParamVersions:
         b = {"x": 2}
         assert merge_param_versions([a, b]) == {"x": 5}
         assert merge_param_versions([b, a]) == {"x": 5}
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
### Summary

Enables five test files that Bazel was silently not executing (no `pytest.main()`
call, so they ran as `__main__` with zero assertions) and fixes the stale tests
this surfaced. Part of #284.

### Implementation Summary

Added the trailing `pytest.main()` call (and `import pytest` where missing) to:

- `generate_format_spec_test.py`
- `parameter_models_test.py`
- `version_tracking_test.py`
- `metadata_parsing_test.py`
- `validate_cross_references_test.py`

Enabling them surfaced three genuine failures (previously hidden), now fixed:

- **`generate_format_spec_test`** — `test_sysreq_shows_required_sil` and
  `test_regreq_shows_optional_sil` located the document-type section with a bare
  substring (`output.index("System Requirement")`) that matched the **Table of
  Contents** entry rather than the `## ` section heading, so they sliced the
  wrong region. Anchored on the `## ` heading.
- **`parameter_models_test`** — `test_int_rejected_due_to_strict` assumed a
  strict `float` field rejects `int`. In pydantic v2 strict mode, `float`
  **accepts** `int` (coercing to float), unlike strict `int` which rejects
  `float`. Renamed to `test_int_accepted_and_coerced` and assert the real
  behaviour.

The other three files passed once enabled.

### Testing

`bazel test //fire/...` (22 pass) and `bazel build --config=typecheck //fire/...`
both pass; pre-commit clean. Confirmed each of the five files now executes its
assertions (verified via an injected temporary failure).

### Remaining part of #284 (deferred)

The regression guard (a check that every `*_test.py` contains `pytest.main(`) is
intentionally **not** in this PR: it would need every test file compliant, but
the two files fixed in #283 aren't on `main` yet. It should land as a final,
small PR once both #283 and this PR are merged.