### PR TITLE
Open the BCR pull request against the upstream registry

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -197,7 +197,7 @@ jobs:
         run: |
           VERSION="${{ steps.version.outputs.version }}"
           gh pr create \
-            --repo nesono/bazel-central-registry \
+            --repo bazelbuild/bazel-central-registry \
             --base main \
             --head "fire-${VERSION}" \
             --title "Add fire ${VERSION}" \

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -191,14 +191,17 @@ jobs:
           git commit -m "Add fire ${VERSION}"
           git push origin "fire-${VERSION}"
 
-      - name: Create pull request on BCR fork
+      - name: Create pull request on the Bazel Central Registry
         env:
           GH_TOKEN: ${{ secrets.BCR_PUBLISH_TOKEN }}
         run: |
           VERSION="${{ steps.version.outputs.version }}"
+          # The branch lives in the fork, so --head must be namespaced as
+          # owner:branch — an unqualified name is looked up in --repo itself,
+          # which has no such branch.
           gh pr create \
             --repo bazelbuild/bazel-central-registry \
             --base main \
-            --head "fire-${VERSION}" \
+            --head "nesono:fire-${VERSION}" \
             --title "Add fire ${VERSION}" \
-            --body "Automated BCR entry for [fire ${VERSION}](https://github.com/nesono/fire/releases/tag/v${VERSION})."
+            --body "Automated BCR entry for [fire ${VERSION}](https://github.com/nesono/fire/releases/tag/${VERSION})."


### PR DESCRIPTION
Fixes the BCR publish step so it opens the pull request against the real
registry instead of a dead end in the fork.

### Background

`release.yaml` was creating a *fork-internal* PR (`fire-X.Y.Z` → the fork's own
`main`), which publishes nothing. For 0.6.0 that PR was closed unmerged and the
upstream PR was opened by hand; the same happened for 0.6.1
(bazelbuild/bazel-central-registry#9813 had to be created manually).

### Changes

- **`--head` is namespaced as `nesono:fire-${VERSION}`.** Retargeting `--repo`
  to `bazelbuild/bazel-central-registry` alone is not enough: an unqualified
  head is looked up in `--repo` itself, and the branch only exists in the fork,
  so the step would have failed with a 422. Cross-repository PRs require
  `owner:branch`. This is the form used to open #9813, so it is verified against
  the live endpoint.
- **Dropped the `v` prefix from the release link** in the PR body. Tags lost the
  prefix at 0.6.0, so the generated URL 404s — as it currently does in the
  0.6.0 BCR PR.
- **Renamed the step**, which no longer targets the fork.

### Not addressed here

- The "Sync fork main with upstream" step is still `continue-on-error: true`, so
  an auth or scope failure reports ✓ while leaving the fork's `main` stale and
  the release branch cut from an old tree. During the 0.6.1 release this masked
  first an expired token, then a missing `workflow` scope. Making it fatal would
  block releases, so that tradeoff is left as a separate decision.
- `PUBLISHING.md` step 4 still describes reviewing and merging the fork PR.

### Verification

YAML parses and the rendered step is correct; all pre-commit hooks pass. The
`gh pr create` call itself cannot be exercised without cutting a release — the
next release is the real test, and the sync step's *log* (not its status icon)
is the thing to read.
