### PR TITLE
Sync BCR fork main with upstream before publishing

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -115,6 +115,20 @@ jobs:
               f.write(content)
           "
 
+      - name: Sync fork main with upstream
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.BCR_PUBLISH_TOKEN }}
+        run: |
+          # Base the BCR branch on a fresh upstream main so the check-file-sync
+          # check passes (it requires the branch to contain the latest
+          # tools/bcr_validation.py). This needs BCR_PUBLISH_TOKEN to have
+          # workflow scope, since upstream commits modify .github/workflows/;
+          # continue-on-error keeps the release working (with a possibly stale
+          # base that a maintainer then rebases) if that scope is missing.
+          gh repo sync nesono/bazel-central-registry \
+            --source bazelbuild/bazel-central-registry --branch main
+
       - name: Clone BCR fork and create branch
         env:
           BCR_PUBLISH_TOKEN: ${{ secrets.BCR_PUBLISH_TOKEN }}


### PR DESCRIPTION
### Summary

Makes the release workflow base the BCR branch on a fresh upstream `main`, so the
auto-generated BCR PR stops failing the `check-file-sync` check.

### Implementation Summary

The `publish-to-bcr` job cloned the fork and branched off its `main`, which drifts
behind `bazelbuild/main`. `check-file-sync` requires the PR branch to contain the
latest `tools/bcr_validation.py`, so a stale base fails it (as seen on the 0.6.0
PR, which needed a manual rebase).

- New **Sync fork main with upstream** step runs `gh repo sync` (fork ← upstream
  `main`) before the clone, so the BCR branch is based on a current `main`.
- The step needs `BCR_PUBLISH_TOKEN` to carry **workflow scope** (upstream commits
  modify `.github/workflows/`). It is `continue-on-error`, so if that scope is
  missing the release still completes with the previous behavior (a stale base a
  maintainer then rebases) rather than failing outright.

### Testing

`pre-commit run --files .github/workflows/release.yaml` passes (YAML well-formed,
step ordering: sync → clone → add files → commit → PR). Full end-to-end validation
happens on the next release trigger.

### Note

For the imminent 0.6.1 release, the fork's `main` was already synced to upstream
manually, so its BCR PR will pass `check-file-sync` regardless of whether this PR
is merged first.