### PR TITLE
Prepare release 0.6.1

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,6 +1,6 @@
 module(
     name = "fire",
-    version = "0.6.0",
+    version = "0.6.1",
     compatibility_level = 3,
 )
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ and Java.
 Add to `MODULE.bazel`:
 
 ```starlark
-bazel_dep(name = "fire", version = "0.6.0")
+bazel_dep(name = "fire", version = "0.6.1")
 
 # Add language rules for the languages you intend to use
 bazel_dep(name = "rules_cc", version = "0.2.16")

--- a/integration_test/MODULE.bazel.template
+++ b/integration_test/MODULE.bazel.template
@@ -16,7 +16,7 @@ bazel_dep(name = "rules_shell", version = "0.6.1")
 bazel_dep(name = "rules_python", version = "1.8.5")
 bazel_dep(name = "bazel_skylib", version = "1.9.0")
 
-bazel_dep(name = "fire", version = "0.6.0")
+bazel_dep(name = "fire", version = "0.6.1")
 local_path_override(
     module_name = "fire",
     path = "..",


### PR DESCRIPTION
### Summary

Bumps the module version from `0.6.0` to `0.6.1` in preparation for publishing to
the Bazel Central Registry, per `PUBLISHING.md` step 1.

### Implementation Summary

- `MODULE.bazel`: `version = "0.6.1"`.
- `README.md`: integration snippet `bazel_dep(name = "fire", version = "0.6.1")`.
- `integration_test/MODULE.bazel.template`: same.

`compatibility_level` stays at `3`: the 0.6.1 changes (PL-e added to the default
SIL values, plus test-infrastructure fixes) are additive, with no
backwards-incompatible API changes.

### Next steps (after merge, per PUBLISHING.md)

1. Create a GitHub release tagged `0.6.1` — `release.yaml` uploads the source
   tarball and then, in its dependent `publish-to-bcr` job, opens a PR on
   `bazel-central-registry`.
2. Review and merge the BCR PR.

### Testing

`bazel mod graph` resolves the root as `fire@0.6.1`; pre-commit passes.