### PR TITLE
Add pre-commit guard requiring pytest.main() in test files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -52,3 +52,17 @@ repos:
     rev: "v0.13.3"
     hooks:
       - id: ruff
+  - repo: local
+    hooks:
+      - id: require-pytest-main
+        name: require pytest.main() in fire test files
+        description:
+          Bazel runs each *_test.py as __main__; without a pytest.main() call no
+          assertions execute and the test silently passes.
+        entry: |
+          bash -c 'rc=0; for f in "$@"; do
+            grep -q "pytest.main(" "$f" ||
+              { echo "Missing pytest.main() call: $f"; rc=1; }
+          done; exit $rc' --
+        language: system
+        files: '^fire/.*_test\.py$'


### PR DESCRIPTION
### Summary

Adds a pre-commit hook that fails when a `fire/*_test.py` file lacks a
`pytest.main()` call, preventing recurrence of the silently-inert-tests bug.
Closes #284.

### Implementation Summary

Bazel runs each `*_test.py` as `__main__`; without a trailing `pytest.main()`
call, no assertions execute and the target passes without testing anything
(the bug fixed across #283 and #285).

- New `repo: local` pre-commit hook `require-pytest-main`: greps each matched
  file for `pytest.main(` and fails with an actionable message if absent.
- Scoped via `files: '^fire/.*_test\.py$'` to the pytest-based tests. The two
  `examples/*_test.py` scripts use a different, valid idiom (plain functions
  invoked directly under `if __name__ == "__main__":`) and are intentionally
  excluded.

### Testing

- `pre-commit run require-pytest-main --all-files` passes (all `fire/` test
  files are compliant after #283 and #285).
- Verified the hook fails on a synthetic `*_test.py` with no `pytest.main()`
  call, emitting `Missing pytest.main() call: <file>`.
- `pre-commit run --files .pre-commit-config.yaml` passes (config well-formed).