### PR TITLE
Recognize requirement entries at any heading depth (#292)

### DIFF
--- a/FORMAT_SPECIFICATION.md
+++ b/FORMAT_SPECIFICATION.md
@@ -40,7 +40,9 @@ System requirements are stored in Markdown files with the `.sysreq.md` extension
 
 Each requirement consists of:
 
-1. **Requirement ID** (H2 heading): `## REQ-ID`
+1. **Requirement ID** (heading): `## REQ-ID`. Recognized at any heading
+   level (`#` .. `######`), so ID-bearing entries may be nested under informal
+   section headers (e.g. `### HARA-H-001` under `## Hazards`).
 2. **Metadata line**: `SIL: <value> | Sec: <value> | Version: <value>`
 3. **Requirement text**: One or more paragraphs describing the requirement
 4. **Optional subsections**: Rationale, Acceptance Criteria, Verification, etc.
@@ -715,9 +717,10 @@ SIL: ASIL-D | Sec: true | Version: 1 | Parent: TODO(LINK-456)
 ### Requirement Files (`.sysreq.md`, `.swreq.md`)
 
 1. **Requirement ID:**
-   - Must match pattern `^[A-Z][A-Z0-9_-]+$`
+   - Must match pattern `^[A-Z][A-Z0-9_-]+$` by default (or the document
+     type's `id_pattern` when configured)
    - Must be unique within the file
-   - Used as H2 heading (`## REQ-ID`)
+   - Used as a heading (`## REQ-ID`), recognized at any level `#` .. `######`
 
 2. **Metadata Line:**
    - Must be the first line(s) after the requirement ID heading

--- a/README.md
+++ b/README.md
@@ -22,8 +22,10 @@ bazel_dep(name = "rules_python", version = "1.8.5")
 
 ## System Requirements
 
-System requirements are stored in `.sysreq.md` files. Each requirement is an
-H2 heading followed by a metadata line and free-form Markdown text.
+System requirements are stored in `.sysreq.md` files. Each requirement is a
+heading followed by a metadata line and free-form Markdown text. Entries are
+recognized at any heading level (`#` .. `######`), so ID-bearing entries may be
+nested under informal section headers.
 
 **Metadata fields:**
 
@@ -425,6 +427,15 @@ document_types:
     description: "Product handbook entries"
     required_fields: [version]
     optional_fields: [sil]
+
+  # Analysis type with entries nested under informal section headers
+  # (e.g. `### HARA-H-001` under `## Hazards`). Set id_pattern to make entry
+  # recognition explicit.
+  hara:
+    suffix: ".hara.md"
+    display_name: "Hazard Analysis"
+    required_fields: [version]
+    id_pattern: "HARA-H-\\d+"
 ```
 
 Pass the config to FIRE rules:

--- a/docs/design/configurable-document-types.md
+++ b/docs/design/configurable-document-types.md
@@ -114,7 +114,7 @@ hara:
   suffix: ".hara.md"
   display_name: "Hazard Analysis"
   required_fields: [version]
-  id_pattern: "HARA-H-\\d+"   # regex the bare ID token must fully match
+  id_pattern: "HARA-H-\\d+" # regex the bare ID token must fully match
 ```
 
 When unset, the default all-caps ID shape (`[A-Z][A-Z0-9_-]+`) applies.

--- a/docs/design/configurable-document-types.md
+++ b/docs/design/configurable-document-types.md
@@ -98,6 +98,27 @@ handbook:
   optional_fields: []
 ```
 
+### Explicit entry-ID recognition (optional)
+
+Entries are detected by an all-caps ID token in a heading at any level
+(`#` .. `######`), so ID-bearing entries can be nested under informal section
+headers (e.g. `### HARA-H-001` under `## Hazards`). Mixed-case/numeric section
+headers are ignored automatically.
+
+To make recognition explicit per document type — and guard against an all-caps
+section header being misparsed as an entry — set `id_pattern` (a regex the bare
+ID token must fully match):
+
+```yaml
+hara:
+  suffix: ".hara.md"
+  display_name: "Hazard Analysis"
+  required_fields: [version]
+  id_pattern: "HARA-H-\\d+"   # regex the bare ID token must fully match
+```
+
+When unset, the default all-caps ID shape (`[A-Z][A-Z0-9_-]+`) applies.
+
 ## Key Architectural Decisions
 
 - **`field_definitions`** are reusable across document types (sil is identical for sysreq and swreq)

--- a/fire/starlark/config_models.py
+++ b/fire/starlark/config_models.py
@@ -8,6 +8,7 @@ Consumers supply a fire_config.yaml; when absent, the built-in default
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
 from typing import List, Literal, Optional
 
@@ -49,7 +50,13 @@ class FieldDefinition(BaseModel):
 
 
 class DocumentTypeDefinition(BaseModel):
-    """A document type with its file suffix and field requirements."""
+    """A document type with its file suffix, field requirements and entry-ID pattern.
+
+    ``id_pattern`` is an optional regex a heading's bare token must fully match
+    to be treated as a requirement entry, rather than relying on the default
+    "all-caps ID != mixed-case section header" heuristic. Set it to guard
+    against an all-caps section header being misparsed as an entry.
+    """
 
     suffix: str
     display_name: str
@@ -57,11 +64,23 @@ class DocumentTypeDefinition(BaseModel):
     required_fields: List[str] = Field(default_factory=list)
     optional_fields: List[str] = Field(default_factory=list)
 
+    id_pattern: Optional[str] = None
+
     @field_validator("suffix")
     @classmethod
     def validate_suffix(cls, v: str) -> str:
         if not v.endswith(".md"):
             raise ValueError("suffix must end with '.md'")
+        return v
+
+    @field_validator("id_pattern")
+    @classmethod
+    def validate_id_pattern(cls, v: Optional[str]) -> Optional[str]:
+        if v is not None:
+            try:
+                re.compile(v)
+            except re.error as exc:
+                raise ValueError(f"id_pattern is not a valid regex: {exc}") from exc
         return v
 
 
@@ -87,6 +106,15 @@ class FireConfig(BaseModel):
     def suffix_to_document_type(self) -> dict[str, DocumentTypeDefinition]:
         """Return a mapping from file suffix to document type definition."""
         return {dt.suffix: dt for dt in self.document_types.values()}
+
+    def document_type_for_file(
+        self, file_path: str
+    ) -> Optional[DocumentTypeDefinition]:
+        """Return the document type whose suffix matches *file_path*, or None."""
+        for dt in self.document_types.values():
+            if file_path.endswith(dt.suffix):
+                return dt
+        return None
 
     def known_fields(self) -> list[str]:
         """Return all known field display names (lowercased) for metadata parsing."""

--- a/fire/starlark/config_models_test.py
+++ b/fire/starlark/config_models_test.py
@@ -69,6 +69,18 @@ class TestDocumentTypeDefinition:
         with pytest.raises(ValueError, match="must end with '.md'"):
             DocumentTypeDefinition(suffix=".sysreq.yaml", display_name="Bad")
 
+    def test_id_pattern_accepts_valid_regex(self):
+        dt = DocumentTypeDefinition(
+            suffix=".hara.md", display_name="HARA", id_pattern=r"HARA-H-\d+"
+        )
+        assert dt.id_pattern == r"HARA-H-\d+"
+
+    def test_id_pattern_rejects_invalid_regex(self):
+        with pytest.raises(ValueError, match="not a valid regex"):
+            DocumentTypeDefinition(
+                suffix=".hara.md", display_name="HARA", id_pattern="[unclosed"
+            )
+
 
 class TestFireConfig:
     def _minimal_config(self, **overrides):
@@ -109,6 +121,13 @@ class TestFireConfig:
         mapping = cfg.suffix_to_document_type()
         assert ".sysreq.md" in mapping
         assert mapping[".sysreq.md"].display_name == "System Requirement"
+
+    def test_document_type_for_file(self):
+        cfg = FireConfig.model_validate(self._minimal_config())
+        dt = cfg.document_type_for_file("some/dir/foo.sysreq.md")
+        assert dt is not None
+        assert dt.suffix == ".sysreq.md"
+        assert cfg.document_type_for_file("foo.unknown.md") is None
 
     def test_known_fields(self):
         cfg = FireConfig.model_validate(self._minimal_config())

--- a/fire/starlark/validate_cross_references.py
+++ b/fire/starlark/validate_cross_references.py
@@ -105,14 +105,14 @@ def _find_requirement_heading_index(lines: list[str], req_id: str) -> int | None
     """Find the line index of the requirement heading.
 
     Matches a heading at any depth (``#`` .. ``######``) whose token is exactly
-    ``req_id``, optionally followed by trailing text. Entries can therefore be
-    nested under informal section headers at any level. The trailing-space
-    check prevents prefix collisions: searching for ``REQ-1`` must not match a
-    heading like ``## REQ-12``.
+    ``req_id`` (trailing whitespace allowed, but no trailing title). Entries can
+    therefore be nested under informal section headers at any level. Requiring a
+    bare-ID heading keeps ``#<ID>`` anchors reliable and prevents prefix
+    collisions: searching for ``REQ-1`` must not match ``## REQ-12``.
 
     Returns the index of the matching line, or None if not found.
     """
-    pattern = re.compile(rf"^#{{1,6}} {re.escape(req_id)}(?: .*)?$")
+    pattern = re.compile(rf"^#{{1,6}} {re.escape(req_id)}$")
     for i, line in enumerate(lines):
         if pattern.match(line.rstrip()):
             return i

--- a/fire/starlark/validate_cross_references.py
+++ b/fire/starlark/validate_cross_references.py
@@ -44,6 +44,25 @@ _REQUIREMENT_SUFFIXES: Final = (".sysreq.md", ".swreq.md", ".regreq.md")
 
 _BARE_TODO_RE: Final = re.compile(r"TODO(?!\([A-Z]+-[0-9]+\))")
 
+# Default bare-ID shape used when a document type does not define an explicit
+# id_pattern: an all-caps token (letters, digits, '_' and '-').
+_DEFAULT_ID_RE: Final = re.compile(r"[A-Z][A-Z0-9_-]+")
+
+
+def _entry_id_regex(
+    file_path: str, config: FireConfig | None = None
+) -> re.Pattern[str]:
+    """Return the regex a heading token must fully match to be an entry ID.
+
+    When the file's document type defines ``id_pattern``, that explicit rule is
+    used; otherwise the default all-caps ID shape applies.
+    """
+    if config is not None:
+        doc_type = config.document_type_for_file(file_path)
+        if doc_type is not None and doc_type.id_pattern is not None:
+            return re.compile(doc_type.id_pattern)
+    return _DEFAULT_ID_RE
+
 
 def _metadata_model_for_file(
     file_path: str,
@@ -85,16 +104,17 @@ def validate_no_bare_todos(content: str, file_path: str) -> list[str]:
 def _find_requirement_heading_index(lines: list[str], req_id: str) -> int | None:
     """Find the line index of the requirement heading.
 
-    Matches a line that is exactly ``## <req_id>`` or ``## <req_id> ...``.
-    The trailing-space check prevents prefix collisions: searching for
-    ``REQ-1`` must not match a heading like ``## REQ-12``.
+    Matches a heading at any depth (``#`` .. ``######``) whose token is exactly
+    ``req_id``, optionally followed by trailing text. Entries can therefore be
+    nested under informal section headers at any level. The trailing-space
+    check prevents prefix collisions: searching for ``REQ-1`` must not match a
+    heading like ``## REQ-12``.
 
     Returns the index of the matching line, or None if not found.
     """
-    target = f"## {req_id}"
+    pattern = re.compile(rf"^#{{1,6}} {re.escape(req_id)}(?: .*)?$")
     for i, line in enumerate(lines):
-        stripped = line.rstrip()
-        if stripped == target or stripped.startswith(target + " "):
+        if pattern.match(line.rstrip()):
             return i
     return None
 
@@ -114,7 +134,8 @@ def parse_inline_metadata_for_requirement(
 ):
     """Parse inline metadata for a specific requirement ID.
 
-    Looks for ## REQ-ID heading followed by a line with pipe-separated fields.
+    Looks for a heading (any depth) whose token is REQ-ID, followed by a line
+    with pipe-separated fields.
     Format: Key1: value1 | Key2: value2 | Key3: [link](url)
     Returns tuple of (RequirementMetadata | None, ValidationError | None).
     """
@@ -355,10 +376,18 @@ def validate_requirement_file(
     known_fields = config.known_fields() if config else None
 
     # Validate the requirement file's own metadata
-    # Find all requirement IDs in the file and validate each one
-    req_id_pattern = r"^## ([A-Z][A-Z0-9_-]+)\s*$"
-    for match in re.finditer(req_id_pattern, content, re.MULTILINE):
-        req_id = match.group(1)
+    # Find all requirement IDs in the file and validate each one. Entries are
+    # recognized at any heading depth (# .. ######) so that ID-bearing entries
+    # can be nested under informal section headers. Whether a heading token is
+    # an entry ID (vs a section header) is decided by the document type's
+    # id_pattern when configured, else the default all-caps ID shape.
+    id_re = _entry_id_regex(file_path, config)
+    heading_pattern = r"^#{1,6} (\S.*?)\s*$"
+    for match in re.finditer(heading_pattern, content, re.MULTILINE):
+        token = match.group(1)
+        if not id_re.fullmatch(token):
+            continue
+        req_id = token
         model_class = _metadata_model_for_file(file_path, config, models)
         metadata, validation_error = parse_inline_metadata_for_requirement(
             content, req_id, model_class, known_fields

--- a/fire/starlark/validate_cross_references_test.py
+++ b/fire/starlark/validate_cross_references_test.py
@@ -89,6 +89,57 @@ class TestFindRequirementHeadingIndex:
         lines = ["## REQ-1   "]
         assert vcr._find_requirement_heading_index(lines, "REQ-1") == 0
 
+    def test_matches_h3_heading(self):
+        # Entries may be nested under informal section headers at H3 level.
+        lines = ["## Hazards", "", "### HARA-H-001", "body"]
+        assert vcr._find_requirement_heading_index(lines, "HARA-H-001") == 2
+
+    def test_matches_h3_heading_with_trailing_text(self):
+        lines = ["### HARA-H-001 Some description"]
+        assert vcr._find_requirement_heading_index(lines, "HARA-H-001") == 0
+
+    def test_h3_prefix_id_does_not_match_longer_id(self):
+        lines = ["### HARA-H-0012", "body"]
+        assert vcr._find_requirement_heading_index(lines, "HARA-H-001") is None
+
+    def test_matches_arbitrary_heading_depth(self):
+        # Any heading depth (# .. ######) is recognized.
+        for depth in range(1, 7):
+            lines = ["intro", f"{'#' * depth} REQ-9", "body"]
+            assert vcr._find_requirement_heading_index(lines, "REQ-9") == 1
+
+    def test_no_match_for_seven_hashes(self):
+        lines = ["####### REQ-9"]
+        assert vcr._find_requirement_heading_index(lines, "REQ-9") is None
+
+
+# ---------------------------------------------------------------------------
+# _entry_id_regex
+# ---------------------------------------------------------------------------
+
+
+class TestEntryIdRegex:
+    def test_default_all_caps_id_shape(self):
+        pat = vcr._entry_id_regex("foo.sysreq.md")
+        assert pat.fullmatch("REQ-1")
+        assert pat.fullmatch("HARA-H-001")
+        assert not pat.fullmatch("Hazards")
+
+    def test_uses_config_id_pattern(self, default_config):
+        default_config.document_types["sysreq"].id_pattern = r"HARA-H-\d+"
+        pat = vcr._entry_id_regex("foo.sysreq.md", config=default_config)
+        assert pat.fullmatch("HARA-H-001")
+        assert not pat.fullmatch("REQ-1")
+
+    def test_matching_doc_type_without_id_pattern_uses_default(self, default_config):
+        # Config provided and suffix matches, but the type has no id_pattern.
+        pat = vcr._entry_id_regex("foo.sysreq.md", config=default_config)
+        assert pat.pattern == vcr._DEFAULT_ID_RE.pattern
+
+    def test_unknown_suffix_falls_back_to_default(self, default_config):
+        pat = vcr._entry_id_regex("foo.unknown.md", config=default_config)
+        assert pat.pattern == vcr._DEFAULT_ID_RE.pattern
+
 
 # ---------------------------------------------------------------------------
 # _requirement_suffixes
@@ -171,6 +222,21 @@ class TestParseInlineMetadataForRequirement:
         assert meta is None
         assert err is not None
 
+    def test_valid_metadata_parses_h3_entry(self):
+        content = textwrap.dedent(
+            """
+            ## Hazards
+
+            ### REQ-1
+            Sil: ASIL-D | Sec: false | Version: 1
+            Body
+            """
+        )
+        meta, err = vcr.parse_inline_metadata_for_requirement(content, "REQ-1")
+        assert err is None
+        assert meta is not None
+        assert meta.version == 1
+
 
 # ---------------------------------------------------------------------------
 # extract_markdown_references
@@ -204,6 +270,108 @@ class TestExtractMarkdownReferences:
         param_refs, req_refs = vcr.extract_markdown_references(body)
         assert param_refs == []
         assert req_refs == []
+
+
+# ---------------------------------------------------------------------------
+# validate_requirement_file — entry detection
+# ---------------------------------------------------------------------------
+
+
+class TestValidateRequirementFileEntryDetection:
+    def test_h3_entry_under_informal_section_is_validated(self, tmp_path):
+        req = tmp_path / "hazards.sysreq.md"
+        req.write_text(
+            textwrap.dedent(
+                """
+                # Hazard Analysis
+
+                ## Hazards
+
+                ### HARA-H-001
+                SIL: ASIL-D | Sec: false | Version: 1
+
+                Loss of braking on grade.
+                """
+            )
+        )
+        errors = vcr.validate_requirement_file(str(req), str(tmp_path))
+        assert errors == []
+
+    def test_all_caps_section_header_flagged_without_hardening(self, tmp_path):
+        # With the default all-caps heuristic, an all-caps section header is
+        # indistinguishable from an entry and gets flagged as missing metadata.
+        req = tmp_path / "doc.sysreq.md"
+        req.write_text("## HAZARDS\n\nSome prose without metadata.\n")
+        errors = vcr.validate_requirement_file(str(req), str(tmp_path))
+        assert any("HAZARDS" in e for e in errors)
+
+    def test_id_pattern_hardening_ignores_section_header(
+        self, tmp_path, default_config
+    ):
+        # Explicit id_pattern makes entry recognition unambiguous: the all-caps
+        # section header no longer looks like an entry.
+        default_config.document_types["sysreq"].id_pattern = r"HARA-H-\d+"
+        models = build_models_from_config(default_config)
+        req = tmp_path / "doc.sysreq.md"
+        req.write_text(
+            textwrap.dedent(
+                """
+                ## HAZARDS
+
+                ### HARA-H-001
+                SIL: ASIL-D | Sec: false | Version: 1
+
+                Loss of braking.
+                """
+            )
+        )
+        errors = vcr.validate_requirement_file(
+            str(req), str(tmp_path), config=default_config, models=models
+        )
+        assert errors == []
+
+    def test_deep_heading_entry_is_validated(self, tmp_path):
+        # Entry detection works at any depth, not just H2/H3.
+        req = tmp_path / "deep.sysreq.md"
+        req.write_text(
+            textwrap.dedent(
+                """
+                # Doc
+
+                ## Section
+
+                #### REQ-DEEP
+                SIL: ASIL-D | Sec: false | Version: 1
+
+                Deeply nested entry.
+                """
+            )
+        )
+        errors = vcr.validate_requirement_file(str(req), str(tmp_path))
+        assert errors == []
+
+    def test_heading_with_trailing_text_is_not_an_entry(self, tmp_path):
+        # The ID must be the whole heading token; a trailing title means the
+        # heading is not treated as an entry (issue #292 explicitly excludes
+        # `## REQ-ID Title`). Invalid metadata below must therefore be ignored.
+        req = tmp_path / "doc.sysreq.md"
+        req.write_text("## REQ-1 Some Title\nSIL: NOPE | Sec: false | Version: 1\n")
+        errors = vcr.validate_requirement_file(str(req), str(tmp_path))
+        assert errors == []
+
+    def test_custom_id_pattern_ignores_default_shaped_id(
+        self, tmp_path, default_config
+    ):
+        # With a custom id_pattern, an all-caps ID that does not match it is
+        # treated as a section header, not an entry — even with bad metadata.
+        default_config.document_types["sysreq"].id_pattern = r"HARA-H-\d+"
+        models = build_models_from_config(default_config)
+        req = tmp_path / "doc.sysreq.md"
+        req.write_text("## REQ-1\nSIL: NOPE | Sec: false | Version: 1\n")
+        errors = vcr.validate_requirement_file(
+            str(req), str(tmp_path), config=default_config, models=models
+        )
+        assert errors == []
 
 
 if __name__ == "__main__":

--- a/fire/starlark/validate_cross_references_test.py
+++ b/fire/starlark/validate_cross_references_test.py
@@ -79,11 +79,11 @@ class TestFindRequirementHeadingIndex:
         lines = ["## REQ-12", "body", "## REQ-1", "more"]
         assert vcr._find_requirement_heading_index(lines, "REQ-1") == 2
 
-    def test_matches_heading_with_trailing_text(self):
-        # Headings may have a trailing space and additional text;
-        # they should still match.
+    def test_trailing_text_after_id_does_not_match(self):
+        # Anchor resolution requires a bare-ID heading so `#<ID>` anchors stay
+        # reliable; a trailing title changes the rendered slug and must not match.
         lines = ["## REQ-1 Some description"]
-        assert vcr._find_requirement_heading_index(lines, "REQ-1") == 0
+        assert vcr._find_requirement_heading_index(lines, "REQ-1") is None
 
     def test_matches_heading_with_trailing_whitespace(self):
         lines = ["## REQ-1   "]
@@ -94,9 +94,9 @@ class TestFindRequirementHeadingIndex:
         lines = ["## Hazards", "", "### HARA-H-001", "body"]
         assert vcr._find_requirement_heading_index(lines, "HARA-H-001") == 2
 
-    def test_matches_h3_heading_with_trailing_text(self):
+    def test_h3_heading_with_trailing_text_does_not_match(self):
         lines = ["### HARA-H-001 Some description"]
-        assert vcr._find_requirement_heading_index(lines, "HARA-H-001") == 0
+        assert vcr._find_requirement_heading_index(lines, "HARA-H-001") is None
 
     def test_h3_prefix_id_does_not_match_longer_id(self):
         lines = ["### HARA-H-0012", "body"]


### PR DESCRIPTION
Closes #292.

## Summary

Requirement entry detection and cross-reference anchor resolution were hard-coded to `##` (H2). This makes them **level-agnostic**: requirement IDs are now recognized at any heading level (`#` .. `######`), so ID-bearing entries can be nested under informal section headers, e.g. `### HARA-H-001` under `## Hazards`.

## Changes

- **Entry detection** (`validate_requirement_file`): heading match generalized from `#{2}` to `#{1,6}`; the captured token is checked against an ID regex.
- **Anchor resolution** (`_find_requirement_heading_index`): matches a heading at any depth whose token is exactly the target ID (keeps the prefix-collision guard, e.g. `REQ-1` ≠ `REQ-12`; trailing text still allowed for resolution).
- **Optional hardening**: new per-document-type `id_pattern` (regex the bare heading token must fully match) makes entry-vs-section recognition explicit, guarding against an all-caps section header (`## HAZARDS`) being misparsed as an entry. When unset, the default all-caps ID shape (`[A-Z][A-Z0-9_-]+`) applies — fully backwards compatible.

Informal section headers (`## Hazards`, `## 5 Test Matrix Summary`) are mixed-case/numeric and already don't match the all-caps ID pattern, so they remain ignored with no document changes required. As per the issue, an explanatory title after the ID on the heading line (`## REQ-ID Title`) is **not** treated as an entry.

## Docs

Updated `FORMAT_SPECIFICATION.md`, `README.md`, and `docs/design/configurable-document-types.md`.

## Tests

Added coverage for arbitrary heading depth (H1–H6 + 7-hash rejection), H3 entries under informal sections end-to-end, trailing-text exclusion, deep-heading entries, `id_pattern` validation, and the `id_pattern` hardening (all-caps section header and default-shaped-but-non-matching ID both ignored).
